### PR TITLE
Fix oauth middleware to read views-shaped `/api/config`

### DIFF
--- a/middleware/oauth.global.ts
+++ b/middleware/oauth.global.ts
@@ -47,16 +47,18 @@ export default defineNuxtRouteMiddleware(async (to) => {
         return;
       }
 
-      const response =
-        await $fetch<
-          [
-            Record<string, { ROUTE_LEVEL_PERMISSION?: RouteLevelPermission }>,
-            string[],
-          ]
-        >("/api/config");
-      const [tableConfig] = response;
+      // /api/config returns { views, availableTables } after the views migration.
+      const response = await $fetch<{
+        views: Array<{
+          primaryDataset: string;
+          viewConfig: { ROUTE_LEVEL_PERMISSION?: RouteLevelPermission };
+        }>;
+      }>("/api/config");
+      const viewEntry = response.views?.find(
+        (view) => view.primaryDataset === tableName,
+      );
       const permission: RouteLevelPermission =
-        tableConfig?.[tableName]?.ROUTE_LEVEL_PERMISSION ?? "member";
+        viewEntry?.viewConfig?.ROUTE_LEVEL_PERMISSION ?? "member";
 
       // Authenticated from here on
       const typedUser = user.value as User;


### PR DESCRIPTION
## Goal

Restore role-based access checks on authenticated dataset routes after the views migration.

## Screenshots

N/A

## What I changed and why

`/api/config` now returns `{ views, availableTables }`, but `middleware/oauth.global.ts` still treated the response as the old `[tableConfig, tables]` tuple.

That made `const [tableConfig] = response` throw. The middleware `catch` only forces login for unauthenticated users, so for logged-in users the permission switch never ran and RBAC was silently skipped.

This PR reads permission from `response.views` by `primaryDataset`.

## How I convinced myself this is right
- Tested manually setting to different roles in Auth0 ensuring say a `SignedIn` user cannot access an Admin route etc.
- Confirmed `server/api/config/index.get.ts` returns `{ views, availableTables }`.
- Confirmed the old middleware destructuring throws on that object shape and falls into the catch path.
- After the change, permission resolves from `viewEntry.viewConfig.ROUTE_LEVEL_PERMISSION` with the same `"member"` default as before.

## What I'm not doing here

- No E2E / Playwright / seed changes (those stay on https://github.com/ConservationMetrics/gc-explorer/pull/490).
- No changes to public_views unauthenticated access.
- No broader auth or config API refactor.

## LLM use disclosure

None