### PR TITLE
Bold labels in sidebar

### DIFF
--- a/components/alerts/AlertsIntroPanel.vue
+++ b/components/alerts/AlertsIntroPanel.vue
@@ -60,7 +60,7 @@ const emit = defineEmits(["dateRangeChanged"]);
             v-if="props.alertsStatistics.typeOfAlerts?.length"
             class="flex items-center gap-2"
           >
-            <span class="font-medium text-sm">{{ $t("typeOfAlerts") }}:</span>
+            <span class="font-bold text-sm">{{ $t("typeOfAlerts") }}:</span>
             <span class="text-sm text-muted-foreground">{{
               props.alertsStatistics.typeOfAlerts.join(", ")
             }}</span>
@@ -69,13 +69,13 @@ const emit = defineEmits(["dateRangeChanged"]);
             v-if="props.alertsStatistics.dataProviders?.length"
             class="flex items-center gap-2"
           >
-            <span class="font-medium text-sm">{{ $t("dataProviders") }}:</span>
+            <span class="font-bold text-sm">{{ $t("dataProviders") }}:</span>
             <span class="text-sm text-muted-foreground">{{
               props.alertsStatistics.dataProviders.join(", ")
             }}</span>
           </div>
           <div class="flex items-center gap-2">
-            <span class="font-medium text-sm"
+            <span class="font-bold text-sm"
               >{{ $t("alertDetectionRange") }}:</span
             >
             <span class="text-sm text-muted-foreground">{{
@@ -83,15 +83,13 @@ const emit = defineEmits(["dateRangeChanged"]);
             }}</span>
           </div>
           <div class="flex items-center gap-2">
-            <span class="font-medium text-sm"
-              >{{ $t("recentAlertsDate") }}:</span
-            >
+            <span class="font-bold text-sm">{{ $t("recentAlertsDate") }}:</span>
             <span class="text-sm text-muted-foreground">{{
               props.alertsStatistics.recentAlertsDate
             }}</span>
           </div>
           <div class="flex items-center gap-2">
-            <span class="font-medium text-sm"
+            <span class="font-bold text-sm"
               >{{ $t("recentAlertsNumber") }}:</span
             >
             <span class="text-sm text-muted-foreground">{{
@@ -99,7 +97,7 @@ const emit = defineEmits(["dateRangeChanged"]);
             }}</span>
           </div>
           <div class="flex items-center gap-2">
-            <span class="font-medium text-sm">{{ $t("alertsTotal") }}:</span>
+            <span class="font-bold text-sm">{{ $t("alertsTotal") }}:</span>
             <span class="text-sm text-muted-foreground">{{
               props.alertsStatistics.alertsTotal
             }}</span>
@@ -110,7 +108,7 @@ const emit = defineEmits(["dateRangeChanged"]);
             "
             class="flex items-center gap-2"
           >
-            <span class="font-medium text-sm">{{ $t("hectaresTotal") }}:</span>
+            <span class="font-bold text-sm">{{ $t("hectaresTotal") }}:</span>
             <span class="text-sm text-muted-foreground">{{
               props.alertsStatistics.hectaresTotal
             }}</span>

--- a/components/shared/DataFeature.vue
+++ b/components/shared/DataFeature.vue
@@ -100,7 +100,7 @@ const setMediaBasePath = () => {
           >
             <!-- Translate keys only when it's an alert to avoid performance issues with translating all keys -->
             <div class="flex items-center gap-2">
-              <span class="text-sm font-medium" data-testid="field-label">
+              <span class="text-sm font-bold" data-testid="field-label">
                 {{
                   isAlert
                     ? $t(key).charAt(0).toUpperCase() + $t(key).slice(1)


### PR DESCRIPTION
## Goal

## Feature Request

While working on other tasks, I noticed that all labels in the sidebar were no longer rendering as bold:

<img width="334" height="216" alt="Image" src="https://github.com/user-attachments/assets/70d76bb5-d92a-471f-b0dd-5ac27e651b0c" />

This is true for alerts, gallery, and map views.

I think this was an unintended regression.

This PR makes them bold again, using the same Windi class as before:

<img width="363" height="321" alt="image" src="https://github.com/user-attachments/assets/6efa9dde-9a69-4b07-ac2a-6cff7ab740c5" />

