### PR TITLE
Set a default basemap when configuring map settings

### DIFF
--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -62,15 +62,21 @@ watch(terrainExaggeration, (value) => {
 });
 
 // Basemaps management
-const parseBasemaps = (): BasemapConfig[] => {
+const DEFAULT_BASEMAP: BasemapConfig = {
+  name: "Satellite Streets",
+  style: "mapbox://styles/mapbox/satellite-streets-v12",
+  isDefault: true,
+};
+
+const getConfiguredBasemaps = (): BasemapConfig[] | null => {
   if (props.config.MAPBOX_BASEMAPS) {
     try {
-      return JSON.parse(props.config.MAPBOX_BASEMAPS);
+      const parsed = JSON.parse(props.config.MAPBOX_BASEMAPS) as BasemapConfig[];
+      if (parsed.length > 0) return parsed;
     } catch {
-      return [];
+      // fall through to legacy/default handling
     }
   }
-  // Fallback to legacy MAPBOX_STYLE
   if (props.config.MAPBOX_STYLE) {
     return [
       {
@@ -80,7 +86,11 @@ const parseBasemaps = (): BasemapConfig[] => {
       },
     ];
   }
-  return [];
+  return null;
+};
+
+const parseBasemaps = (): BasemapConfig[] => {
+  return getConfiguredBasemaps() ?? [{ ...DEFAULT_BASEMAP }];
 };
 
 const basemaps = ref<BasemapConfig[]>(parseBasemaps());
@@ -89,6 +99,9 @@ const basemaps = ref<BasemapConfig[]>(parseBasemaps());
 onMounted(() => {
   basemaps.value = parseBasemaps();
   ensureDefault();
+  if (!getConfiguredBasemaps()) {
+    saveBasemaps();
+  }
 });
 
 watch(

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -71,7 +71,9 @@ const DEFAULT_BASEMAP: BasemapConfig = {
 const getConfiguredBasemaps = (): BasemapConfig[] | null => {
   if (props.config.MAPBOX_BASEMAPS) {
     try {
-      const parsed = JSON.parse(props.config.MAPBOX_BASEMAPS) as BasemapConfig[];
+      const parsed = JSON.parse(
+        props.config.MAPBOX_BASEMAPS,
+      ) as BasemapConfig[];
       if (parsed.length > 0) return parsed;
     } catch {
       // fall through to legacy/default handling
@@ -326,7 +328,7 @@ const handleDrop = (e: DragEvent, dropIndex: number) => {
             :disabled="!canAddBasemap"
             @click="addBasemap"
           >
-            + {{ $t("addBasemapOption") }}
+            + {{ $t("addBackgroundMapOption") }}
           </button>
         </div>
       </template>

--- a/components/shared/BasemapSelector.vue
+++ b/components/shared/BasemapSelector.vue
@@ -158,33 +158,6 @@ const emitBasemapChange = () => {
           />
           {{ $t("yourMapboxStyleDefault") }}
         </label>
-        <!-- Standard Mapbox basemaps -->
-        <label>
-          <input
-            v-model="selectedBasemap"
-            type="radio"
-            :value="{
-              id: 'satellite-streets',
-              style: 'mapbox://styles/mapbox/satellite-streets-v12',
-            }"
-            name="basemap"
-            @change="emitBasemapChange"
-          />
-          {{ $t("mapboxSatellite") }}
-        </label>
-        <label>
-          <input
-            v-model="selectedBasemap"
-            type="radio"
-            :value="{
-              id: 'streets',
-              style: 'mapbox://styles/mapbox/streets-v12',
-            }"
-            name="basemap"
-            @change="emitBasemapChange"
-          />
-          {{ $t("mapboxStreets") }}
-        </label>
         <label v-if="planetApiKey">
           <input
             v-model="selectedBasemap"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2,7 +2,7 @@
   "accessDenied": "Access Denied",
   "accessDeniedMessage": "You are not authorized to view the page you were trying to access. Please contact a Guardian Connector administrator to change your role in order to view this page.",
   "accessPermissions": "Access Permissions",
-  "addBasemapOption": "Add basemap option",
+  "addBackgroundMapOption": "Add background map option",
   "addDescription": "Add description",
   "addNewTable": "Add new dataset view",
   "administration": "Administration",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -2,7 +2,7 @@
   "accessDenied": "Acceso Denegado",
   "accessDeniedMessage": "No está autorizado para ver la página a la que intentaba acceder. Por favor, contacte a un administrador de Guardian Connector para cambiar su rol y poder ver esta página.",
   "accessPermissions": "Permisos de Acceso",
-  "addBasemapOption": "Agregar opción de mapa base",
+  "addBackgroundMapOption": "Agregar opción de mapa de fondo",
   "addDescription": "Agregar descripción",
   "addNewTable": "Agregar nueva vista de conjunto de datos",
   "administration": "Administración",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -2,7 +2,7 @@
   "accessDenied": "Toegang Geweigerd",
   "accessDeniedMessage": "U bent niet gemachtigd om de pagina te bekijken waartoe u probeerde toegang te krijgen. Neem contact op met een Guardian Connector-beheerder om uw rol te wijzigen om deze pagina te kunnen bekijken.",
   "accessPermissions": "Toegangsrechten",
-  "addBasemapOption": "Voeg basiskaart optie toe",
+  "addBackgroundMapOption": "Voeg achtergrondkaart optie toe",
   "addDescription": "Beschrijving toevoegen",
   "addNewTable": "Voeg nieuwe dataset weergave toe",
   "administration": "Beheer",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -2,7 +2,7 @@
   "accessDenied": "Acesso Negado",
   "accessDeniedMessage": "Você não está autorizado a visualizar a página que estava tentando acessar. Entre em contato com um administrador do Guardian Connector para alterar sua função para visualizar esta página.",
   "accessPermissions": "Permissões de Acesso",
-  "addBasemapOption": "Adicionar opção de mapa base",
+  "addBackgroundMapOption": "Adicionar opção de mapa de fundo",
   "addDescription": "Adicionar descrição",
   "addNewTable": "Adicionar nova visualização de conjunto de dados",
   "administration": "Administração",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -2,7 +2,7 @@
   "accessDenied": "Ufikiaji Umekataliwa",
   "accessDeniedMessage": "Huna ruhusa ya kuona ukurasa uliokuwa unajaribu kufikia. Tafadhali wasiliana na msimamizi wa Guardian Connector ili kubadilisha jukumu lako ili uweze kuona ukurasa huu.",
   "accessPermissions": "Ruhusa za Ufikiaji",
-  "addBasemapOption": "Ongeza chaguo la ramani ya msingi",
+  "addBackgroundMapOption": "Ongeza chaguo la ramani ya msingi",
   "addDescription": "Ongeza maelezo",
   "addNewTable": "Ongeza mtazamo mpya wa seti ya data",
   "administration": "Utawala",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -2,7 +2,7 @@
   "accessDenied": "ไม่ได้รับอนุญาตให้เข้าถึง",
   "accessDeniedMessage": "คุณไม่มีสิทธิเข้าถึงหน้าที่พยายามเปิด โปรดติดต่อผู้ดูแลระบบ Guardian Connector เพื่อปรับบทบาทของคุณจึงจะดูหน้านี้ได้",
   "accessPermissions": "สิทธิการเข้าถึง",
-  "addBasemapOption": "เพิ่มตัวเลือกแผนที่ฐาน",
+  "addBackgroundMapOption": "เพิ่มตัวเลือกแผนที่ฐาน",
   "addDescription": "เพิ่มคำอธิบาย",
   "addNewTable": "เพิ่มมุมมองชุดข้อมูลใหม่",
   "administration": "การบริหารจัดการ",

--- a/tests/unit/components/ConfigMap.test.ts
+++ b/tests/unit/components/ConfigMap.test.ts
@@ -89,6 +89,51 @@ describe("ConfigMap component", () => {
     expect(vm.basemaps[0].isDefault).toBe(true);
   });
 
+  it("populates Satellite Streets default when no basemap config exists", async () => {
+    const emptyConfig = {
+      MAPBOX_ACCESS_TOKEN: "",
+      MAPBOX_ZOOM: 10,
+      MAPBOX_CENTER_LATITUDE: "10",
+      MAPBOX_CENTER_LONGITUDE: "10",
+      MAPBOX_PROJECTION: "mercator",
+      MAPBOX_BEARING: 0,
+      MAPBOX_PITCH: 0,
+      MAPBOX_3D: false,
+    } as ViewConfig;
+
+    const wrapper = mount(ConfigMap, {
+      props: { ...baseProps, config: emptyConfig },
+      global: globalConfig,
+    });
+
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as {
+      basemaps: Array<{ name: string; style: string; isDefault: boolean }>;
+    };
+
+    expect(vm.basemaps).toHaveLength(1);
+    expect(vm.basemaps[0].name).toBe("Satellite Streets");
+    expect(vm.basemaps[0].style).toBe(
+      "mapbox://styles/mapbox/satellite-streets-v12",
+    );
+    expect(vm.basemaps[0].isDefault).toBe(true);
+
+    const emitted = wrapper.emitted("updateConfig");
+    expect(emitted).toBeTruthy();
+    const basemapsPayload = emitted?.find(
+      (e) => (e[0] as { MAPBOX_BASEMAPS?: string }).MAPBOX_BASEMAPS,
+    )?.[0] as { MAPBOX_BASEMAPS: string };
+    expect(basemapsPayload).toBeTruthy();
+    expect(JSON.parse(basemapsPayload.MAPBOX_BASEMAPS)).toEqual([
+      {
+        name: "Satellite Streets",
+        style: "mapbox://styles/mapbox/satellite-streets-v12",
+        isDefault: true,
+      },
+    ]);
+  });
+
   it("parses MAPBOX_BASEMAPS from config", () => {
     const configWithBasemaps = {
       ...baseProps.config,


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/488.

## Screenshots

<img width="1221" height="348" alt="image" src="https://github.com/user-attachments/assets/877137ac-736c-40c7-b176-08288902a552" />

## What I changed and why

- Populate default Mapbox basemap option when none exists
- Change language of "Add Background Map" button
- Remove hard-coded basemap options in BasemapSelector component

## How I convinced myself this is right


## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Test generated by Cursor