### PR TITLE
Compute coordinates and provide Google link for alert features

### DIFF
--- a/tests/unit/utils/dataTransformers.test.ts
+++ b/tests/unit/utils/dataTransformers.test.ts
@@ -195,6 +195,13 @@ describe("transformAlertEntry", () => {
     expect(result).not.toHaveProperty("g__coordinates");
   });
 
+  it("should compute geographicCentroid for Google Maps link", () => {
+    const result = transformAlertEntry(rawAlert, table);
+    const coordPattern = /^-?\d{1,3}\.\d+, -?\d{1,3}\.\d+$/;
+
+    expect(result.geographicCentroid).toMatch(coordPattern);
+  });
+
   it("should handle GFW records without proprietary fields", () => {
     const gfwAlert = {
       ...rawAlert,
@@ -208,5 +215,6 @@ describe("transformAlertEntry", () => {
     expect(result).not.toHaveProperty("territory");
     expect(result).not.toHaveProperty("t0_url");
     expect(result).not.toHaveProperty("alertAreaHectares");
+    expect(result.geographicCentroid).toMatch(/^-?\d{1,3}\.\d+, -?\d{1,3}\.\d+$/);
   });
 });

--- a/tests/unit/utils/dataTransformers.test.ts
+++ b/tests/unit/utils/dataTransformers.test.ts
@@ -10,6 +10,8 @@ import {
 import { alertsData } from "@/tests/unit/fixtures/alertsData";
 import { mapeoData } from "@/tests/unit/fixtures/mapeoData";
 
+const coordPattern = /^-?\d{1,3}\.\d+, -?\d{1,3}\.\d+$/;
+
 describe("transformSurveyDataKey", () => {
   it("should remove g__ prefix and replace with geo", () => {
     expect(transformSurveyDataKey("g__coordinates")).toBe("geocoordinates");
@@ -197,7 +199,6 @@ describe("transformAlertEntry", () => {
 
   it("should compute geographicCentroid for Google Maps link", () => {
     const result = transformAlertEntry(rawAlert, table);
-    const coordPattern = /^-?\d{1,3}\.\d+, -?\d{1,3}\.\d+$/;
 
     expect(result.geographicCentroid).toMatch(coordPattern);
   });
@@ -215,6 +216,6 @@ describe("transformAlertEntry", () => {
     expect(result).not.toHaveProperty("territory");
     expect(result).not.toHaveProperty("t0_url");
     expect(result).not.toHaveProperty("alertAreaHectares");
-    expect(result.geographicCentroid).toMatch(/^-?\d{1,3}\.\d+, -?\d{1,3}\.\d+$/);
+    expect(result.geographicCentroid).toMatch(coordPattern);
   });
 });

--- a/utils/dataTransformers.ts
+++ b/utils/dataTransformers.ts
@@ -1,3 +1,7 @@
+import {
+  calculateCentroidFromParsedCoords,
+  tryParseDataEntryGeoCoordinates,
+} from "@/utils/geoUtils";
 import type { DataEntry } from "@/types";
 
 const SATELLITE_LOOKUP: Record<string, string> = {
@@ -179,6 +183,12 @@ export const transformAlertEntry = (
     ? `${entry.day_detec}-${formattedMonth}-${entry.year_detec}`
     : `${formattedMonth}-${entry.year_detec}`;
   result.alertDetectionRange = `${entry.date_start_t1} to ${entry.date_end_t1}`;
+
+  const parsedCoords = tryParseDataEntryGeoCoordinates(entry);
+  if (parsedCoords) {
+    result.geographicCentroid =
+      calculateCentroidFromParsedCoords(parsedCoords);
+  }
 
   if (entry.data_source === "Global Forest Watch") {
     return result;

--- a/utils/dataTransformers.ts
+++ b/utils/dataTransformers.ts
@@ -186,8 +186,7 @@ export const transformAlertEntry = (
 
   const parsedCoords = tryParseDataEntryGeoCoordinates(entry);
   if (parsedCoords) {
-    result.geographicCentroid =
-      calculateCentroidFromParsedCoords(parsedCoords);
+    result.geographicCentroid = calculateCentroidFromParsedCoords(parsedCoords);
   }
 
   if (entry.data_source === "Global Forest Watch") {


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/487

## Screenshots

<img width="359" height="573" alt="image" src="https://github.com/user-attachments/assets/8b70f406-757a-4f26-90cc-acf52e9d96e7" />

## What I changed and why

Utilize `calculateCentroidFromParsedCoords` and `tryParseDataEntryGeoCoordinates` to calculate `geographicCentroid` for alert features.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None