### PR TITLE
Refactor `DataFilter` component to allow filtering of data where filterColumn is not set

### DIFF
--- a/components/shared/DataFilter.vue
+++ b/components/shared/DataFilter.vue
@@ -19,12 +19,11 @@ const selectedFilterValue = ref([]);
 const getUniqueFilterValues = computed(() => {
   const allDataFilterValues = props.data.map((item) => {
     const value = item[props.filterColumn];
+    const color = item["filter-color"] || defaultColoredDotColor;
     return {
       label: value !== null && value !== undefined ? value : t("noColumnEntry"),
       value: value,
-      color: item["filter-color"]
-        ? item["filter-color"]
-        : defaultColoredDotColor,
+      color: color,
     };
   });
 

--- a/components/shared/DataFilter.vue
+++ b/components/shared/DataFilter.vue
@@ -13,7 +13,7 @@ const props = defineProps({
 
 const emit = defineEmits(["filter"]);
 
-const defaultColoredDotColor = "#ffffff";
+const defaultColoredDotColor = "#808080";
 const selectedFilterValue = ref([]);
 
 const getUniqueFilterValues = computed(() => {

--- a/lang/en.json
+++ b/lang/en.json
@@ -71,6 +71,7 @@
   "mostRecentAlerts": "Most recent alerts",
   "mostRecentAlertsShownIn": "Most recent alerts shown on map in",
   "notes": "Notes",
+  "noColumnEntry": "No column entry",
   "numberOfAlerts": "Number of alerts",
   "other": "Other",
   "password": "Password",

--- a/lang/es.json
+++ b/lang/es.json
@@ -71,6 +71,7 @@
   "mostRecentAlerts": "Alertas más recientes",
   "mostRecentAlertsShownIn": "Las alertas más recientes se muestran en el mapa en",
   "notes": "Notas",
+  "noColumnEntry": "Sin entrada de columna",
   "numberOfAlerts": "Número de alertas",
   "other": "Otro",
   "password": "Contraseña",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -72,6 +72,7 @@
   "mostRecentAlerts": "Meest recente alerts",
   "mostRecentAlertsShownIn": "Meest recente alerts getoond op kaart in",
   "notes": "Notities",
+  "noColumnEntry": "Geen kolominvoer",
   "numberOfAlerts": "Aantal alerts",
   "other": "Andere",
   "password": "Wachtwoord",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -71,6 +71,7 @@
   "mostRecentAlerts": "Alertas mais recentes",
   "mostRecentAlertsShownIn": "Alertas mais recentes mostrados no mapa em",
   "notes": "Notas",
+  "noColumnEntry": "Sem entrada de coluna",
   "numberOfAlerts": "Número de alertas",
   "other": "Outro",
   "password": "Senha",


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/80. Makes it possible for a user to select "No column entry" in the filter dropdown to add data for which the filter column value is null or undefined.

## Screenshots

![image](https://github.com/user-attachments/assets/3a423e81-91da-431d-a848-708e8d0315fd)

## What I changed

* In mapping data values for `filterColumn`, if the value is null or undefined then return an object with an undefined `value`, `noColumnEntry` (i18n string) `label`, and `color`.
* When creating a `uniqueFilterValues` map, if this object is found, then add it to the very end of the list.
* Set fallback value for `defaultColoredDotColor` to `#808080` (a neutral gray).
* I also refactored the code for improved legibility by choosing better names for variables and functions throughout.