### PR TITLE
Drizzle Migration HotFix: Fix idempotent migration for config table rename

### DIFF
--- a/server/db/migrations/0001_rename_config_to_view_config.sql
+++ b/server/db/migrations/0001_rename_config_to_view_config.sql
@@ -1,5 +1,11 @@
 -- Migration: Rename config table to view_config
 -- This migration renames the existing config table to view_config
 
--- Rename the table
-ALTER TABLE config RENAME TO view_config;
+-- Only rename if config table exists and view_config doesn't exist
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'config')
+       AND NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'view_config') THEN
+        ALTER TABLE config RENAME TO view_config;
+    END IF;
+END $$;

--- a/server/db/migrations/meta/0001_rename_config_to_view_config.json
+++ b/server/db/migrations/meta/0001_rename_config_to_view_config.json
@@ -4,7 +4,7 @@
   "entries": [
     {
       "type": "sql",
-      "sql": "-- Migration: Rename config table to view_config\n-- This migration renames the existing config table to view_config\n\n-- Rename the table\nALTER TABLE config RENAME TO view_config;\n\n-- Add the new timestamp columns if they don't exist\nALTER TABLE view_config \nADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL;\n\nALTER TABLE view_config \nADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL;"
+      "sql": "-- Migration: Rename config table to view_config\n-- This migration renames the existing config table to view_config\n\n-- Only rename if config table exists and view_config doesn't exist\nDO $$\nBEGIN\n    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'config')\n       AND NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'view_config') THEN\n        ALTER TABLE config RENAME TO view_config;\n    END IF;\nEND $$;"
     }
   ]
 }


### PR DESCRIPTION
## Goal
Fix idempotent migration for config table rename

## Screenshots
N/A

## What I changed
- Updated migration SQL to use `DO $$ BEGIN IF EXISTS (...) AND NOT EXISTS (...) THEN ALTER TABLE ... END IF; END $$;` block which basically checks that config exists and view_config does not THEN alters
- Updated migration metadata to match the new SQL content
- Made migration safe to re-run without errors

## What I'm not doing here
- Not changing any other functionality
- Not modifying existing schemas