### PR TITLE
fix: on alerts dashboard, toggle show/hide alert layers as a group

### DIFF
--- a/components/shared/MapLegend.vue
+++ b/components/shared/MapLegend.vue
@@ -60,7 +60,11 @@ watch(
         @change="toggleLayerVisibility(item)"
       />
       <label :for="item.id">
+        <div v-if="item.iconUrl" class="icon-box">
+          <img :src="item.iconUrl" :alt="item.name" class="legend-icon" />
+        </div>
         <div
+          v-else
           :class="['color-box', getTypeClass(item)]"
           :style="{ backgroundColor: item.color }"
         ></div>
@@ -120,6 +124,21 @@ watch(
   height: 10px;
   margin: 5px;
   margin-right: 15px;
+}
+
+.icon-box {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-right: 10px;
+  vertical-align: middle;
+  position: relative;
+}
+
+.legend-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .legend-item {

--- a/types/types.ts
+++ b/types/types.ts
@@ -99,6 +99,7 @@ export type MapLegendItem = {
   name: string;
   type: string;
   visible: boolean;
+  iconUrl?: string;
 };
 
 export type AlertsMetadata = {


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/163.

This PR solves the issue described in #163, and also provides a solution for an as-of-yet undocumented issue where either a linestring, point, or polygon is used to represent alerts in the legend, when there may be multiple geometries on the map.

## Screenshots

Before (note the polygon on the map, which the line in the legend does not represent well):
<img width="522" height="261" alt="image" src="https://github.com/user-attachments/assets/c1cf82dc-9835-4b55-b7cf-69732131ffce" />

After:
<img width="287" height="99" alt="image" src="https://github.com/user-attachments/assets/ce9c205f-969b-4ef2-9ceb-a29a59f1cc54" />

## Test log
```
=== Testing Most recent alerts ===
Found 4 layers: [
  'most-recent-alerts-polygon',
  'most-recent-alerts-polygon-stroke',
  'most-recent-alerts-linestring',
  'most-recent-alerts-symbol'
]
✅ 4 layers initially visible
✓ most-recent-alerts-polygon is hidden
✓ most-recent-alerts-polygon-stroke is hidden
✓ most-recent-alerts-linestring is hidden
✓ most-recent-alerts-symbol is hidden
✓ most-recent-alerts-polygon is visible again
✓ most-recent-alerts-polygon-stroke is visible again
✓ most-recent-alerts-linestring is visible again
✓ most-recent-alerts-symbol is visible again
✅ Most recent alerts all 4 layers can be controlled as a group

=== Testing Previous alerts ===
Found 5 layers: [
  'previous-alerts-polygon',
  'previous-alerts-polygon-stroke',
  'previous-alerts-linestring',
  'previous-alerts-point',
  'previous-alerts-symbol'
]
✅ 5 layers initially visible
✓ previous-alerts-polygon is hidden
✓ previous-alerts-polygon-stroke is hidden
✓ previous-alerts-linestring is hidden
✓ previous-alerts-point is hidden
✓ previous-alerts-symbol is hidden
✓ previous-alerts-polygon is visible again
✓ previous-alerts-polygon-stroke is visible again
✓ previous-alerts-linestring is visible again
✓ previous-alerts-point is visible again
✓ previous-alerts-symbol is visible again
✅ Previous alerts all 5 layers can be controlled as a group

Legend verification:
Legend entries found: [
  'Most recent alerts',
  'Previous alerts',
  'Mapeo data',
  'Road primary',
  'Aerialway'
]
✅ Legend shows grouped entries, not individual geometry layers
·
  1 passed (7.9s)
```

## What I changed

* In `AlertsDashboard`, implemented a custom `toggleLayerVisibility` function that handles alert group layers by iterating through all geometry types (polygon, linestring, point, symbol) and their stroke variants
* In `MapLegend`, replaced generic fill-type legend icons with actual alert warning icons for better visual representation
* For playwright tests, rather than expanding an already large-in-scope "layer visibility toggles" test, created a bespoke "legend can control all alert layer types" test. 
* Tried to to fix the flaky "layer visibility toggles" test. Seeing this in the CircleCI logs,
    ```
    150 |     await checkbox.click();
    > 151 |     await page.waitForTimeout(500);
    ```
    I had a theory that since this is the very last action in the test, somehow the click event was not registering, and this could be improved by...
    ```
    await checkbox.focus();
    await checkbox.uncheck();
    await page.waitForTimeout(500);
    ```
    This change at least seemed to pass here on a first CircleCI run? But I realize the test was flaky to begin with as it would sometimes pass, so not sure if it really solved the problem. I wonder if/whether the tests can be written to only rely upon `waitForTimeout()` and ditch any timeouts