### PR TITLE
[WIP] Basic (and currently inefficient) implementation of GFW API data on the Alerts Dashboard

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -22,6 +22,8 @@ interface ViewConfig {
   EMBED_MEDIA: string;
   FRONT_END_FILTERING: string;
   FRONT_END_FILTER_FIELD: string;
+  GFW_API_KEY: string;
+  GFW_AOI: string;
   MAPBOX_STYLE: string;
   MAPBOX_PROJECTION: string;
   MAPBOX_CENTER_LATITUDE: string;

--- a/api/index.ts
+++ b/api/index.ts
@@ -221,6 +221,7 @@ if (!VIEWS_CONFIG) {
 
             // Optionally add GFW data
             if (VIEWS[table].GFW_API_KEY && VIEWS[table].GFW_AOI) {
+              console.log("Fetching GFW data...")
               const gfwApiKey = VIEWS[table].GFW_API_KEY;
               const gfwAOI = [JSON.parse(VIEWS[table].GFW_AOI)];
 
@@ -237,39 +238,46 @@ if (!VIEWS_CONFIG) {
               // from 2024-01-01 onwards.
               // We should allow these to be configurable in the future.
 
-              const rawGfwData = await fetch(
-                "https://data-api.globalforestwatch.org/dataset/gfw_integrated_alerts/latest/query",
-                {
-                  method: "POST",
-                  headers: {
-                    "x-api-key": gfwApiKey,
-                    "Content-Type": "application/json",
-                  },
-                  body: JSON.stringify({
-                    geometry: {
-                      type: "Polygon",
-                      coordinates: gfwAOI,
+              try {
+                const rawGfwData = await fetch(
+                  "https://data-api.globalforestwatch.org/dataset/gfw_integrated_alerts/latest/query",
+                  {
+                    method: "POST",
+                    headers: {
+                      "x-api-key": gfwApiKey,
+                      "Content-Type": "application/json",
                     },
-                    sql: "SELECT latitude, longitude, gfw_integrated_alerts__date, gfw_integrated_alerts__confidence FROM results WHERE gfw_integrated_alerts__date >= '2024-01-01'",
-                  }),
-                },
-              ).then((res: Response) => res.json());
-
-              // Convert GFW data response to GeoJSON format
-              gfwData = {
-                type: 'FeatureCollection',
-                features: rawGfwData.data.map((alert: any) => ({
-                  type: 'Feature',
-                  geometry: {
-                    type: 'Point',
-                    coordinates: [alert.longitude, alert.latitude]
+                    body: JSON.stringify({
+                      geometry: {
+                        type: "Polygon",
+                        coordinates: gfwAOI,
+                      },
+                      sql: "SELECT latitude, longitude, gfw_integrated_alerts__date, gfw_integrated_alerts__confidence FROM results WHERE gfw_integrated_alerts__date >= '2024-01-01'",
+                    }),
                   },
-                  properties: {
-                    date: alert.gfw_integrated_alerts__date,
-                    confidence: alert.gfw_integrated_alerts__confidence
-                  }
-                }))
-              };
+                ).then((res: Response) => res.json());
+
+                // Convert GFW data response to GeoJSON format
+                gfwData = {
+                  type: 'FeatureCollection',
+                  features: rawGfwData.data.map((alert: any) => ({
+                    type: 'Feature',
+                    geometry: {
+                      type: 'Point',
+                      coordinates: [alert.longitude, alert.latitude]
+                    },
+                    properties: {
+                      date: alert.gfw_integrated_alerts__date,
+                      confidence: alert.gfw_integrated_alerts__confidence
+                    }
+                  }))
+                };
+
+                console.log("Successfully fetched GFW data!");
+              } catch (error: any) {
+                console.error("Error fetching GFW data:", error.message);
+                gfwData = null;
+              }
             }
 
             // Prepare statistics data for the alerts view

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import fetch, { Response } from 'node-fetch';
 
 import setupDatabaseConnection from "./database/dbConnection";
 import fetchData from "./database/dbOperations";
@@ -181,6 +182,7 @@ if (!VIEWS_CONFIG) {
 
             let mapeoData = null;
 
+            // Optionally add Mapeo data
             if (mapeoTable && mapeoCategoryIds) {
               // Fetch Mapeo data
               const rawMapeoData = await fetchData(db, mapeoTable, IS_SQLITE);
@@ -215,6 +217,61 @@ if (!VIEWS_CONFIG) {
               mapeoData = processedMapeoData;
             }
 
+            let gfwData = null;
+
+            // Optionally add GFW data
+            if (VIEWS[table].GFW_API_KEY && VIEWS[table].GFW_AOI) {
+              const gfwApiKey = VIEWS[table].GFW_API_KEY;
+              const gfwAOI = [JSON.parse(VIEWS[table].GFW_AOI)];
+
+              // TODO: Figure out a more efficient way to fetch GFW data
+              // The GFW API does raster analysis on the fly increasing latency, 
+              // and the payload can be quite large (with a ceiling of 5291556 bytes)
+              // For even a small AOI, the response can be quite large, slowing down 
+              // the GCV API response time. A possible solution is to use a separate 
+              // service (frizzle?) to fetch GFW data and store it in a database, 
+              // or as a GeoJSON file
+
+              // TODO: For this first attempt, the alert layer is hardcoded to 
+              // gfw_integrated_alerts and the query data is hardcoded to alerts 
+              // from 2024-01-01 onwards.
+              // We should allow these to be configurable in the future.
+
+              const rawGfwData = await fetch(
+                "https://data-api.globalforestwatch.org/dataset/gfw_integrated_alerts/latest/query",
+                {
+                  method: "POST",
+                  headers: {
+                    "x-api-key": gfwApiKey,
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({
+                    geometry: {
+                      type: "Polygon",
+                      coordinates: gfwAOI,
+                    },
+                    sql: "SELECT latitude, longitude, gfw_integrated_alerts__date, gfw_integrated_alerts__confidence FROM results WHERE gfw_integrated_alerts__date >= '2024-01-01'",
+                  }),
+                },
+              ).then((res: Response) => res.json());
+
+              // Convert GFW data response to GeoJSON format
+              gfwData = {
+                type: 'FeatureCollection',
+                features: rawGfwData.data.map((alert: any) => ({
+                  type: 'Feature',
+                  geometry: {
+                    type: 'Point',
+                    coordinates: [alert.longitude, alert.latitude]
+                  },
+                  properties: {
+                    date: alert.gfw_integrated_alerts__date,
+                    confidence: alert.gfw_integrated_alerts__confidence
+                  }
+                }))
+              };
+            }
+
             // Prepare statistics data for the alerts view
             const statistics = prepareAlertStatistics(mainData, metadata);
 
@@ -230,6 +287,7 @@ if (!VIEWS_CONFIG) {
               alertResources: VIEWS[table].ALERT_RESOURCES === "YES",
               alertsData: geojsonData,
               embedMedia: VIEWS[table].EMBED_MEDIA === "YES",
+              gfwData: gfwData,
               imageExtensions: imageExtensions,
               logoUrl: VIEWS[table].LOGO_URL,
               mapLegendLayerIds: VIEWS[table].MAP_LEGEND_LAYER_IDS,

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -66,6 +66,7 @@ export default {
     "alertResources",
     "alertsData",
     "embedMedia",
+    "gfwData",
     "imageExtensions",
     "logoUrl",
     "mapLegendLayerIds",
@@ -378,6 +379,33 @@ export default {
         geoJsonSource.previousAlerts.features.some(
           (feature) => feature.geometry.type === "LineString",
         );
+    },
+
+    addGfwData() {
+      const geoJsonSource = this.gfwData;
+
+      // Add the GFW data source to the map
+      if (!this.map.getSource("global-forest-watch-data")) {
+        this.map.addSource("global-forest-watch-data", {
+          type: "geojson",
+          data: geoJsonSource,
+        });
+      }
+
+      // Add a layer for GFW data
+      if (!this.map.getLayer("global-forest-watch-data")) {
+        this.map.addLayer({
+          id: "global-forest-watch-data",
+          type: "circle",
+          source: "global-forest-watch-data",
+          paint: {
+            "circle-radius": 2,
+            "circle-color": "#808080",
+            "circle-stroke-width": 0,
+          },
+        });
+      }
+
     },
 
     addMapeoData() {
@@ -696,6 +724,9 @@ export default {
     },
 
     prepareMapCanvasContent() {
+      if (this.gfwData) {
+        this.addGfwData();
+      }
       if (this.alertsData) {
         this.addAlertsData();
       }
@@ -714,10 +745,14 @@ export default {
 
     prepareMapLegendContent() {
       this.map.once("idle", () => {
-        let mapLegendLayerIds;
+        let mapLegendLayerIds = this.mapLegendLayerIds;
+
+        // Add gfw-data layer to mapLegendContent
+        if (this.gfwData) {
+          mapLegendLayerIds = "global-forest-watch-data," + mapLegendLayerIds;
+        }
 
         // Add most-recent-alerts & previous-alerts layers to mapLegendContent
-        mapLegendLayerIds = this.mapLegendLayerIds;
         if (this.hasLineStrings) {
           mapLegendLayerIds = "most-recent-alerts-linestring,previous-alerts-linestring," + mapLegendLayerIds;
         } else {

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,14 @@ Activates a dropdown filter for data in views. Set to `YES` and define the field
 
 Depending on your data, you will want to use a meaningful field for filtering (for example, `Category` for Mapeo data). This variable defines the field used for front-end dropdown filtering.
 
+#### `GFW_API_KEY` (optional)
+
+If you want to show Global Forest Watch data on your alerts dashboard, provide an API key.
+
+#### `GFW_AOI` (optional)
+
+If you want to show Global Forest Watch data on your alerts dashboard, provide an AOI (Area of Interest) where you want to query GFW data. It should be in format `[[long,lat],[long,lat]...]`.
+
 #### `LOGO_URL` (optional)
 
 You can provide a URL to your organization / community logo which will show up in the Alerts dashboard intro panel.

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,7 +52,7 @@ Depending on your data, you will want to use a meaningful field for filtering (f
 
 #### `GFW_API_KEY` (optional)
 
-If you want to show Global Forest Watch data on your alerts dashboard, provide an API key.
+If you want to show Global Forest Watch data on your alerts dashboard, provide an API key. Note that GFW API keys expire after one year, and need to be refreshed with a bearer token: https://www.globalforestwatch.org/help/developers/guides/create-and-use-an-api-key/
 
 #### `GFW_AOI` (optional)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.5",
         "@types/mapbox-gl": "^2.7.19",
+        "@types/node-fetch": "^2.6.11",
         "@types/pg": "^8.10.9",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
@@ -7000,6 +7001,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
       "integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ=="
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@types/optimize-css-assets-webpack-plugin": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@types/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.8.tgz",
@@ -8084,6 +8095,12 @@
         }
       ],
       "optional": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -9290,6 +9307,18 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -10230,6 +10259,15 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -11382,6 +11420,20 @@
         "vue-template-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.5",
     "@types/mapbox-gl": "^2.7.19",
+    "@types/node-fetch": "^2.6.11",
     "@types/pg": "^8.10.9",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",

--- a/pages/alerts/_tablename.vue
+++ b/pages/alerts/_tablename.vue
@@ -5,6 +5,7 @@
       :alert-resources="alertResources"
       :alertsData="alertsData"
       :embed-media="embedMedia"
+      :gfw-data="gfwData"
       :image-extensions="imageExtensions"
       :logo-url="logoUrl"
       :map-legend-layer-ids="mapLegendLayerIds"
@@ -62,6 +63,7 @@ export default {
         alertsData: response.alertsData,
         dataFetched: true,
         embedMedia: response.embedMedia,
+        gfwData: response.gfwData,
         imageExtensions: response.imageExtensions,
         logoUrl: response.logoUrl,
         mapLegendLayerIds: response.mapLegendLayerIds,


### PR DESCRIPTION
## Goal

Work towards #53: To optionally fetch Integrated Deforestation Alerts from the GFW API and add those to the Alerts Dashboard.

## Discussion

The objective of this PR is **not** to submit code for review and merging. Instead, it should serve as a vehicle for discussion toward a better approach, as the method used here is definitely inefficient.

The GFW API yields vector data by doing raster analysis on the fly, resulting in a high amount of latency, and there is a payload ceiling of 5,291,556 bytes. Using the method implemented here, even an API query for a relatively small AOI around the village of Kawemhakan in Suriname took 875.657ms (for 668 points). For the entire Wayana territory, we reached the payload ceiling.

It seems to me that there are two options to overcome this:

(1) I think this approach to fetch data from the GFW API _could_ work if we are actually storing the response in a database or as a GeoJSON file, which we update regularly with new GFW data. We could easily write a frizzle pull component to do this. This would be the way to go if we want to serve GFW data  _**as alerts**_: that is, as active features on the Alerts Dashboard that you can click on to view properties, and export as CSV/GeoJSON. Not to mention that we will eventually make it possible for users to add data to alerts, and relate together alerts that belong to the same incident.

(2) If we just want to visualize GFW data on an alerts dashboard as a contextual map layer and nothing more, then we should see if GFW makes a public tileset of their data available somewhere. We wouldn't need to worry about limiting it to an AOI since tiled data is only loaded for your viewport anyway.

I think that if we want to provide GFW data as an open alternative to proprietary change detection data, then we should consider (1). 

## Screenshots

![image](https://github.com/ConservationMetrics/guardianconnector-views/assets/31662219/8e30ff7d-2850-4643-a97b-7b072bad5193)

## What I changed

* For the `/alerts` API, optionally fetch `gfw_integrated_alerts` data from the GFW API, and return that as a GeoJSON object, to be added as a source and layer on the `AlertsDashboard` map canvas.
