### PR TITLE
Single source of truth: MAPEO_TABLE → secondary_dataset column  

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+server/database/migrations/meta/*_snapshot.json linguist-generated

--- a/components/config/ConfigAlerts.vue
+++ b/components/config/ConfigAlerts.vue
@@ -10,12 +10,14 @@ import type { ViewConfig } from "@/types";
 const props = defineProps<{
   tableName: string;
   config: ViewConfig;
+  secondaryDataset?: string | null;
   views: Array<string>;
   keys: Array<string>;
 }>();
 
 const emit = defineEmits<{
   (e: "updateConfig", payload: Partial<ViewConfig>): void;
+  (e: "updateSecondaryDataset", value: string): void;
 }>();
 
 type Tag = { text: string };
@@ -41,6 +43,25 @@ const handleTagsChanged = (key: string, newTags: Tag[]): void => {
 
 <template>
   <div class="space-y-6">
+    <div class="space-y-2">
+      <label
+        :for="`${tableName}-secondaryDataset`"
+        class="block text-sm font-medium text-gray-700"
+      >
+        {{ $t("mapeoTable") }}
+      </label>
+      <input
+        :id="`${tableName}-secondaryDataset`"
+        class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+        type="text"
+        :value="secondaryDataset ?? ''"
+        @input="
+          (e) =>
+            emit('updateSecondaryDataset', (e.target as HTMLInputElement).value)
+        "
+      />
+    </div>
+
     <div v-for="key in keys" :key="key" class="space-y-2">
       <label
         :for="`${tableName}-${key}`"
@@ -48,21 +69,7 @@ const handleTagsChanged = (key: string, newTags: Tag[]): void => {
       >
         {{ $t(toCamelCase(key)) }}
       </label>
-      <template v-if="key === 'MAPEO_TABLE'">
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="text"
-          :value="config[key]"
-          @input="
-            (e) =>
-              emit('updateConfig', {
-                [key]: (e.target as HTMLInputElement).value,
-              })
-          "
-        />
-      </template>
-      <template v-else-if="key === 'MAPEO_CATEGORY_IDS'">
+      <template v-if="key === 'MAPEO_CATEGORY_IDS'">
         <VueTagsInput
           class="tag-field"
           :tags="tags[key]"

--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
   tableName: string;
   viewType: ViewType;
   viewConfig: ViewConfig;
+  secondaryDataset?: string | null;
   configToCopy: ViewConfig | null;
 }>();
 
@@ -37,7 +38,7 @@ const mediaKeys = computed(() => [
   "MEDIA_BASE_PATH_ICONS",
   "MEDIA_COLUMN",
 ]);
-const alertKeys = computed(() => ["MAPEO_CATEGORY_IDS", "MAPEO_TABLE"]);
+const alertKeys = computed(() => ["MAPEO_CATEGORY_IDS"]);
 const filterKeys = computed(() => [
   "FILTER_OUT_VALUES_FROM_COLUMN",
   "FRONT_END_FILTER_COLUMN",
@@ -58,21 +59,27 @@ const viewTypeList = computed(() => [props.viewType]);
 // On mounted, set localConfig to props.config
 const originalConfig = ref<ViewConfig>({});
 const localConfig = ref<ViewConfig>({});
+const originalSecondaryDataset = ref("");
+const localSecondaryDataset = ref("");
 onMounted(() => {
   if (props.viewConfig) {
     localConfig.value = JSON.parse(JSON.stringify(props.viewConfig));
   }
+  localSecondaryDataset.value = props.secondaryDataset ?? "";
   originalConfig.value = JSON.parse(JSON.stringify(localConfig.value));
+  originalSecondaryDataset.value = localSecondaryDataset.value;
 });
 
 // Watch for changes to viewConfig prop and update baseline after save
 watch(
-  () => props.viewConfig,
-  (newConfig) => {
+  () => [props.viewConfig, props.secondaryDataset] as const,
+  ([newConfig, newSecondaryDataset]) => {
     if (newConfig) {
       localConfig.value = JSON.parse(JSON.stringify(newConfig));
       originalConfig.value = JSON.parse(JSON.stringify(localConfig.value));
     }
+    localSecondaryDataset.value = newSecondaryDataset ?? "";
+    originalSecondaryDataset.value = localSecondaryDataset.value;
   },
   { deep: true },
 );
@@ -87,6 +94,17 @@ watch(
   },
 );
 
+const shouldShowConfigMap = computed(
+  () => props.viewType === "alerts" || props.viewType === "map",
+);
+const shouldShowConfigMedia = computed(() =>
+  ["map", "gallery", "alerts"].includes(props.viewType),
+);
+const shouldShowConfigAlerts = computed(() => props.viewType === "alerts");
+const shouldShowConfigFilters = computed(
+  () => props.viewType === "map" || props.viewType === "gallery",
+);
+
 // Form validations and helpers
 const isChanged = computed(() => {
   const localConfigFiltered = Object.fromEntries(
@@ -95,10 +113,15 @@ const isChanged = computed(() => {
   const originalConfigFiltered = Object.fromEntries(
     Object.entries(originalConfig.value).filter(([value]) => value !== ""),
   );
-  return (
+  const configChanged =
     JSON.stringify(localConfigFiltered) !==
-    JSON.stringify(originalConfigFiltered)
-  );
+    JSON.stringify(originalConfigFiltered);
+  const secondaryDatasetChanged =
+    shouldShowConfigAlerts.value &&
+    localSecondaryDataset.value.trim() !==
+      originalSecondaryDataset.value.trim();
+
+  return configChanged || secondaryDatasetChanged;
 });
 
 // Track permission validation state
@@ -113,20 +136,13 @@ const isFormValid = computed(() => {
   return isMapConfigValid && isPermissionValid.value;
 });
 
-const shouldShowConfigMap = computed(
-  () => props.viewType === "alerts" || props.viewType === "map",
-);
-const shouldShowConfigMedia = computed(() =>
-  ["map", "gallery", "alerts"].includes(props.viewType),
-);
-const shouldShowConfigAlerts = computed(() => props.viewType === "alerts");
-const shouldShowConfigFilters = computed(
-  () => props.viewType === "map" || props.viewType === "gallery",
-);
-
 // Handlers for updating config and form submission
 const handleConfigUpdate = (partialUpdate: Partial<ViewConfig>) => {
   Object.assign(localConfig.value, partialUpdate);
+};
+
+const handleSecondaryDatasetUpdate = (value: string) => {
+  localSecondaryDataset.value = value;
 };
 
 const handlePermissionValidation = (isValid: boolean) => {
@@ -158,6 +174,9 @@ const handleSubmit = () => {
   emit("submitConfig", {
     tableName: props.tableName,
     config: localConfig.value,
+    secondaryDataset: shouldShowConfigAlerts.value
+      ? localSecondaryDataset.value
+      : null,
   });
 };
 </script>
@@ -214,8 +233,10 @@ const handleSubmit = () => {
             :table-name="tableName"
             :views="viewTypeList"
             :config="localConfig"
+            :secondary-dataset="localSecondaryDataset"
             :keys="alertKeys"
             @update-config="handleConfigUpdate"
+            @update-secondary-dataset="handleSecondaryDatasetUpdate"
           />
         </ConfigCollapsibleSection>
 

--- a/composables/useIncidents.ts
+++ b/composables/useIncidents.ts
@@ -122,7 +122,7 @@ export const useIncidents = (
 
   /**
    * True when a persisted incident entry refers to mapeo rows. {@link CollectionEntry.source_table}
-   * is the warehouse table name (often the view’s MAPEO_TABLE, or `mapeo_data`)
+   * is the warehouse table name (often the view's secondary dataset, or `mapeo_data`)
    */
   const savedEntryIsMapeo = (entry: CollectionEntry): boolean => {
     const configuredMapeoTable = secondaryDatasetRef?.value;
@@ -1014,7 +1014,7 @@ const SOURCE_ID_KEYS = ['alertID', '_id', 'source_id', 'sourceId'] as const;
 
   /**
    * Adds a source to the selected sources list for incident creation
-   * @param sourceTable - Warehouse table (alerts route table or view MAPEO_TABLE)
+   * @param sourceTable - Warehouse table (alerts route table or secondary dataset)
    * @param sourceId - The unique identifier from the source table
    * @param featureType - "alert" or "mapeo" so the server uses alert_id or _id when fetching the row
    * @param notes - Optional notes about the source

--- a/pages/config/[dataset].vue
+++ b/pages/config/[dataset].vue
@@ -17,6 +17,7 @@ const viewRows = ref<ViewConfigRow[]>([]);
 const tableNames = ref();
 const dataFetched = ref(false);
 const datasetConfig = ref<ViewConfig | null>(null);
+const secondaryDataset = ref<string | null>(null);
 const errorMessage = ref<string | null>(null);
 
 const editedViewType = ref<ViewType | undefined>(undefined);
@@ -44,6 +45,7 @@ if (data.value && !error.value) {
 
   if (editedViewRow) {
     datasetConfig.value = editedViewRow.viewConfig;
+    secondaryDataset.value = editedViewRow.secondaryDataset ?? null;
     editedViewType.value = editedViewRow.viewType;
     dataFetched.value = true;
   } else {
@@ -60,9 +62,11 @@ const showSavedModal = ref(false);
 
 const submitConfig = async ({
   config,
+  secondaryDataset: submittedSecondaryDataset,
   tableName,
 }: {
   config: ViewConfig;
+  secondaryDataset?: string | null;
   tableName: string;
 }) => {
   errorMessage.value = null;
@@ -73,11 +77,15 @@ const submitConfig = async ({
       query: resolvedViewType.value
         ? { view_type: resolvedViewType.value }
         : undefined,
-      body: JSON.stringify(config),
+      body: JSON.stringify({
+        config,
+        secondaryDataset: submittedSecondaryDataset,
+      }),
     });
     // Update the local datasetConfig to reflect the saved state
     // This will trigger the watch in ConfigCard to update originalConfig baseline thus clearing the button and applying edit
     datasetConfig.value = JSON.parse(JSON.stringify(config));
+    secondaryDataset.value = submittedSecondaryDataset ?? null;
     showSavedModal.value = true;
     setTimeout(() => {
       showSavedModal.value = false;
@@ -225,6 +233,7 @@ definePageMeta({ layout: "explorer" });
           :table-name="dataset"
           :view-type="resolvedViewType"
           :view-config="datasetConfig"
+          :secondary-dataset="secondaryDataset"
           :config-to-copy="configToCopy"
           @submit-config="submitConfig"
           @remove-table-from-config="handleRemoveTableFromConfig"

--- a/pages/config/index.vue
+++ b/pages/config/index.vue
@@ -29,7 +29,7 @@ const submitConfig = async ({
   try {
     await $fetch(`/api/config/update_config/${tableName}`, {
       method: "POST",
-      body: JSON.stringify(config),
+      body: JSON.stringify({ config }),
     });
   } catch (error) {
     console.error("Error submitting request data:", error);

--- a/server/api/config/update_config/[table].post.ts
+++ b/server/api/config/update_config/[table].post.ts
@@ -2,17 +2,22 @@ import { updateConfig } from "@/server/database/dbOperations";
 import { validatePermissions } from "@/utils/accessControls";
 
 import type { H3Event } from "h3";
-import type { ViewType } from "@/types";
+import type { ViewConfig, ViewType } from "@/types";
+
+type UpdateConfigBody = {
+  config: ViewConfig;
+  secondaryDataset?: string | null;
+};
 
 export default defineEventHandler(async (event: H3Event) => {
   const table = event.context?.params?.table as string;
-  const config = await readBody(event);
+  const body = (await readBody(event)) as UpdateConfigBody;
   const viewType = getQuery(event).view_type as ViewType | undefined;
 
   try {
     await validatePermissions(event, "admin");
 
-    await updateConfig(table, config, viewType);
+    await updateConfig(table, body.config, viewType, body.secondaryDataset);
     return { message: "Configuration updated successfully" };
   } catch (error) {
     if (error instanceof Error) {

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -71,31 +71,49 @@ const createDuplicateViewError = (table: string, viewType: ViewType) => {
 };
 
 /**
- * Derives a view's secondary dataset (its Mapeo table) from its config. This is
- * the single source for the `MAPEO_TABLE` → `secondary_dataset` mapping, shared by
- * every place that builds a view row (live writes and the test fixture seed) so the column
- * can never drift from the config field it mirrors: only alerts views have a
- * secondary dataset, and a blank value normalizes to null.
- *
- * TODO(single-source-of-truth): `MAPEO_TABLE` and `secondary_dataset` currently hold
- * the SAME fact in two places — the value stays in the view_config JSON AND is copied
- * into the secondary_dataset column here. They cannot drift (the column is always
- * derived from `MAPEO_TABLE` via this one helper, and nothing writes the column
- * independently), but today the column is effectively a write-only mirror: every
- * reader (alerts.ts, the config edit UI) still reads `MAPEO_TABLE` from the JSON.
- * The follow-up that returns primary/secondary_dataset from the API should make the
- * column the only source: stop persisting `MAPEO_TABLE` in the JSON (strip it like
- * `VIEWS`) and reconstruct it from the column on read for backward compatibility.
+ * Derives the secondary_dataset column from an incoming alerts config payload.
  *
  * @param {ViewType} viewType - The view's type.
- * @param {ViewConfig} config - The view's settings JSON.
+ * @param {ViewConfig} config - The submitted view settings.
  * @returns {string | null} The secondary dataset, or null when not applicable.
  */
-const deriveSecondaryDataset = (
+const deriveSecondaryDatasetFromConfig = (
   viewType: ViewType,
   config: ViewConfig,
 ): string | null =>
   viewType === "alerts" ? config.MAPEO_TABLE?.trim() || null : null;
+
+/**
+ * Removes fields that are stored in typed view columns rather than view_config.
+ *
+ * @param {ViewConfig} config - Submitted view settings.
+ * @returns {ViewConfig} Settings safe to serialize into views.view_config.
+ */
+const toStoredViewConfig = (config: ViewConfig): ViewConfig => {
+  const storedConfig = { ...config } as ViewConfig & { VIEWS?: unknown };
+  delete storedConfig.MAPEO_TABLE;
+  delete storedConfig.VIEWS;
+  return storedConfig;
+};
+
+type ViewConfigSourceRow = Pick<
+  typeof viewConfig.$inferSelect,
+  "secondaryDataset" | "viewConfig" | "viewType"
+>;
+
+/**
+ * Parses stored config and reconstructs transient client fields from view columns.
+ *
+ * @param {ViewConfigSourceRow} row - View row from the config database.
+ * @returns {ViewConfig} Config object used by existing clients.
+ */
+const parseViewConfigRowConfig = (row: ViewConfigSourceRow): ViewConfig => {
+  const parsedConfig = JSON.parse(row.viewConfig) as ViewConfig;
+  if (row.viewType === "alerts" && row.secondaryDataset) {
+    return { ...parsedConfig, MAPEO_TABLE: row.secondaryDataset };
+  }
+  return parsedConfig;
+};
 
 /**
  * Checks whether a given table exists in the warehouse schema.
@@ -132,12 +150,10 @@ const checkTableExists = async (
 export const buildViewConfigColumns = (
   primaryDataset: string,
   config: ViewConfig,
-  configString: string,
   viewType: ViewType,
 ) => {
-  // secondaryDataset mirrors config.MAPEO_TABLE; configString still contains
-  // MAPEO_TABLE too. See deriveSecondaryDataset's TODO on collapsing to one source.
-  const secondaryDataset = deriveSecondaryDataset(viewType, config);
+  const secondaryDataset = deriveSecondaryDatasetFromConfig(viewType, config);
+  const configString = JSON.stringify(toStoredViewConfig(config));
 
   return {
     // viewName falls back to primaryDataset, but NOTE they are not the same kind of
@@ -527,7 +543,7 @@ export const fetchViewConfigRows = async (): Promise<ViewConfigRow[]> => {
     return result.map((row) => ({
       primaryDataset: row.primaryDataset,
       secondaryDataset: row.secondaryDataset,
-      viewConfig: JSON.parse(row.viewConfig) as ViewConfig,
+      viewConfig: parseViewConfigRowConfig(row),
       viewId: row.viewId,
       viewName: row.viewName,
       viewType: row.viewType as ViewType,
@@ -556,7 +572,7 @@ export const fetchViewConfigRowsForTable = async (
     return result.map((row) => ({
       primaryDataset: row.primaryDataset,
       secondaryDataset: row.secondaryDataset,
-      viewConfig: JSON.parse(row.viewConfig) as ViewConfig,
+      viewConfig: parseViewConfigRowConfig(row),
       viewId: row.viewId,
       viewName: row.viewName,
       viewType: row.viewType as ViewType,
@@ -585,7 +601,9 @@ export const fetchTableConfig = async (
   try {
     const result = await configDb
       .select({
+        secondaryDataset: viewConfig.secondaryDataset,
         viewConfig: viewConfig.viewConfig,
+        viewType: viewConfig.viewType,
       })
       .from(viewConfig)
       .where(
@@ -605,7 +623,7 @@ export const fetchTableConfig = async (
       throw createMissingViewConfigError(table);
     }
 
-    const parsedConfig = JSON.parse(result[0].viewConfig) as ViewConfig;
+    const parsedConfig = parseViewConfigRowConfig(result[0]);
     if (!parsedConfig || Object.keys(parsedConfig).length === 0) {
       throw createMissingViewConfigError(table);
     }
@@ -689,11 +707,9 @@ export const updateConfig = async (
         `updateConfig requires a view type for "${tableName}"; refusing to update without identifying a single view.`,
       );
     }
-    const configString = JSON.stringify(typedConfig);
     const viewColumns = buildViewConfigColumns(
       tableName,
       typedConfig,
-      configString,
       viewType,
     );
 
@@ -720,9 +736,8 @@ export const addNewTableToConfig = async (
 ): Promise<void> => {
   try {
     const newConfig: ViewConfig = {};
-    const configString = JSON.stringify(newConfig);
     await configDb.insert(viewConfig).values({
-      ...buildViewConfigColumns(tableName, newConfig, configString, viewType),
+      ...buildViewConfigColumns(tableName, newConfig, viewType),
     });
   } catch (error) {
     // (view_type, primary_dataset) is unique, so re-adding a view type the dataset

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -90,9 +90,8 @@ const deriveSecondaryDatasetFromConfig = (
  * @returns {ViewConfig} Settings safe to serialize into views.view_config.
  */
 const toStoredViewConfig = (config: ViewConfig): ViewConfig => {
-  const storedConfig = { ...config } as ViewConfig & { VIEWS?: unknown };
+  const storedConfig = { ...config };
   delete storedConfig.MAPEO_TABLE;
-  delete storedConfig.VIEWS;
   return storedConfig;
 };
 

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -71,50 +71,6 @@ const createDuplicateViewError = (table: string, viewType: ViewType) => {
 };
 
 /**
- * Derives the secondary_dataset column from an incoming alerts config payload.
- *
- * @param {ViewType} viewType - The view's type.
- * @param {ViewConfig} config - The submitted view settings.
- * @returns {string | null} The secondary dataset, or null when not applicable.
- */
-const deriveSecondaryDatasetFromConfig = (
-  viewType: ViewType,
-  config: ViewConfig,
-): string | null =>
-  viewType === "alerts" ? config.MAPEO_TABLE?.trim() || null : null;
-
-/**
- * Removes fields that are stored in typed view columns rather than view_config.
- *
- * @param {ViewConfig} config - Submitted view settings.
- * @returns {ViewConfig} Settings safe to serialize into views.view_config.
- */
-const toStoredViewConfig = (config: ViewConfig): ViewConfig => {
-  const storedConfig = { ...config };
-  delete storedConfig.MAPEO_TABLE;
-  return storedConfig;
-};
-
-type ViewConfigSourceRow = Pick<
-  typeof viewConfig.$inferSelect,
-  "secondaryDataset" | "viewConfig" | "viewType"
->;
-
-/**
- * Parses stored config and reconstructs transient client fields from view columns.
- *
- * @param {ViewConfigSourceRow} row - View row from the config database.
- * @returns {ViewConfig} Config object used by existing clients.
- */
-const parseViewConfigRowConfig = (row: ViewConfigSourceRow): ViewConfig => {
-  const parsedConfig = JSON.parse(row.viewConfig) as ViewConfig;
-  if (row.viewType === "alerts" && row.secondaryDataset) {
-    return { ...parsedConfig, MAPEO_TABLE: row.secondaryDataset };
-  }
-  return parsedConfig;
-};
-
-/**
  * Checks whether a given table exists in the warehouse schema.
  *
  * @param {string | undefined} table - Table name to verify.
@@ -138,22 +94,20 @@ const checkTableExists = async (
 };
 
 /**
- * Builds the new single-table view metadata columns from existing config shape.
+ * Builds the view metadata columns from the submitted config.
  *
  * @param {string} primaryDataset - Primary warehouse table for the view.
  * @param {ViewConfig} config - Parsed view config.
- * @param {string} configString - Serialized config JSON.
  * @param {ViewType} viewType - View type for the row.
+ * @param {string | null} [secondaryDataset] - Optional alerts companion table.
  * @returns New view metadata column values for views.
  */
 export const buildViewConfigColumns = (
   primaryDataset: string,
   config: ViewConfig,
   viewType: ViewType,
+  secondaryDataset?: string | null,
 ) => {
-  const secondaryDataset = deriveSecondaryDatasetFromConfig(viewType, config);
-  const configString = JSON.stringify(toStoredViewConfig(config));
-
   return {
     // viewName falls back to primaryDataset, but NOTE they are not the same kind of
     // value: DATASET_TABLE is the human display name and primaryDataset is the table
@@ -163,8 +117,9 @@ export const buildViewConfigColumns = (
     viewName: config.DATASET_TABLE?.trim() || primaryDataset,
     viewType,
     primaryDataset,
-    secondaryDataset,
-    viewConfig: configString,
+    secondaryDataset:
+      viewType === "alerts" ? secondaryDataset?.trim() || null : null,
+    viewConfig: JSON.stringify(config),
   };
 };
 
@@ -542,7 +497,7 @@ export const fetchViewConfigRows = async (): Promise<ViewConfigRow[]> => {
     return result.map((row) => ({
       primaryDataset: row.primaryDataset,
       secondaryDataset: row.secondaryDataset,
-      viewConfig: parseViewConfigRowConfig(row),
+      viewConfig: JSON.parse(row.viewConfig) as ViewConfig,
       viewId: row.viewId,
       viewName: row.viewName,
       viewType: row.viewType as ViewType,
@@ -571,7 +526,7 @@ export const fetchViewConfigRowsForTable = async (
     return result.map((row) => ({
       primaryDataset: row.primaryDataset,
       secondaryDataset: row.secondaryDataset,
-      viewConfig: parseViewConfigRowConfig(row),
+      viewConfig: JSON.parse(row.viewConfig) as ViewConfig,
       viewId: row.viewId,
       viewName: row.viewName,
       viewType: row.viewType as ViewType,
@@ -600,9 +555,7 @@ export const fetchTableConfig = async (
   try {
     const result = await configDb
       .select({
-        secondaryDataset: viewConfig.secondaryDataset,
         viewConfig: viewConfig.viewConfig,
-        viewType: viewConfig.viewType,
       })
       .from(viewConfig)
       .where(
@@ -622,7 +575,7 @@ export const fetchTableConfig = async (
       throw createMissingViewConfigError(table);
     }
 
-    const parsedConfig = parseViewConfigRowConfig(result[0]);
+    const parsedConfig = JSON.parse(result[0].viewConfig) as ViewConfig;
     if (!parsedConfig || Object.keys(parsedConfig).length === 0) {
       throw createMissingViewConfigError(table);
     }
@@ -675,6 +628,7 @@ export const updateConfig = async (
   tableName: string,
   config: unknown,
   viewType?: ViewType,
+  secondaryDataset?: string | null,
 ): Promise<void> => {
   try {
     const typedConfig = config as ViewConfig;
@@ -710,6 +664,7 @@ export const updateConfig = async (
       tableName,
       typedConfig,
       viewType,
+      secondaryDataset,
     );
 
     await configDb

--- a/server/database/migrations/0007_add_view_config_view_columns.sql
+++ b/server/database/migrations/0007_add_view_config_view_columns.sql
@@ -46,11 +46,7 @@ BEGIN
            THEN NULLIF(btrim(legacy.views_config::jsonb ->> 'MAPEO_TABLE'), '')
            ELSE NULL END,
       -- view_config: strip VIEWS (now superseded by the view_type column).
-      -- TODO(single-source-of-truth): MAPEO_TABLE is deliberately KEPT in this JSON for
-      -- now even though it is also copied into secondary_dataset above, because all
-      -- readers (alerts.ts, config edit UI) still read MAPEO_TABLE from the JSON. The
-      -- follow-up that returns primary/secondary_dataset from the API should also strip
-      -- MAPEO_TABLE here (as we do VIEWS) so secondary_dataset becomes the only source.
+      -- MAPEO_TABLE is removed from view_config by migration 0009.
       (legacy.views_config::jsonb - 'VIEWS')::text
     FROM view_config legacy
     CROSS JOIN LATERAL unnest(string_to_array(legacy.views_config::jsonb ->> 'VIEWS', ',')) AS view_token

--- a/server/database/migrations/0009_strip_mapeo_table_from_view_config.sql
+++ b/server/database/migrations/0009_strip_mapeo_table_from_view_config.sql
@@ -1,0 +1,4 @@
+UPDATE views
+SET view_config = (view_config::jsonb - 'MAPEO_TABLE')::text
+WHERE view_type = 'alerts'
+  AND secondary_dataset IS NOT NULL;

--- a/server/database/migrations/meta/0009_snapshot.json
+++ b/server/database/migrations/meta/0009_snapshot.json
@@ -1,0 +1,368 @@
+{
+  "id": "801cd1f3-de85-425e-8fe1-57f5ab8a842c",
+  "prevId": "5249b045-b369-4321-8be3-8fbe6044c60c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.views": {
+      "name": "views",
+      "schema": "",
+      "columns": {
+        "view_id": {
+          "name": "view_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "views_view_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "view_name": {
+          "name": "view_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "view_type": {
+          "name": "view_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_dataset": {
+          "name": "primary_dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_dataset": {
+          "name": "secondary_dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_config": {
+          "name": "view_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "views_view_id_idx": {
+          "name": "views_view_id_idx",
+          "columns": [
+            {
+              "expression": "view_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "views_view_type_primary_dataset_unique": {
+          "name": "views_view_type_primary_dataset_unique",
+          "columns": [
+            "view_type",
+            "primary_dataset"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_views": {
+      "name": "public_views",
+      "schema": "",
+      "columns": {
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.annotated_collections": {
+      "name": "annotated_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_type": {
+          "name": "collection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_entries": {
+      "name": "collection_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_table": {
+          "name": "source_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_data": {
+          "name": "source_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collection_entries_collection_id_annotated_collections_id_fk": {
+          "name": "collection_entries_collection_id_annotated_collections_id_fk",
+          "tableFrom": "collection_entries",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "tableTo": "annotated_collections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collection_entries_collection_id_source_table_source_id_unique": {
+          "name": "collection_entries_collection_id_source_table_source_id_unique",
+          "columns": [
+            "collection_id",
+            "source_table",
+            "source_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_alerts_table": {
+          "name": "parent_alerts_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_type": {
+          "name": "incident_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_party": {
+          "name": "responsible_party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'suspected'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "impact_description": {
+          "name": "impact_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_evidence": {
+          "name": "supporting_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "incidents_parent_alerts_table_idx": {
+          "name": "incidents_parent_alerts_table_idx",
+          "columns": [
+            {
+              "expression": "parent_alerts_table",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "incidents_collection_id_annotated_collections_id_fk": {
+          "name": "incidents_collection_id_annotated_collections_id_fk",
+          "tableFrom": "incidents",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "tableTo": "annotated_collections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1782822317981,
       "tag": "0008_blue_vanisher",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1783506319409,
+      "tag": "0009_strip_mapeo_table_from_view_config",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/db-seed/guardianconnector.sql
+++ b/tests/db-seed/guardianconnector.sql
@@ -31,13 +31,13 @@ INSERT INTO views (view_name, view_type, primary_dataset, secondary_dataset, vie
     'alerts',
     'fake_alerts',
     'mapeo_data',
-    '{"EMBED_MEDIA":"YES","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","LOGO_URL":"https://conservationmetrics.com/wp-content/themes/conservation-metrics/images/logo-conservation-metrics.png","MAPBOX_STYLE":"mapbox://styles/mapbox/satellite-streets-v12","MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"38","MAPBOX_CENTER_LONGITUDE":"-79","MAPBOX_ZOOM":7,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"MAPEO_TABLE":"mapeo_data","MAPEO_CATEGORY_IDS":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
+    '{"EMBED_MEDIA":"YES","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","LOGO_URL":"https://conservationmetrics.com/wp-content/themes/conservation-metrics/images/logo-conservation-metrics.png","MAPBOX_STYLE":"mapbox://styles/mapbox/satellite-streets-v12","MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"38","MAPBOX_CENTER_LONGITUDE":"-79","MAPBOX_ZOOM":7,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"MAPEO_CATEGORY_IDS":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
   ),
   (
     'gfw_alerts_viirs',
     'alerts',
     'gfw_alerts_viirs',
     'mapeo_data',
-    '{"EMBED_MEDIA":"NO","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","MAPBOX_STYLE":"mapbox://styles/mapbox/satellite-streets-v12","MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"1.20","MAPBOX_CENTER_LONGITUDE":"34.60","MAPBOX_ZOOM":8,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"MAPEO_TABLE":"mapeo_data","MAPEO_CATEGORY_IDS":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
+    '{"EMBED_MEDIA":"NO","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","MAPBOX_STYLE":"mapbox://styles/mapbox/satellite-streets-v12","MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"1.20","MAPBOX_CENTER_LONGITUDE":"34.60","MAPBOX_ZOOM":8,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"MAPEO_CATEGORY_IDS":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
   )
 ON CONFLICT (view_type, primary_dataset) DO NOTHING;

--- a/tests/unit/server/viewConfigModel.test.ts
+++ b/tests/unit/server/viewConfigModel.test.ts
@@ -35,17 +35,13 @@ describe("buildViewConfigColumns", () => {
       ROUTE_LEVEL_PERMISSION: "anyone",
     };
 
-    const columns = buildViewConfigColumns(
-      "fake_alerts",
-      config,
-      JSON.stringify(config),
-      "alerts",
-    );
+    const columns = buildViewConfigColumns("fake_alerts", config, "alerts");
 
     expect(columns.viewType).toBe("alerts");
     expect(columns.secondaryDataset).toBe("mapeo_data");
     expect(columns.primaryDataset).toBe("fake_alerts");
     expect(columns.viewName).toBe("Fake Alerts");
+    expect(JSON.parse(columns.viewConfig)).not.toHaveProperty("MAPEO_TABLE");
   });
 
   it("leaves secondaryDataset null for map and gallery views", () => {
@@ -57,13 +53,11 @@ describe("buildViewConfigColumns", () => {
     const mapColumns = buildViewConfigColumns(
       "bcmform_responses",
       config,
-      JSON.stringify(config),
       "map",
     );
     const galleryColumns = buildViewConfigColumns(
       "bcmform_responses",
       config,
-      JSON.stringify(config),
       "gallery",
     );
 
@@ -80,7 +74,6 @@ describe("buildViewConfigColumns", () => {
     const columns = buildViewConfigColumns(
       "seed_survey_data",
       config,
-      JSON.stringify(config),
       "gallery",
     );
 
@@ -93,7 +86,6 @@ describe("buildViewConfigColumns", () => {
     const columns = buildViewConfigColumns(
       "seed_survey_data",
       config,
-      JSON.stringify(config),
       "gallery",
     );
 

--- a/tests/unit/server/viewConfigModel.test.ts
+++ b/tests/unit/server/viewConfigModel.test.ts
@@ -65,21 +65,6 @@ describe("buildViewConfigColumns", () => {
     expect(galleryColumns.secondaryDataset).toBeNull();
   });
 
-  it("does not include a VIEWS key in the serialized view config", () => {
-    const config: ViewConfig = {
-      DATASET_TABLE: "Survey",
-      MAPBOX_ZOOM: 16,
-    };
-
-    const columns = buildViewConfigColumns(
-      "seed_survey_data",
-      config,
-      "gallery",
-    );
-
-    expect(JSON.parse(columns.viewConfig)).not.toHaveProperty("VIEWS");
-  });
-
   it("falls back to primaryDataset for viewName when DATASET_TABLE is absent", () => {
     const config: ViewConfig = { MAPBOX_ZOOM: 16 };
 

--- a/tests/unit/server/viewConfigModel.test.ts
+++ b/tests/unit/server/viewConfigModel.test.ts
@@ -28,37 +28,42 @@ vi.mock("@/server/database/dbConnection", () => ({
 }));
 
 describe("buildViewConfigColumns", () => {
-  it("sets secondaryDataset from MAPEO_TABLE and viewType for alerts views", () => {
+  it("sets secondaryDataset from the typed alerts field", () => {
     const config: ViewConfig = {
       DATASET_TABLE: "Fake Alerts",
-      MAPEO_TABLE: "mapeo_data",
       ROUTE_LEVEL_PERMISSION: "anyone",
     };
 
-    const columns = buildViewConfigColumns("fake_alerts", config, "alerts");
+    const columns = buildViewConfigColumns(
+      "fake_alerts",
+      config,
+      "alerts",
+      "mapeo_data",
+    );
 
     expect(columns.viewType).toBe("alerts");
     expect(columns.secondaryDataset).toBe("mapeo_data");
     expect(columns.primaryDataset).toBe("fake_alerts");
     expect(columns.viewName).toBe("Fake Alerts");
-    expect(JSON.parse(columns.viewConfig)).not.toHaveProperty("MAPEO_TABLE");
+    expect(JSON.parse(columns.viewConfig)).toEqual(config);
   });
 
   it("leaves secondaryDataset null for map and gallery views", () => {
     const config: ViewConfig = {
       DATASET_TABLE: "BCM Form Responses",
-      MAPEO_TABLE: "mapeo_data",
     };
 
     const mapColumns = buildViewConfigColumns(
       "bcmform_responses",
       config,
       "map",
+      "mapeo_data",
     );
     const galleryColumns = buildViewConfigColumns(
       "bcmform_responses",
       config,
       "gallery",
+      "mapeo_data",
     );
 
     expect(mapColumns.secondaryDataset).toBeNull();

--- a/types/index.ts
+++ b/types/index.ts
@@ -45,10 +45,7 @@ export interface ViewConfig {
   MAPBOX_BASEMAPS?: string; // JSON string of BasemapConfig[]
   MAPBOX_ZOOM?: number;
   MAPEO_CATEGORY_IDS?: string;
-  // Mirrored into the views.secondary_dataset column on save (see
-  // deriveSecondaryDataset). Not yet a single source of truth; readers still use
-  // this field. TODO(single-source-of-truth): drop once the API returns/consumes
-  // secondary_dataset.
+  // Config API/UI field backed by views.secondary_dataset.
   MAPEO_TABLE?: string;
   MAP_LEGEND_LAYER_IDS?: string;
   MEDIA_BASE_PATH?: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -45,8 +45,6 @@ export interface ViewConfig {
   MAPBOX_BASEMAPS?: string; // JSON string of BasemapConfig[]
   MAPBOX_ZOOM?: number;
   MAPEO_CATEGORY_IDS?: string;
-  // Config API/UI field backed by views.secondary_dataset.
-  MAPEO_TABLE?: string;
   MAP_LEGEND_LAYER_IDS?: string;
   MEDIA_BASE_PATH?: string;
   MEDIA_BASE_PATH_ALERTS?: string;


### PR DESCRIPTION
## Goal

Make `views.secondary_dataset` the stored source of truth for an alerts view’s Mapeo table name, while keeping the existing config UI working during the transition. Closes #486 

## Screenshots

N/A

## What I changed and why

- Config writes now accept `MAPEO_TABLE` from the alerts config form, derive `views.secondary_dataset` from it, then strip `MAPEO_TABLE` before serializing the JSON config
- Config reads reconstruct `MAPEO_TABLE` from `secondaryDataset` for existing API/UI compatibility, avoiding a larger form rewrite in this PR
- Added migration `0009_strip_mapeo_table_from_view_config` that removes `MAPEO_TABLE` from stored alert `view_config` JSON where `secondary_dataset` is already populated, without touching the actual Mapeo table value
- `MAPEO_TABLE` is no longer persisted inside `views.view_config`

## How I convinced myself this is right

I convinced myself this is right by checking the flow from both sides. When an admin saves the alerts config, the Mapeo table name is still accepted from the existing form, but it is saved only to `secondary_dataset`. When the config is loaded again, the UI still receives the value it expects, but it is rebuilt from `secondary_dataset` instead of being read from duplicated JSON.


## What I'm not doing here

This PR does not redesign the config UI which we've spoken on regularly as a blocker. 


## LLM use disclosure

GPT 5.5