### PR TITLE
Add search and view type filter to config page

### DIFF
--- a/components/ConfigDashboard.vue
+++ b/components/ConfigDashboard.vue
@@ -2,6 +2,9 @@
 import { useI18n } from "vue-i18n";
 import type { ViewConfigRow, ViewType } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
+import SearchBar from "@/components/shared/SearchBar.vue";
+import ViewTypeFilter from "@/components/shared/ViewTypeFilter.vue";
+import { matchesSearchQuery, matchesViewTypeFilter } from "@/utils/viewFilters";
 import {
   ChevronLeft,
   Images,
@@ -18,6 +21,7 @@ const props = defineProps<{
 
 const { t } = useI18n();
 const route = useRoute();
+const router = useRouter();
 
 const emit = defineEmits([
   "addTableToConfig",
@@ -31,6 +35,50 @@ const sortedViewsConfig = computed(() => {
       `${second.viewName}-${second.viewType}`,
     );
   });
+});
+
+const availableViewTypes = computed<ViewType[]>(() => {
+  const types = new Set<ViewType>();
+  sortedViewsConfig.value.forEach((row) => {
+    types.add(row.viewType);
+  });
+  return Array.from(types).sort();
+});
+
+const activeViewFilter = ref<string>(
+  typeof route.query.view === "string" ? route.query.view : "all",
+);
+
+watch(activeViewFilter, (value) => {
+  const query = { ...route.query };
+  if (value === "all") {
+    delete query.view;
+  } else {
+    query.view = value;
+  }
+  router.replace({ path: route.path, query });
+});
+
+const searchQuery = ref<string>(
+  typeof route.query.q === "string" ? route.query.q : "",
+);
+
+watch(searchQuery, (value) => {
+  const query = { ...route.query };
+  if (value) {
+    query.q = value;
+  } else {
+    delete query.q;
+  }
+  router.replace({ path: route.path, query });
+});
+
+const filteredViewsConfig = computed(() => {
+  return sortedViewsConfig.value.filter(
+    (row) =>
+      matchesViewTypeFilter(activeViewFilter.value, row.viewType) &&
+      matchesSearchQuery(searchQuery.value, row.viewName, row.primaryDataset),
+  );
 });
 
 /**
@@ -137,12 +185,36 @@ watch(tableNameToAdd, (newVal) => {
       </h1>
     </div>
 
+    <SearchBar
+      v-if="sortedViewsConfig.length"
+      v-model="searchQuery"
+      :placeholder="$t('searchDatasets')"
+    />
+
     <div
-      v-if="sortedViewsConfig"
+      v-if="sortedViewsConfig.length"
+      class="flex flex-wrap items-center justify-between gap-3 mb-4"
+    >
+      <ViewTypeFilter
+        v-model="activeViewFilter"
+        :view-types="availableViewTypes"
+      />
+      <button
+        data-testid="add-new-dataset-view-button"
+        class="flex items-center gap-2 px-4 py-2 sm:py-3 bg-violet-700 hover:bg-violet-800 text-white font-medium rounded-lg transition-colors duration-200"
+        @click="handleAddNewTable"
+      >
+        <Plus class="w-5 h-5" />
+        {{ $t("addNewTable") }}
+      </button>
+    </div>
+
+    <div
+      v-if="filteredViewsConfig.length"
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 items-stretch mb-6"
     >
       <div
-        v-for="row in sortedViewsConfig"
+        v-for="row in filteredViewsConfig"
         :key="row.viewId"
         data-testid="config-dataset-card"
         class="bg-violet-50 rounded-lg p-4 sm:p-6 shadow-sm border border-violet-100 overflow-hidden flex flex-col h-full"
@@ -212,7 +284,13 @@ watch(tableNameToAdd, (newVal) => {
       </div>
     </div>
 
-    <div class="flex justify-end mb-6">
+    <div v-else-if="sortedViewsConfig.length" class="text-center py-12 mb-6">
+      <p class="text-gray-500 text-sm sm:text-base">
+        {{ $t("noResultsFound") }}
+      </p>
+    </div>
+
+    <div v-else-if="!sortedViewsConfig.length" class="flex justify-end mb-6">
       <button
         data-testid="add-new-dataset-view-button"
         class="flex items-center gap-2 px-4 py-2 sm:py-3 bg-violet-700 hover:bg-violet-800 text-white font-medium rounded-lg transition-colors duration-200"
@@ -222,6 +300,7 @@ watch(tableNameToAdd, (newVal) => {
         {{ $t("addNewTable") }}
       </button>
     </div>
+
     <div
       v-if="showModal"
       data-testid="config-modal"

--- a/components/shared/SearchBar.vue
+++ b/components/shared/SearchBar.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { Search } from "lucide-vue-next";
+
+defineProps<{
+  modelValue: string;
+  placeholder: string;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+</script>
+
+<template>
+  <div class="relative flex items-center mb-4">
+    <Search class="absolute left-3 w-5 h-5 text-gray-400 pointer-events-none" />
+    <input
+      type="text"
+      :value="modelValue"
+      :placeholder="placeholder"
+      class="w-full pl-10 pr-4 py-2.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+      @input="
+        emit('update:modelValue', ($event.target as HTMLInputElement).value)
+      "
+    />
+  </div>
+</template>

--- a/components/shared/ViewTypeFilter.vue
+++ b/components/shared/ViewTypeFilter.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import type { ViewType } from "@/types";
+import { Images, Map, TriangleAlert } from "lucide-vue-next";
+
+defineProps<{
+  modelValue: string;
+  viewTypes: ViewType[];
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+</script>
+
+<template>
+  <div class="flex flex-wrap gap-2">
+    <button
+      type="button"
+      class="inline-flex items-center px-3 py-1.5 text-xs sm:text-sm font-medium rounded-lg border transition-colors"
+      :class="
+        modelValue === 'all'
+          ? 'bg-violet-700 text-white border-violet-700'
+          : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+      "
+      @click="emit('update:modelValue', 'all')"
+    >
+      {{ $t("all") }}
+    </button>
+    <button
+      v-for="viewType in viewTypes"
+      :key="viewType"
+      type="button"
+      class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm font-medium rounded-lg border transition-colors capitalize"
+      :class="
+        modelValue === viewType
+          ? 'bg-violet-700 text-white border-violet-700'
+          : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+      "
+      @click="emit('update:modelValue', viewType)"
+    >
+      <Map v-if="viewType === 'map'" class="w-3.5 h-3.5" />
+      <Images v-else-if="viewType === 'gallery'" class="w-3.5 h-3.5" />
+      <TriangleAlert v-else-if="viewType === 'alerts'" class="w-3.5 h-3.5" />
+      {{ $t(viewType) }}
+    </button>
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,8 +3,10 @@ import type { ViewConfig, ViewConfigRow, ViewType, User } from "@/types";
 import { Role } from "@/types";
 import DataLoadError from "@/components/shared/DataLoadError.vue";
 import EmptyStateIllustration from "@/components/shared/EmptyStateIllustration.vue";
+import SearchBar from "@/components/shared/SearchBar.vue";
+import ViewTypeFilter from "@/components/shared/ViewTypeFilter.vue";
 import DatasetCard from "@/components/index/DatasetCard.vue";
-import { Images, Map, Search, TriangleAlert } from "lucide-vue-next";
+import { matchesSearchQuery, matchesViewTypeFilter } from "@/utils/viewFilters";
 
 /** A dataset grouped from one or more view rows sharing the same primaryDataset. */
 interface DatasetGroup {
@@ -144,11 +146,8 @@ const availableViewTypes = computed<ViewType[]>(() => {
  * @returns {DatasetGroup[]} Datasets whose view types include the active filter.
  */
 const displayedDatasets = computed<DatasetGroup[]>(() => {
-  if (activeViewFilter.value === "all") {
-    return groupedDatasets.value;
-  }
   return groupedDatasets.value.filter((group) =>
-    group.viewTypes.includes(activeViewFilter.value as ViewType),
+    matchesViewTypeFilter(activeViewFilter.value, group.viewTypes),
   );
 });
 
@@ -159,14 +158,13 @@ const displayedDatasets = computed<DatasetGroup[]>(() => {
  * @returns {DatasetGroup[]} The search-filtered datasets.
  */
 const searchedDatasets = computed<DatasetGroup[]>(() => {
-  const q = searchQuery.value.trim().toLowerCase();
-  if (!q) return displayedDatasets.value;
-
-  return displayedDatasets.value.filter((group) => {
-    const displayName = group.viewName.toLowerCase();
-    const description = (group.config.VIEW_DESCRIPTION || "").toLowerCase();
-    return displayName.includes(q) || description.includes(q);
-  });
+  return displayedDatasets.value.filter((group) =>
+    matchesSearchQuery(
+      searchQuery.value,
+      group.viewName,
+      group.config.VIEW_DESCRIPTION,
+    ),
+  );
 });
 
 // Check if user should see config link
@@ -229,55 +227,17 @@ definePageMeta({ layout: "explorer" });
       </div>
 
       <!-- Search Bar -->
-      <div class="relative flex items-center mb-4">
-        <Search
-          class="absolute left-3 w-5 h-5 text-gray-400 pointer-events-none"
-        />
-        <input
-          v-model="searchQuery"
-          type="text"
-          :placeholder="$t('searchDatasets')"
-          class="w-full pl-10 pr-4 py-2.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-        />
-      </div>
+      <SearchBar v-model="searchQuery" :placeholder="$t('searchDatasets')" />
 
       <!-- View Type Filter & Manage Datasets -->
       <div
         v-if="groupedDatasets.length"
         class="flex flex-wrap items-center justify-between gap-3 mb-4"
       >
-        <div class="flex flex-wrap gap-2">
-          <button
-            class="inline-flex items-center px-3 py-1.5 text-xs sm:text-sm font-medium rounded-lg border transition-colors"
-            :class="
-              activeViewFilter === 'all'
-                ? 'bg-violet-700 text-white border-violet-700'
-                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
-            "
-            @click="activeViewFilter = 'all'"
-          >
-            {{ $t("all") }}
-          </button>
-          <button
-            v-for="viewType in availableViewTypes"
-            :key="viewType"
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm font-medium rounded-lg border transition-colors capitalize"
-            :class="
-              activeViewFilter === viewType
-                ? 'bg-violet-700 text-white border-violet-700'
-                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
-            "
-            @click="activeViewFilter = viewType"
-          >
-            <Map v-if="viewType === 'map'" class="w-3.5 h-3.5" />
-            <Images v-else-if="viewType === 'gallery'" class="w-3.5 h-3.5" />
-            <TriangleAlert
-              v-else-if="viewType === 'alerts'"
-              class="w-3.5 h-3.5"
-            />
-            {{ $t(viewType) }}
-          </button>
-        </div>
+        <ViewTypeFilter
+          v-model="activeViewFilter"
+          :view-types="availableViewTypes"
+        />
         <!-- NuxtLink messes up the layout, hence the use of a regular anchor tag -->
         <a
           v-if="shouldShowConfigLink"

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -49,6 +49,151 @@ test("config page - displays configuration dashboard with table cards", async ({
   expect(pillCount).toBeGreaterThanOrEqual(0); // Some datasets may have no views configured
 });
 
+test("config page - search bar filters dataset view cards by name", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.goto("/config");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='config-dataset-card']", {
+    timeout: 15000,
+  });
+
+  const allCards = page.locator("[data-testid='config-dataset-card']");
+  const initialCount = await allCards.count();
+  expect(initialCount).toBeGreaterThan(0);
+
+  const searchInput = page.locator("input[type='text']");
+  await expect(searchInput).toBeVisible({ timeout: 5000 });
+
+  const firstCardHeading = page
+    .locator("[data-testid='config-dataset-card'] h2")
+    .first();
+  const headingText = await firstCardHeading.textContent();
+  const searchTerm = (headingText || "").trim().substring(0, 5);
+
+  await searchInput.fill(searchTerm);
+  await page.waitForTimeout(500);
+
+  const filteredCards = page.locator("[data-testid='config-dataset-card']");
+  const filteredCount = await filteredCards.count();
+  expect(filteredCount).toBeGreaterThan(0);
+  expect(filteredCount).toBeLessThanOrEqual(initialCount);
+});
+
+test("config page - search bar shows no results message for gibberish", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.goto("/config");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='config-dataset-card']", {
+    timeout: 15000,
+  });
+
+  const searchInput = page.locator("input[type='text']");
+  await searchInput.fill("zzzznonexistentdatasetview12345");
+  await page.waitForTimeout(500);
+
+  const cards = page.locator("[data-testid='config-dataset-card']");
+  expect(await cards.count()).toBe(0);
+
+  const noResults = page.getByText(/no datasets match/i);
+  await expect(noResults).toBeVisible({ timeout: 5000 });
+});
+
+test("config page - search persists in URL query param", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.goto("/config");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='config-dataset-card']", {
+    timeout: 15000,
+  });
+
+  const searchInput = page.locator("input[type='text']");
+  await searchInput.fill("test");
+  await page.waitForTimeout(500);
+
+  expect(page.url()).toContain("q=test");
+
+  await page.goto("/config?q=test");
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(500);
+
+  await expect(page.locator("input[type='text']")).toHaveValue("test");
+});
+
+test("config page - view type filter filters dataset view cards", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.goto("/config");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='config-dataset-card']", {
+    timeout: 15000,
+  });
+
+  const allCards = page.locator("[data-testid='config-dataset-card']");
+  const initialCount = await allCards.count();
+  expect(initialCount).toBeGreaterThan(0);
+
+  const allButton = page.getByRole("button", { name: /^all$/i });
+  await expect(allButton).toBeVisible();
+
+  const mapButton = page.getByRole("button", { name: /^map$/i });
+  if ((await mapButton.count()) === 0) {
+    return;
+  }
+
+  await mapButton.click();
+  await page.waitForTimeout(500);
+
+  const filteredCards = page.locator("[data-testid='config-dataset-card']");
+  const filteredCount = await filteredCards.count();
+  expect(filteredCount).toBeLessThanOrEqual(initialCount);
+  expect(filteredCount).toBeGreaterThan(0);
+
+  const visibleMapTags = page.locator("[data-testid='config-view-tag-map']");
+  expect(await visibleMapTags.count()).toBe(filteredCount);
+
+  await allButton.click();
+  await page.waitForTimeout(500);
+
+  expect(await allCards.count()).toBe(initialCount);
+});
+
+test("config page - view filter persists in URL query param", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.goto("/config");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='config-dataset-card']", {
+    timeout: 15000,
+  });
+
+  const mapButton = page.getByRole("button", { name: /^map$/i });
+  if ((await mapButton.count()) === 0) {
+    return;
+  }
+
+  await mapButton.click();
+  await page.waitForTimeout(500);
+
+  expect(page.url()).toContain("view=map");
+
+  await page.goto("/config?view=map");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='config-dataset-card']", {
+    timeout: 15000,
+  });
+
+  const cardCount = await page
+    .locator("[data-testid='config-dataset-card']")
+    .count();
+  const mapTagCount = await page
+    .locator("[data-testid='config-view-tag-map']")
+    .count();
+  expect(mapTagCount).toBe(cardCount);
+});
+
 test("config page - add new dataset view and edit it", async ({
   authenticatedPageAsAdmin: page,
 }) => {

--- a/tests/unit/utils/viewFilters.test.ts
+++ b/tests/unit/utils/viewFilters.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesSearchQuery, matchesViewTypeFilter } from "@/utils/viewFilters";
+
+describe("matchesSearchQuery", () => {
+  it("matches when the query is empty", () => {
+    expect(matchesSearchQuery("", "Biodiversity Gallery")).toBe(true);
+    expect(matchesSearchQuery("   ", "Biodiversity Gallery")).toBe(true);
+  });
+
+  it("matches viewName or primaryDataset case-insensitively", () => {
+    expect(
+      matchesSearchQuery("bio", "Biodiversity Gallery", "bcmform_responses"),
+    ).toBe(true);
+    expect(
+      matchesSearchQuery(
+        "BCMFORM",
+        "Biodiversity Gallery",
+        "bcmform_responses",
+      ),
+    ).toBe(true);
+    expect(
+      matchesSearchQuery("xyz", "Biodiversity Gallery", "bcmform_responses"),
+    ).toBe(false);
+  });
+
+  it("treats nullish fields as empty strings", () => {
+    expect(matchesSearchQuery("gallery", null, undefined, "Gallery")).toBe(
+      true,
+    );
+    expect(matchesSearchQuery("gallery", null, undefined)).toBe(false);
+  });
+});
+
+describe("matchesViewTypeFilter", () => {
+  it("includes every item when the filter is all", () => {
+    expect(matchesViewTypeFilter("all", "map")).toBe(true);
+    expect(matchesViewTypeFilter("all", ["gallery", "alerts"])).toBe(true);
+  });
+
+  it("matches a single view type", () => {
+    expect(matchesViewTypeFilter("gallery", "gallery")).toBe(true);
+    expect(matchesViewTypeFilter("gallery", "map")).toBe(false);
+  });
+
+  it("matches when any listed view type equals the filter", () => {
+    expect(matchesViewTypeFilter("map", ["gallery", "map"])).toBe(true);
+    expect(matchesViewTypeFilter("alerts", ["gallery", "map"])).toBe(false);
+  });
+});

--- a/utils/viewFilters.ts
+++ b/utils/viewFilters.ts
@@ -1,0 +1,43 @@
+import type { ViewType } from "@/types";
+
+/**
+ * Returns true when the search query is empty, or when any field contains the
+ * query (case-insensitive substring match).
+ *
+ * @param {string} query - Raw search input from the user.
+ * @param {...(string | null | undefined)} fields - Text fields to match against.
+ * @returns {boolean} Whether the item should be included in search results.
+ */
+export const matchesSearchQuery = (
+  query: string,
+  ...fields: Array<string | null | undefined>
+): boolean => {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return fields.some((field) =>
+    (field || "").toLowerCase().includes(normalizedQuery),
+  );
+};
+
+/**
+ * Returns true when the active filter is "all", or when the item's view type(s)
+ * include the selected filter.
+ *
+ * @param {string} filter - Active filter value (`"all"` or a ViewType).
+ * @param {ViewType | ViewType[]} viewTypes - One view type or a list of types.
+ * @returns {boolean} Whether the item should be included for this filter.
+ */
+export const matchesViewTypeFilter = (
+  filter: string,
+  viewTypes: ViewType | ViewType[],
+): boolean => {
+  if (filter === "all") {
+    return true;
+  }
+
+  const types = Array.isArray(viewTypes) ? viewTypes : [viewTypes];
+  return types.includes(filter as ViewType);
+};


### PR DESCRIPTION
## Goal

Reuse the home page search bar and view-type filter on `/config` so dataset views are easier to find as the list grows. Closes #500 

## Screenshots

<img width="1470" height="875" alt="Screenshot 2026-07-15 at 10 59 40" src="https://github.com/user-attachments/assets/a04dfa9a-396d-4e58-8264-af469bf8b2f8" />
<img width="1470" height="875" alt="Screenshot 2026-07-15 at 10 59 33" src="https://github.com/user-attachments/assets/2e199cb1-5204-4068-bb7c-51891a738d1f" />
<img width="1470" height="875" alt="Screenshot 2026-07-15 at 10 59 30" src="https://github.com/user-attachments/assets/300f49e1-5725-441a-b64c-117d9ef17ab5" />
<img width="1470" height="875" alt="Screenshot 2026-07-15 at 10 59 23" src="https://github.com/user-attachments/assets/c2d91cb9-0e5d-44a0-a727-ce57594e705a" />
<img width="1470" height="875" alt="Screenshot 2026-07-15 at 10 59 18" src="https://github.com/user-attachments/assets/59822a24-3a9f-450d-9f72-90280a914ef4" />
<img width="1320" height="200" alt="Screenshot 2026-07-15 at 10 59 10" src="https://github.com/user-attachments/assets/874cc103-3094-450d-b2ee-370c8268e553" />


## What I changed and why

- Extracted `SearchBar` and `ViewTypeFilter` into shared components backed by a small pure filter helper, eliminating duplicated markup between the home and config dashboard pages
- Home page behavior is unchanged: URL sync stays in the page and search still matches display name and description
- Config dashboard now uses the same controls to filter cards by view type and search `viewName` and `primaryDataset`, with matching query-param deep links, and the Add button sits in the filter row
- Added unit tests for the filter helpers and e2e coverage asserting search, empty results, view-type filtering, and URL persistence on the config dashboard
- 
## How I convinced myself this is right

The shared components only expose `v-model` / props, so the filtering and URL sync remain in the page/dashboard where they already lived on home and config mirrors that pattern. The unit tests execute the match helpers with empty queries, case-insensitive substrings, and single vs multi type lists, which is the same logic both UIs call. The new config e2e tests exercise the end behavior a user sees: typing a card name reduces the grid, gibberish shows the no-results copy, Map filter leaves only map-tagged cards, and reloading `/config?q=` / `?view=` restores the controls.

## What I'm not doing here

- Type-first create flow (#499)

## LLM use disclosure

Cursor Grok 4.5 helped with tests