### PR TITLE
Filter input collapses on a filled row instead of wrapping to empty line

### DIFF
--- a/components/shared/DataFilter.vue
+++ b/components/shared/DataFilter.vue
@@ -57,10 +57,17 @@ const getUniqueFilterValues = computed(() => {
 const emitFilterSelection = () => {
   emit("filter", [...selectedFilterValue.value]);
 };
+
+/** Quoted string for the CSS `content` of the "add more" hint (keeps i18n). */
+const selectMoreLabel = computed(() => JSON.stringify(t("selectMoreOptions")));
 </script>
 
 <template>
-  <div class="filter-modal mb-2" data-testid="data-filter">
+  <div
+    class="filter-modal mb-2"
+    data-testid="data-filter"
+    :style="{ '--select-more-label': selectMoreLabel }"
+  >
     <h4 data-testid="filter-heading">
       {{ $t("filterDataByColumn") }}: <strong>{{ filterColumn }}</strong>
     </h4>
@@ -130,6 +137,39 @@ const emitFilterSelection = () => {
     padding: 5px;
 
     --vs-selected-bg: #f9f9f9;
+
+    /* These elements belong to the child component, hence :deep().
+       Stack the selected tags one per row so the box stays narrow and hugs
+       the widest tag, rather than wrapping tags mid-row and leaving a gap. */
+    :deep(.value-container.multi) {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    /* Full-width row under the tags: the click target to add more / type-ahead
+       when tags exist, and the placeholder row while nothing is selected. */
+    :deep(.search-input) {
+      min-width: 0;
+      flex-grow: 0;
+      align-self: stretch;
+      width: auto;
+    }
+
+    /* Hint over that input row prompting to add more. The library blanks the
+       real placeholder once anything is selected, so this pseudo-element fills
+       in; it's hidden while the menu is open so it never covers typed text. */
+    &:not(.open) :deep(.value-container:has(.option-box)::after) {
+      content: var(--select-more-label, "");
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      padding: var(--vs-padding);
+      color: #9ca3af;
+      font-size: var(--vs-font-size);
+      line-height: var(--vs-line-height);
+      white-space: nowrap;
+      pointer-events: none;
+    }
 
     .option-box {
       --vs-multi-value-gap: 4px;

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -251,6 +251,7 @@
   "selectBasemap": "Select basemap",
   "selectDataset": "Select a dataset...",
   "selectDatasetToAdd": "Select dataset to add",
+  "selectMoreOptions": "Select more options",
   "showIcons": "Show Icons",
   "showPoints": "Show Points",
   "submit": "Submit",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -247,6 +247,7 @@
   "selectBasemap": "Seleccione el mapa base",
   "selectDataset": "Seleccionar un conjunto de datos...",
   "selectDatasetToAdd": "Seleccione el conjunto de datos para agregar",
+  "selectMoreOptions": "Seleccionar más opciones",
   "showIcons": "Mostrar Iconos",
   "showPoints": "Mostrar Puntos",
   "submit": "Enviar",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -248,6 +248,7 @@
   "selectBasemap": "Selecteer basiskaart",
   "selectDataset": "Selecteer een dataset...",
   "selectDatasetToAdd": "Selecteer dataset om toe te voegen",
+  "selectMoreOptions": "Meer opties selecteren",
   "showIcons": "Toon Iconen",
   "showPoints": "Toon Punten",
   "submit": "Toevoegen",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -247,6 +247,7 @@
   "selectBasemap": "Selecione o mapa base",
   "selectDataset": "Selecionar um conjunto de dados...",
   "selectDatasetToAdd": "Selecione o conjunto de dados para adicionar",
+  "selectMoreOptions": "Selecionar mais opções",
   "showIcons": "Mostrar Ícones",
   "showPoints": "Mostrar Pontos",
   "submit": "Enviar",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -251,6 +251,7 @@
   "selectBasemap": "Chagua ramani ya msingi",
   "selectDataset": "Chagua seti ya data...",
   "selectDatasetToAdd": "Chagua seti ya data la kuongeza",
+  "selectMoreOptions": "Chagua chaguo zaidi",
   "showIcons": "Onyesha Ikoni",
   "showPoints": "Onyesha Nukta",
   "submit": "Wasilisha",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -251,6 +251,7 @@
   "selectBasemap": "เลือกแผนที่ฐาน",
   "selectDataset": "เลือกชุดข้อมูล...",
   "selectDatasetToAdd": "เลือกชุดข้อมูลที่จะเพิ่ม",
+  "selectMoreOptions": "เลือกตัวเลือกเพิ่มเติม",
   "showIcons": "แสดงไอคอน",
   "showPoints": "แสดงจุด",
   "submit": "ส่ง",


### PR DESCRIPTION
## Goal

Clean up the `DataFilter` box: selected tags were wrapping mid-row and leaving big empty gaps, and the box grew wider than it needed to be.

## Screenshots

Before
<img width="625" height="240" alt="image" src="https://github.com/user-attachments/assets/4f11bce5-7814-442d-861e-7b2418665566" />

After
<img width="387" height="240" alt="image" src="https://github.com/user-attachments/assets/84d2521d-cf62-49e0-8049-fe93920c85cb" />

## What I changed and why

- Stack selected tags one-per-row so the box stays narrow and hugs the widest tag, instead of wrapping tags mid-row and leaving a dead gap.
- Kept a full-width input row under the tags as the click/type target to add more.
- Since the select library blanks its placeholder once something is selected, added a "Select more options" hint (via a pseudo-element fed a translated string) on that row, shown only while the dropdown is closed.

## How I convinced myself this is right

Tried this with several datasets (like in screenshot)

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Prompt engineered in Cursor and some code / comments adjusted by me.