### PR TITLE
Switch out "Planet NICFI" tile URL for "PlanetScope Select"

### DIFF
--- a/components/shared/BasemapSelector.vue
+++ b/components/shared/BasemapSelector.vue
@@ -25,6 +25,7 @@ const toggleBasemapWindow = () => {
 };
 
 // PlanetScope Monthly Select Basemaps
+// Reference: https://docs.planet.com/develop/apis/tiles/
 const minMonth = "2020_01"; // The first month we have PlanetScope Monthly Select Basemaps
 const maxMonth = computed(() => {
   // If the current day is less than or equal to 15, maxMonth is two months ago.

--- a/components/shared/BasemapSelector.vue
+++ b/components/shared/BasemapSelector.vue
@@ -24,12 +24,12 @@ const toggleBasemapWindow = () => {
   showBasemapWindow.value = !showBasemapWindow.value;
 };
 
-// Planet NICFI monthly basemaps
-const minMonth = "2020-09"; // The first month we have Planet NICFI monthly basemaps
+// PlanetScope Monthly Select Basemaps
+const minMonth = "2020_01"; // The first month we have PlanetScope Monthly Select Basemaps
 const maxMonth = computed(() => {
   // If the current day is less than or equal to 15, maxMonth is two months ago.
   // Otherwise, maxMonth is the previous month.
-  // This is because Planet NICFI monthly basemaps for the previous month are published on the 15th of each month.
+  // This is because PlanetScope Monthly Select Basemaps for the previous month are published on the 15th of each month.
   const date = new Date();
   if (date.getDate() <= 15) {
     date.setMonth(date.getMonth() - 2);
@@ -39,14 +39,16 @@ const maxMonth = computed(() => {
   const year = date.getFullYear();
   const monthNumber = date.getMonth() + 1;
   const formattedMonth = monthNumber < 10 ? `0${monthNumber}` : monthNumber;
-  return `${year}-${formattedMonth}`;
+  return `${year}_${formattedMonth}`;
 });
-const monthYear = ref(maxMonth.value);
+const monthYear = ref<string>(maxMonth.value);
 const setPlanetDateRange = (date: Date) => {
-  // minMonth and maxMonth are in format YYYY-MM, but date is a Date object
+  // minMonth and maxMonth are in format YYYY_MM, but date is a Date object
   // so we need to convert it to a string in the same format
-  const formattedDate = date.toISOString().slice(0, 7);
-  return formattedDate < minMonth || formattedDate > maxMonth.value;
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const formatted = `${year}_${month < 10 ? "0" + month : month}`;
+  return formatted < minMonth || formatted > maxMonth.value;
 };
 
 /** Update the monthYear when the Planet basemap is selected */
@@ -137,13 +139,13 @@ const emitBasemapChange = () => {
             name="basemap"
             @change="emitBasemapChange"
           />
-          {{ $t("planetMonthlyVisualBasemap") }}
+          PlanetScope Monthly Select Basemaps
         </label>
         <label v-if="selectedBasemap.id === 'planet'">
           <Datepicker
             v-model:value="monthYear"
-            format="YYYY-MM"
-            value-type="YYYY-MM"
+            format="YYYY_MM"
+            value-type="YYYY_MM"
             type="month"
             :default-value="maxMonth"
             :disabled-date="setPlanetDateRange"

--- a/docs/config.md
+++ b/docs/config.md
@@ -78,7 +78,7 @@ A comma-separated list of Mapbox layer ids to be rendered in an optional map leg
 
 #### `PLANET_API_KEY` (optional)
 
-Provide a Planet NICFI Monthly Basemaps API key to enable the option to use the monthly basemaps as a style option in the basemap selector menu.
+Provide a Planet API key to enable the option to use Planet basemaps as a style option in the basemap selector menu.
 
 #### `UNWANTED_COLUMNS` (optional) and `UNWANTED_SUBSTRINGS` (optional)
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -81,7 +81,6 @@
   "password": "Password",
   "passwordIncorrect": "The password you entered is incorrect",
   "planetApiKey": "Planet API Key",
-  "planetMonthlyVisualBasemap": "Planet (NICFI) - monthly visual basemap",
   "pleaseMatchFormat": "Por favor, siga el formato esperado",
   "previewImagerySource": "Preview Imagery Source",
   "previousAlerts": "Previous alerts",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -81,7 +81,6 @@
   "password": "Contraseña",
   "passwordIncorrect": "La contraseña que ingresó es incorrecta",
   "planetApiKey": "Clave API de Planet",
-  "planetMonthlyVisualBasemap": "Planet (NICFI) - mapa base visual mensual",
   "pleaseMatchFormat": "Por favor, siga el formato esperado",
   "previewImagerySource": "Vista previa de las fuentes de imágenes",
   "previousAlerts": "Alertas anteriores",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -82,7 +82,6 @@
   "password": "Wachtwoord",
   "passwordIncorrect": "Het ingevoerde wachtwoord is onjuist",
   "planetApiKey": "Planet API sleutel",
-  "planetMonthlyVisualBasemap": "Planet (NICFI) - maandelijkse visuele basiskaart",
   "pleaseMatchFormat": "Gelieve het verwachte formaat te volgen",
   "previewImagerySource": "Bron van afbeeldingen",
   "previousAlerts": "Vorige alerts",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -81,7 +81,6 @@
   "password": "Senha",
   "passwordIncorrect": "A senha que você inseriu está incorreta",
   "planetApiKey": "Chave API do Planet",
-  "planetMonthlyVisualBasemap": "Planet (NICFI) - mapa base visual mensal",
   "pleaseMatchFormat": "Por favor, siga o formato esperado",
   "previewImagerySource": "Visualizar fonte de imagens",
   "previousAlerts": "Alertas anteriores",

--- a/utils/mapFunctions.ts
+++ b/utils/mapFunctions.ts
@@ -12,7 +12,7 @@ export const mapStyles: Record<string, MapStyle> = {
         planet: {
           type: "raster",
           tiles: [
-            `https://tiles.planet.com/basemaps/v1/planet-tiles/planet_medres_visual_monthYear_mosaic/gmap/{z}/{x}/{y}?api_key=`,
+            `https://tiles.planet.com/basemaps/v1/planet-tiles/global_monthly_monthYear_mosaic/gmap/{z}/{x}/{y}?api_key=`,
           ],
           tileSize: 256,
         },


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/96. 

This PR updates the Tile URL structure for Planet monthly basemaps from NICFI, which is no longer available, to PlanetScope Select. 

This will enable Project Centinela (or paying) users to access Planet monthly basemaps again.
