### PR TITLE
Hide `BasemapSelector` component if only one basemap available

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -1757,7 +1757,10 @@ onBeforeUnmount(() => {
       @toggle-layer-visibility="toggleLayerVisibility"
     />
     <BasemapSelector
-      v-if="showBasemapSelector"
+      v-if="
+        showBasemapSelector &&
+        ((mapboxBasemaps?.length ?? 0) > 1 || !!planetApiKey)
+      "
       :has-ruler-control="hasRulerControl"
       :mapbox-style="mapboxStyle"
       :mapbox-basemaps="mapboxBasemaps || []"

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -640,7 +640,10 @@ onBeforeUnmount(() => {
       @toggle-layer-visibility="toggleLayerVisibility"
     />
     <BasemapSelector
-      v-if="showBasemapSelector"
+      v-if="
+        showBasemapSelector &&
+        ((mapboxBasemaps?.length ?? 0) > 1 || !!planetApiKey)
+      "
       :mapbox-style="mapboxStyle"
       :mapbox-basemaps="mapboxBasemaps || []"
       :planet-api-key="planetApiKey"

--- a/tests/e2e/01-alerts.spec.ts
+++ b/tests/e2e/01-alerts.spec.ts
@@ -165,9 +165,10 @@ test("alerts dashboard - basemap toggle icon is visible", async ({
   await page.goto("/alerts/fake_alerts");
   await page.waitForLoadState("networkidle");
 
-  // Wait for map to load (BasemapSelector renders after map is ready)
+  // Wait for map to load (BasemapSelector renders when >1 basemap or Planet is available)
   await page.locator("#map").waitFor({ state: "attached", timeout: 15000 });
 
+  // fake_alerts seed has PLANET_API_KEY, so selector shows even with a single Mapbox basemap
   const basemapToggle = page.locator(".basemap-toggle").first();
   await expect(basemapToggle).toBeVisible({ timeout: 10000 });
 

--- a/tests/unit/components/MapView.test.ts
+++ b/tests/unit/components/MapView.test.ts
@@ -508,6 +508,55 @@ describe("MapView component", () => {
     expect(vm.currentBasemap.style).toBe("mapbox://styles/mapbox/satellite-v9");
   });
 
+  it("shows BasemapSelector when multiple basemaps or Planet is available", async () => {
+    const singleBasemap = [
+      {
+        name: "Streets",
+        style: "mapbox://styles/mapbox/streets-v12",
+        isDefault: true,
+      },
+    ];
+    const multipleBasemaps = [
+      ...singleBasemap,
+      {
+        name: "Satellite",
+        style: "mapbox://styles/mapbox/satellite-v9",
+        isDefault: false,
+      },
+    ];
+
+    const wrapper = mount(MapView, {
+      props: {
+        ...baseProps,
+        mapboxBasemaps: singleBasemap,
+        planetApiKey: "",
+      },
+      global: globalConfig,
+    });
+
+    mapboxMock.fireLoad();
+    await flushPromises();
+
+    expect(wrapper.findComponent({ name: "BasemapSelector" }).exists()).toBe(
+      false,
+    );
+
+    await wrapper.setProps({ mapboxBasemaps: multipleBasemaps });
+    await flushPromises();
+    expect(wrapper.findComponent({ name: "BasemapSelector" }).exists()).toBe(
+      true,
+    );
+
+    await wrapper.setProps({
+      mapboxBasemaps: singleBasemap,
+      planetApiKey: "planet-key",
+    });
+    await flushPromises();
+    expect(wrapper.findComponent({ name: "BasemapSelector" }).exists()).toBe(
+      true,
+    );
+  });
+
   it("removes map on component unmount", async () => {
     const wrapper = mount(MapView, {
       props: baseProps,


### PR DESCRIPTION
## Goal

https://github.com/ConservationMetrics/gc-explorer/commit/16d133857d9211e9e7403d6b4579f29ff61dd89e removed hard-coded basemap options, which means there is a possible state where the available basemaps == 1. And in that case, a basemap selector control doesn't make any sense.

## What I changed and why

- Conditionally render `BasemapSelector` component if `mapboxBasemaps.length` PLUS Planet basemap (if available) > 1.
- Tests to check for this behavior.

## How I convinced myself this is right

I clicked on a Basemap Selector control on a map with only one basemap, and thought it looked very odd to only have one radio button choice.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None