### PR TITLE
Resolve "bug: Alerts e2e test passing early"

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -187,7 +187,6 @@ const selectInitialMapeoFeature = (mapeoDocId: string) => {
 
 onMounted(() => {
   mapboxgl.accessToken = props.mapboxAccessToken;
-
   map.value = new mapboxgl.Map({
     container: "map",
     style: props.mapboxStyle || "mapbox://styles/mapbox/streets-v12",

--- a/e2e/alerts.spec.ts
+++ b/e2e/alerts.spec.ts
@@ -6,16 +6,16 @@ test("alerts dashboard - opens sidebar and updates URL on symbol and polygon cli
   await page.goto("/");
   // Wait until the index page has rendered the list of available views
   const alertsLink = page.getByRole("link", { name: /alerts/i }).first();
-  await alertsLink.waitFor({ state: "visible", timeout: 10000 });
+  await alertsLink.waitFor({ state: "visible", timeout: 5000 });
 
   // Navigate to the alerts dashboard via client-side routing
   await alertsLink.click();
 
   // Ensure the route change completed
-  await page.waitForURL("**/alerts/**", { timeout: 10000 });
+  await page.waitForURL("**/alerts/**", { timeout: 5000 });
 
   // Wait until the map container has been added to the DOM
-  await page.locator("#map").waitFor({ state: "attached", timeout: 10000 });
+  await page.locator("#map").waitFor({ state: "attached", timeout: 5000 });
 
   /* Give Mapbox a gentle nudge: click roughly at 75% of the viewport width
    (vertically centered).  This ensures tiles are rendered and
@@ -43,7 +43,7 @@ test("alerts dashboard - opens sidebar and updates URL on symbol and polygon cli
       const map = window._testMap;
       return map && map.isStyleLoaded() && map.loaded();
     },
-    { timeout: 15000 },
+    { timeout: 5000 },
   );
 
   // pull every symbol feature Mapbox has already rendered
@@ -68,7 +68,7 @@ test("alerts dashboard - opens sidebar and updates URL on symbol and polygon cli
       });
       return features.length > 0;
     },
-    { timeout: 10000 },
+    { timeout: 5000 },
   );
 
   //

--- a/e2e/alerts.spec.ts
+++ b/e2e/alerts.spec.ts
@@ -36,6 +36,16 @@ test("alerts dashboard - opens sidebar and updates URL on symbol and polygon cli
     return !!window._testMap;
   });
 
+  // Wait for the map to be fully loaded and rendered
+  await page.waitForFunction(
+    () => {
+      // @ts-expect-error _testMap is exposed for E2E testing only
+      const map = window._testMap;
+      return map && map.isStyleLoaded() && map.loaded();
+    },
+    { timeout: 15000 },
+  );
+
   // pull every symbol feature Mapbox has already rendered
 
   const symbolFeatures = await page.evaluate(() => {
@@ -46,6 +56,19 @@ test("alerts dashboard - opens sidebar and updates URL on symbol and polygon cli
     });
     return features;
   });
+
+  // Wait for at least one symbol feature to be rendered
+  await page.waitForFunction(
+    () => {
+      // @ts-expect-error _testMap is exposed for E2E testing only
+      const map = window._testMap;
+      const features = map.queryRenderedFeatures({
+        layers: ["most-recent-alerts-symbol"],
+      });
+      return features.length > 0;
+    },
+    { timeout: 10000 },
+  );
 
   //
   // loop through them and fire a synthetic click

--- a/e2e/alerts.spec.ts
+++ b/e2e/alerts.spec.ts
@@ -61,6 +61,7 @@ test("alerts dashboard - opens sidebar and updates URL on symbol and polygon cli
   await page.waitForFunction(
     () => {
       // @ts-expect-error _testMap is exposed for E2E testing only
+      // We wait for symbol features to render because DOM or API readiness doesn't guarantee map rendering
       const map = window._testMap;
       const features = map.queryRenderedFeatures({
         layers: ["most-recent-alerts-symbol"],


### PR DESCRIPTION
## Goal

Fix E2E test reliability by adding explicit waiting for map rendering in the alerts dashboard test. Closes #133 

## Screenshots

https://github.com/user-attachments/assets/0a6375c5-1956-40c4-a150-1f70229da5f9

## What I changed

- **Added map style and map loading checks**:   Added explicit waiting mechanisms to ensure the map is fully rendered before test interactions. Wait for `map.isStyleLoaded()` and `map.isLoaded` before proceeding.

## What I'm not doing here

- Not changing the core map functionality or rendering logic
- Not modifying the alerts dashboard component behavior
