### PR TITLE
use views dataset fields for map primary data

### DIFF
--- a/pages/map/[tablename].vue
+++ b/pages/map/[tablename].vue
@@ -39,6 +39,7 @@ const mediaBasePath = ref();
 const mediaBasePathIcons = ref();
 const mediaColumn = ref();
 const planetApiKey = ref();
+const primaryDataset = ref(table);
 const timestampColumn = ref<string | undefined>();
 
 const { data, error, refresh } = await useFetch(`/api/${table}/map`, {
@@ -71,6 +72,7 @@ if (data.value && !error.value) {
   mediaBasePathIcons.value = data.value.mediaBasePathIcons;
   mediaColumn.value = data.value.mediaColumn;
   planetApiKey.value = data.value.planetApiKey;
+  primaryDataset.value = data.value.primary_dataset;
   timestampColumn.value = data.value.timestampColumn;
 } else {
   console.error("Error fetching data:", error.value);
@@ -126,7 +128,7 @@ useHead({
         :media-base-path-icons="mediaBasePathIcons"
         :media-column="mediaColumn"
         :planet-api-key="planetApiKey"
-        :table="table"
+        :table="primaryDataset"
         :timestamp-column="timestampColumn"
       />
     </ClientOnly>

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -2,6 +2,7 @@ import {
   fetchData,
   fetchTableConfig,
   fetchTableSqlColumns,
+  fetchViewDatasets,
 } from "@/server/database/dbOperations";
 import {
   filterOutUnwantedValues,
@@ -28,6 +29,7 @@ export default defineEventHandler(async (event: H3Event) => {
 
   try {
     const tableConfig = await fetchTableConfig(table, "map");
+    const { primaryDataset } = await fetchViewDatasets(table, "map");
 
     // Check visibility permissions
     const permission = tableConfig.ROUTE_LEVEL_PERMISSION ?? "member";
@@ -41,7 +43,7 @@ export default defineEventHandler(async (event: H3Event) => {
     const timestampColumn = tableConfig.TIMESTAMP_COLUMN;
     const filterByColumn = tableConfig.FILTER_BY_COLUMN;
 
-    const tableSqlColumns = await fetchTableSqlColumns(table);
+    const tableSqlColumns = await fetchTableSqlColumns(primaryDataset);
     const dateLikeColumns = tableSqlColumns.filter((column) =>
       /(date|time|created|modified|updated)/i.test(column),
     );
@@ -60,7 +62,7 @@ export default defineEventHandler(async (event: H3Event) => {
         ].filter((column): column is string => Boolean(column)),
       ),
     );
-    const { mainData } = await fetchData(table, {
+    const { mainData } = await fetchData(primaryDataset, {
       limit,
       mainColumns,
     });
@@ -116,7 +118,8 @@ export default defineEventHandler(async (event: H3Event) => {
       mediaBasePathIcons: tableConfig.MEDIA_BASE_PATH_ICONS,
       mediaColumn: tableConfig.MEDIA_COLUMN,
       planetApiKey: tableConfig.PLANET_API_KEY,
-      table,
+      primary_dataset: primaryDataset,
+      table: primaryDataset,
       rowLimitReached: mainData.length >= limit,
       routeLevelPermission: tableConfig.ROUTE_LEVEL_PERMISSION,
     };

--- a/tests/unit/server/mapEndpointDatasets.test.ts
+++ b/tests/unit/server/mapEndpointDatasets.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import mapHandler from "@/server/api/[table]/map";
+
+type MapRouteEvent = {
+  context: { params: { table: string } };
+};
+
+type MapRouteResponse = Record<string, unknown>;
+
+type MapRouteHandler = (event: MapRouteEvent) => Promise<MapRouteResponse>;
+
+const handleMapRequest = mapHandler as unknown as MapRouteHandler;
+
+const hoisted = vi.hoisted(() => {
+  Object.assign(globalThis, {
+    defineEventHandler: (handler: unknown) => handler,
+    useRuntimeConfig: () => ({
+      public: {
+        allowedFileExtensions: {
+          audio: [],
+          image: ["jpg"],
+          video: [],
+        },
+      },
+    }),
+  });
+
+  return {
+    buildMinimalFeatureCollection: vi.fn(),
+    fetchData: vi.fn(),
+    fetchTableConfig: vi.fn(),
+    fetchTableSqlColumns: vi.fn(),
+    fetchViewDatasets: vi.fn(),
+    filterGeoData: vi.fn(),
+    filterOutUnwantedValues: vi.fn(),
+    parseAndValidateLimit: vi.fn(),
+    parseBasemaps: vi.fn(),
+    prepareMapStatistics: vi.fn(),
+    validatePermissions: vi.fn(),
+  };
+});
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchData: hoisted.fetchData,
+  fetchTableConfig: hoisted.fetchTableConfig,
+  fetchTableSqlColumns: hoisted.fetchTableSqlColumns,
+  fetchViewDatasets: hoisted.fetchViewDatasets,
+}));
+
+vi.mock("@/server/dataProcessing/dataFilters", () => ({
+  filterGeoData: hoisted.filterGeoData,
+  filterOutUnwantedValues: hoisted.filterOutUnwantedValues,
+}));
+
+vi.mock("@/server/dataProcessing/dataTransformers", () => ({
+  prepareMapStatistics: hoisted.prepareMapStatistics,
+}));
+
+vi.mock("@/utils/geoUtils", () => ({
+  buildMinimalFeatureCollection: hoisted.buildMinimalFeatureCollection,
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: hoisted.validatePermissions,
+}));
+
+vi.mock("@/server/utils", () => ({
+  parseBasemaps: hoisted.parseBasemaps,
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  parseAndValidateLimit: hoisted.parseAndValidateLimit,
+}));
+
+describe("map endpoint datasets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    hoisted.parseAndValidateLimit.mockReturnValue(25);
+    hoisted.fetchTableConfig.mockResolvedValue({
+      COLOR_COLUMN: "status",
+      FRONT_END_FILTER_COLUMN: "category",
+      ROUTE_LEVEL_PERMISSION: "anyone",
+    });
+    hoisted.fetchViewDatasets.mockResolvedValue({
+      primaryDataset: "map_dataset",
+      secondaryDataset: null,
+    });
+    hoisted.fetchTableSqlColumns.mockResolvedValue([
+      "_id",
+      "g__type",
+      "g__coordinates",
+      "status",
+      "category",
+      "created_at",
+    ]);
+    hoisted.fetchData.mockResolvedValue({
+      mainData: [
+        {
+          _id: "record-1",
+          g__type: "Point",
+          g__coordinates: "[0,0]",
+          status: "open",
+          category: "test",
+          created_at: "2026-01-01",
+        },
+      ],
+      columnsData: null,
+      metadata: null,
+    });
+    hoisted.filterOutUnwantedValues.mockImplementation((data) => data);
+    hoisted.filterGeoData.mockImplementation((data) => data);
+    hoisted.buildMinimalFeatureCollection.mockReturnValue({
+      type: "FeatureCollection",
+      features: [],
+    });
+    hoisted.prepareMapStatistics.mockReturnValue({ totalFeatures: 1 });
+    hoisted.parseBasemaps.mockReturnValue({
+      basemaps: [],
+      defaultMapboxStyle: "mapbox://styles/mapbox/streets-v12",
+    });
+  });
+
+  it("fetches map data from the typed primary dataset and returns it", async () => {
+    const response = await handleMapRequest({
+      context: { params: { table: "route_map" } },
+    });
+
+    expect(hoisted.fetchTableConfig).toHaveBeenCalledWith("route_map", "map");
+    expect(hoisted.fetchViewDatasets).toHaveBeenCalledWith("route_map", "map");
+    expect(hoisted.fetchTableSqlColumns).toHaveBeenCalledWith("map_dataset");
+    expect(hoisted.fetchData).toHaveBeenCalledWith("map_dataset", {
+      limit: 25,
+      mainColumns: [
+        "_id",
+        "g__type",
+        "g__coordinates",
+        "status",
+        "category",
+        "created_at",
+      ],
+    });
+    expect(response.primary_dataset).toBe("map_dataset");
+    expect(response.table).toBe("map_dataset");
+    expect(response.data).toEqual({ type: "FeatureCollection", features: [] });
+  });
+});


### PR DESCRIPTION
## Goal

Route the map view through the typed `views.primary_dataset` column and expose that dataset in the map API response as the next stacked step after the alerts and gallery dataset API work.


## Screenshots
<img width="1446" height="753" alt="Screenshot 2026-07-07 at 11 23 41" src="https://github.com/user-attachments/assets/e833745a-0035-4c72-b59d-45db82e2ae55" />
<img width="1446" height="753" alt="Screenshot 2026-07-07 at 11 23 35" src="https://github.com/user-attachments/assets/b6b7ec29-8483-4949-acd2-86fc76b0bd44" />


## What I changed and why

- Map endpoint now resolves its configured dataset via `fetchViewDatasets(table, "map")`, reads records from the returned primary dataset, and includes `primary_dataset` in the API response
- No secondary dataset logic added, keeping the change focused on primary dataset plumbing
- Map page now passes the API-returned primary dataset into `MapView` so full-record fetches from selected map features use the typed dataset column rather than assuming the route param is the fetch target
- Added server-side test coverage for the map endpoint dataset behavior

## How I convinced myself this is right

The change follows the same invariant as the [alerts](https://github.com/ConservationMetrics/gc-explorer/pull/495) and [gallery](https://github.com/ConservationMetrics/gc-explorer/pull/496) PRs: `[table]` identifies the configured view row, and the actual warehouse table used for reads comes from `views.primary_dataset`. The endpoint still uses the existing map config for permissions, display settings, basemaps, filters, and projections, but the data source now comes from the typed column that the view model owns.



## What I'm not doing here

This PR does not touch alerts, gallery. 


## LLM use disclosure

GPT 5.5 and Osa