### PR TITLE
Add Render / E2E tests for home page functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ $ pnpm test
 
 1. Copy `.env.test.example` to `.env.test`
 2. Ensure `NUXT_PUBLIC_AUTH_STRATEGY="none"` in your `.env.test` file to bypass authentication
-3. Configure a test PostgreSQL database connection in `.env.test`
-4. Ensure your test database has the required tables and data for the tests
+3. Ensure your test database has the required tables, data and views config for the tests. This includes at least one alerts view.
 
 The E2E tests run the real Nuxt application in a browser and connect to a real PostgreSQL database to verify user interactions and page rendering.
 

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -11,7 +11,7 @@ test("index page - displays available views and alerts link", async ({
     page.getByRole("heading", { name: /available views/i }),
   ).toBeVisible();
 
-  // 3. Ensure at least one Alerts link is visible (guaranteed by other tests/config)
+  // 3. Ensure at least one Alerts link is visible (guaranteed through a database connection that has an alerts view)
   const alertsLink = page.getByRole("link", { name: /alerts/i }).first();
   await alertsLink.waitFor({ state: "visible", timeout: 10000 });
 

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+test("index page - displays available views and view links", async ({
+  page,
+}) => {
+  // 1. Navigate to the root of the application
+  await page.goto("/");
+
+  // 2. Wait for the page heading "Available Views" to become visible
+  await expect(
+    page.getByRole("heading", { name: /available views/i }),
+  ).toBeVisible();
+
+  // 3. Ensure at least one Alerts link is visible (guaranteed by other tests/config)
+  const alertsLink = page.getByRole("link", { name: /alerts/i }).first();
+  await alertsLink.waitFor({ state: "visible", timeout: 10000 });
+
+  // 4. (Optional) Verify the link's href leads to an alerts route pattern
+  const href = await alertsLink.getAttribute("href");
+  expect(href).toMatch(/^\/alerts\//);
+
+  // 5. Verify the logo image is displayed
+  const logoImage = page.locator("img[alt='Guardian Connector Explorer Logo']");
+  await expect(logoImage).toBeVisible();
+  expect(await logoImage.getAttribute("src")).toBe("/gcexplorer.png");
+});
+
+test("index page - language picker functionality", async ({ page }) => {
+  // 1. Navigate to the root of the application
+  await page.goto("/");
+
+  // 2. Wait for the language picker button to be visible
+  const languageButton = page
+    .locator("button")
+    .filter({ hasText: /English|Español|Nederlands|Português/i });
+  await languageButton.waitFor({ state: "visible", timeout: 10000 });
+
+  // 3. Verify the button shows current language
+  const buttonText = await languageButton.textContent();
+  expect(buttonText).toMatch(/English|Español|Nederlands|Português/);
+
+  // 4. Click the button to open dropdown
+  await languageButton.click();
+
+  // 5. Wait for dropdown menu to appear and check for language options
+  const dropdownMenu = page.locator(
+    "div.origin-top-right.absolute.right-0.mt-2.w-56.rounded-md.shadow-lg.bg-white.ring-1.ring-black.ring-opacity-5.z-50",
+  );
+  await dropdownMenu.waitFor({ state: "visible", timeout: 5000 });
+
+  // 6. Check that multiple language options are available
+  const languageOptions = dropdownMenu.locator(
+    "a.block.px-4.py-2.text-sm.text-gray-700",
+  );
+  const optionCount = await languageOptions.count();
+  expect(optionCount).toBeGreaterThan(1);
+
+  // 7. Test language switching by clicking a different language
+  const firstOption = languageOptions.first();
+  const firstOptionText = await firstOption.textContent();
+
+  // Only switch if it's different from current language (trim whitespace)
+  if (firstOptionText?.trim() !== buttonText?.trim()) {
+    await firstOption.click();
+
+    // 8. Verify the button text changed
+    await page.waitForTimeout(1000);
+    const newButtonText = await languageButton.textContent();
+    expect(newButtonText?.trim()).toBe(firstOptionText?.trim());
+  }
+});

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("index page - displays available views and view links", async ({
+test("index page - displays available views and alerts link", async ({
   page,
 }) => {
   // 1. Navigate to the root of the application

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -44,14 +44,12 @@ test("index page - language picker functionality", async ({ page }) => {
 
   // 5. Wait for dropdown menu to appear and check for language options
   const dropdownMenu = page.locator(
-    "div.origin-top-right.absolute.right-0.mt-2.w-56.rounded-md.shadow-lg.bg-white.ring-1.ring-black.ring-opacity-5.z-50",
+    "div[class*='absolute'][class*='right-0'][class*='bg-white']",
   );
   await dropdownMenu.waitFor({ state: "visible", timeout: 5000 });
 
   // 6. Check that multiple language options are available
-  const languageOptions = dropdownMenu.locator(
-    "a.block.px-4.py-2.text-sm.text-gray-700",
-  );
+  const languageOptions = dropdownMenu.locator("a[href='#']");
   const optionCount = await languageOptions.count();
   expect(optionCount).toBeGreaterThan(1);
 

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -69,3 +69,41 @@ test("index page - language picker functionality", async ({ page }) => {
     expect(newButtonText?.trim()).toBe(firstOptionText?.trim());
   }
 });
+
+test("index page - language switching to Portuguese changes heading", async ({
+  page,
+}) => {
+  // 1. Navigate to the root of the application
+  await page.goto("/");
+
+  // 2. Wait for the language picker button to be visible
+  const languageButton = page
+    .locator("button")
+    .filter({ hasText: /English|Español|Nederlands|Português/i });
+  await languageButton.waitFor({ state: "visible", timeout: 10000 });
+
+  // 3. Click the button to open dropdown
+  await languageButton.click();
+
+  // 4. Wait for dropdown menu to appear
+  const dropdownMenu = page.locator(
+    "div[class*='absolute'][class*='right-0'][class*='bg-white']",
+  );
+  await dropdownMenu.waitFor({ state: "visible", timeout: 5000 });
+
+  // 5. Find and click the Portuguese option
+  const portugueseOption = dropdownMenu
+    .locator("a[href='#']")
+    .filter({ hasText: /Português/i });
+  await portugueseOption.click();
+
+  // 6. Wait for the page to update and verify the heading changed to Portuguese
+  await expect(
+    page.getByRole("heading", { name: /visualizações disponíveis/i }),
+  ).toBeVisible();
+
+  // 7. Verify the original English heading is no longer visible
+  await expect(
+    page.getByRole("heading", { name: /available views/i }),
+  ).not.toBeVisible();
+});

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -37,7 +37,9 @@ test("index page - language picker functionality", async ({ page }) => {
 
   // 3. Verify the button shows current language
   const buttonText = await languageButton.textContent();
-  expect(buttonText).toMatch(/English|Español|Nederlands|Português/);
+  expect(["English", "Español", "Nederlands", "Português"]).toContain(
+    buttonText?.trim(),
+  );
 
   // 4. Click the button to open dropdown
   await languageButton.click();


### PR DESCRIPTION
## Goal

Add comprehensive render / E2E tests for the home page to ensure core functionality works correctly. Closes #128 

## Screenshots
<img width="588" alt="Screenshot 2025-07-03 at 16 55 19" src="https://github.com/user-attachments/assets/7de4b4c2-0578-415d-ac9c-03376891739a" />



## What I changed

- Added `e2e/index.spec.ts` with two test suites:
  - **Page rendering test**: Verifies the home page loads properly with logo, heading, and alerts links
  - **Language picker test**: Tests language switching functionality with resilient selectors that survive styling changes

## What I'm not doing here

- Unit testing the index since it is technically not a Nuxt page not its standalone component (too complex with Nuxt dependencies)