### PR TITLE
Bug: Public datasets still asking for login & Bug: View Routes do not resolve without auth0 role

### DIFF
--- a/components/config/ConfigPermissions.vue
+++ b/components/config/ConfigPermissions.vue
@@ -23,7 +23,7 @@ const routeLevelPermission = ref<RouteLevelPermission | undefined>(
 const shouldShowPermissions = computed(() => {
   if (!user.value) return false;
   const typedUser = user.value as User;
-  const userRole = typedUser.userRole || Role.Viewer;
+  const userRole = typedUser.userRole ?? Role.Public;
   return userRole >= Role.Admin;
 });
 

--- a/middleware/oauth.global.ts
+++ b/middleware/oauth.global.ts
@@ -39,7 +39,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
       const response = await $fetch<
         [
-          Record<string, { routeLevelPermission?: RouteLevelPermission }>,
+          Record<string, { ROUTE_LEVEL_PERMISSION?: RouteLevelPermission }>,
           string[],
         ]
       >("/api/config", { headers });
@@ -48,7 +48,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
       // Extract the table name from the last part of the path
       const tableName = to.path.split("/").pop()!;
       const permission: RouteLevelPermission =
-        tableConfig?.[tableName]?.routeLevelPermission ?? "member";
+        tableConfig?.[tableName]?.ROUTE_LEVEL_PERMISSION ?? "signed-in";
       // Public access: no login needed
       if (permission === "anyone") return;
 

--- a/middleware/oauth.global.ts
+++ b/middleware/oauth.global.ts
@@ -60,7 +60,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
       // Authenticated from here on
       const typedUser = user.value as User;
-      const userRole = typedUser?.userRole ?? Role.Viewer;
+      const userRole = typedUser?.userRole ?? Role.Public;
       // Role-based access control
       switch (permission) {
         case "member":
@@ -91,7 +91,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
   // Check role-based access for restricted routes
   if (authStrategy === "auth0" && loggedIn.value && user.value) {
     const typedUser = user.value as User;
-    const userRole = typedUser.userRole || Role.Viewer;
+    const userRole = typedUser.userRole ?? Role.Public;
 
     // Redirect non-Admins from config route
     if (to.path === "/config" && userRole < Role.Admin) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -47,7 +47,6 @@ const filteredSortedViewsConfig = computed(() => {
   }
 
   const typedUser = user.value as User | null;
-  console.log("typedUser", typedUser);
   const userRole = typedUser?.userRole ?? Role.Public;
 
   return Object.keys(viewsConfig.value)
@@ -71,9 +70,6 @@ const filteredSortedViewsConfig = computed(() => {
         config.ROUTE_LEVEL_PERMISSION === undefined &&
         userRole < Role.Public
       ) {
-        console.log(
-          "config.ROUTE_LEVEL_PERMISSION is undefined and userRole is lower than Public",
-        );
         return false;
       }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -47,14 +47,14 @@ const filteredSortedViewsConfig = computed(() => {
   }
 
   const typedUser = user.value as User | null;
-  const userRole = typedUser?.userRole || Role.Viewer;
+  console.log("typedUser", typedUser);
+  const userRole = typedUser?.userRole ?? Role.Public;
 
   return Object.keys(viewsConfig.value)
     .filter((key) => {
       const config = viewsConfig.value[key];
       // Filter out empty configs
       if (Object.keys(config).length === 0) return false;
-
       // Filter views based on user role and permission level
       // Hide view if user role is lower than what's required
       if (
@@ -64,6 +64,16 @@ const filteredSortedViewsConfig = computed(() => {
         return false;
       }
       if (config.ROUTE_LEVEL_PERMISSION === "admin" && userRole < Role.Admin) {
+        return false;
+      }
+      // base case for when ROUTE_LEVEL_PERMISSION is undefined i.e. it has never been set and user role is lower than Public
+      if (
+        config.ROUTE_LEVEL_PERMISSION === undefined &&
+        userRole < Role.Public
+      ) {
+        console.log(
+          "config.ROUTE_LEVEL_PERMISSION is undefined and userRole is lower than Public",
+        );
         return false;
       }
 
@@ -84,7 +94,7 @@ const isViewRestricted = (tableName: string) => {
   if (!user.value) return false;
   const permission = viewsConfig.value[tableName]?.ROUTE_LEVEL_PERMISSION;
   const typedUser = user.value as User | null;
-  const userRole = typedUser?.userRole || Role.Viewer;
+  const userRole = typedUser?.userRole ?? Role.Public;
 
   return (
     userRole >= Role.Member &&
@@ -105,7 +115,7 @@ const shouldShowConfigLink = computed(() => {
 
   if (authStrategy === "auth0" && loggedIn.value && user.value) {
     const typedUser = user.value as User | null;
-    const userRole = typedUser?.userRole || Role.Viewer;
+    const userRole = typedUser?.userRole ?? Role.Public;
     return userRole >= Role.Admin;
   }
 

--- a/server/api/auth/auth0.get.ts
+++ b/server/api/auth/auth0.get.ts
@@ -255,18 +255,18 @@ export default oauthAuth0EventHandler({
       }
 
       // Determine user role level
-      let userRole: Role = Role.Public; // Default to Public (not signed in)
+      let userRole: Role = Role.Viewer; // Default to Viewer (not signed in)
       if (userRoles.length > 0) {
         const hasAdminRole = userRoles.some((role) => role.name === "Admin");
         const hasMemberRole = userRoles.some((role) => role.name === "Member");
-        const hasViewerRole = userRoles.some((role) => role.name === "Viewer");
+        const hasPublicRole = userRoles.some((role) => role.name === "Public");
 
         if (hasAdminRole) {
           userRole = Role.Admin;
         } else if (hasMemberRole) {
           userRole = Role.Member;
-        } else if (hasViewerRole) {
-          userRole = Role.Viewer;
+        } else if (hasPublicRole) {
+          userRole = Role.Public;
         } else {
           // User has roles but none of the expected ones, treat as Viewer
           userRole = Role.Viewer;

--- a/types/types.ts
+++ b/types/types.ts
@@ -139,8 +139,8 @@ export type AlertsStatistics = {
 };
 
 export const Role = {
-  Public: 0, // Not signed in, no permissions
-  Viewer: 1, // Signed in but no special permissions
+  Viewer: 0, // Not signed in, no permissions
+  Public: 1, // Signed in but no special permissions
   Member: 2, // Signed in with member permissions
   Admin: 3, // Signed in with admin permissions
 } as const;

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -34,7 +34,7 @@ export const validatePermissions = async (
   // For member permission, check user role
   if (permission === "member") {
     const typedUser = session.user as User;
-    const userRole = typedUser?.userRole || Role.Viewer;
+    const userRole = typedUser?.userRole ?? Role.Public;
 
     if (userRole < Role.Member) {
       throw createError({
@@ -47,7 +47,7 @@ export const validatePermissions = async (
   // For admin permission, check user role
   if (permission === "admin") {
     const typedUser = session.user as User;
-    const userRole = typedUser?.userRole || Role.Viewer;
+    const userRole = typedUser?.userRole ?? Role.Public;
 
     if (userRole < Role.Admin) {
       throw createError({


### PR DESCRIPTION
## Goal
Fix the bug where public (i.e. dataset with `anyone` permissions) datasets were asking for log in. Closes #210 and a bug around view routes not rendering because the permission requirements were too high Closes #189. 

## Screenshots


## What I changed
- Default permissions is `signed-in`
- Role already defaulted to "Viewer"
- Fix type casting which was using outdated variable i.e. `routeLevelPermission` -> `ROUTE_LEVEL_PERMISSION`

## What I'm not doing here

