### PR TITLE
fix: set correct boolean value for skipping config db creation in CI

### DIFF
--- a/server/database/dbConnection.ts
+++ b/server/database/dbConnection.ts
@@ -36,8 +36,10 @@ export const setupDatabaseConnection = async (
   // and since we "hijack" the return values during testing/CI anyway,
   // we can just return null to avoid connection errors and potential crashes.
   // This is the correct behavior since the database DOES NOT exist.
-  if (isConfigDb && !process.env.CI) {
-    console.log("Config database does not exist. Attemping to create...");
+  if (isConfigDb && process.env.CI) {
+    console.log(
+      "Skipping config database connection in CI/testing environment.",
+    );
     return null;
   }
   let client = new pg.Client(dbConnection);


### PR DESCRIPTION
## Goal

When running `main` locally, I got an unexpected error

```
 ERROR  Error fetching config on API side: Cannot read properties of null (reading 'query')

Setting up database connection to guardianconnector...
Config database does not exist. Attemping to create...
```

This is because the recently merged code for running tests in CI set a boolean incorrectly. Also, I improved the console log message to get a better grip of what is going on.