### PR TITLE
Index page: one card per view, not per dataset

### DIFF
--- a/components/index/DatasetCard.vue
+++ b/components/index/DatasetCard.vue
@@ -7,7 +7,7 @@ interface Props {
   tableName: string | number;
   viewName: string;
   config: ViewConfig;
-  viewTypes: ViewType[];
+  viewType: ViewType;
 }
 
 const props = defineProps<Props>();
@@ -96,15 +96,13 @@ const truncateDescription = (desc: string): string => {
 
     <div class="flex flex-wrap gap-1.5 mb-4 overflow-hidden">
       <span
-        v-for="view in [...viewTypes].sort()"
-        :key="view"
-        :data-testid="`view-tag-${view}`"
+        :data-testid="`view-tag-${viewType}`"
         class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-violet-100 text-violet-800 rounded-full flex-shrink-0"
       >
-        <Map v-if="view === 'map'" class="w-3 h-3" />
-        <Images v-else-if="view === 'gallery'" class="w-3 h-3" />
-        <TriangleAlert v-else-if="view === 'alerts'" class="w-3 h-3" />
-        {{ $t(view) }}
+        <Map v-if="viewType === 'map'" class="w-3 h-3" />
+        <Images v-else-if="viewType === 'gallery'" class="w-3 h-3" />
+        <TriangleAlert v-else-if="viewType === 'alerts'" class="w-3 h-3" />
+        {{ $t(viewType) }}
       </span>
     </div>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,14 +8,6 @@ import ViewTypeFilter from "@/components/shared/ViewTypeFilter.vue";
 import DatasetCard from "@/components/index/DatasetCard.vue";
 import { matchesSearchQuery, matchesViewTypeFilter } from "@/utils/viewFilters";
 
-/** A dataset grouped from one or more view rows sharing the same primaryDataset. */
-interface DatasetGroup {
-  tableName: string;
-  viewName: string;
-  config: ViewConfig;
-  viewTypes: ViewType[];
-}
-
 const viewRows = ref<ViewConfigRow[]>([]);
 const availableTables = ref<string[]>([]);
 
@@ -67,36 +59,19 @@ const canAccessConfig = (config: ViewConfig) => {
 };
 
 /**
- * Groups permission-filtered view rows by their primaryDataset.
- * The first row's viewConfig is used as the representative config because dataset-level
- * display fields (DATASET_TABLE/VIEW_DESCRIPTION/ROUTE_LEVEL_PERMISSION) are shared.
+ * Permission-filtered view rows, one card per view (not grouped by dataset).
+ * Sorted by view name then type, matching the config dashboard.
  *
- * @returns {DatasetGroup[]} Datasets sorted by table name, each with deduped, sorted view types.
+ * @returns {ViewConfigRow[]} Accessible views ready for filtering and display.
  */
-const groupedDatasets = computed<DatasetGroup[]>(() => {
-  const groups: Record<string, DatasetGroup> = {};
-
-  viewRows.value
+const accessibleViews = computed<ViewConfigRow[]>(() => {
+  return viewRows.value
     .filter((row) => canAccessConfig(row.viewConfig))
-    .forEach((row) => {
-      const existing = groups[row.primaryDataset];
-      if (existing) {
-        if (!existing.viewTypes.includes(row.viewType)) {
-          existing.viewTypes.push(row.viewType);
-        }
-      } else {
-        groups[row.primaryDataset] = {
-          tableName: row.primaryDataset,
-          viewName: row.viewName || row.primaryDataset,
-          config: row.viewConfig,
-          viewTypes: [row.viewType],
-        };
-      }
-    });
-
-  return Object.values(groups)
-    .map((group) => ({ ...group, viewTypes: [...group.viewTypes].sort() }))
-    .sort((first, second) => first.tableName.localeCompare(second.tableName));
+    .sort((first, second) =>
+      `${first.viewName}-${first.viewType}`.localeCompare(
+        `${second.viewName}-${second.viewType}`,
+      ),
+    );
 });
 
 const activeViewFilter = ref<string>(
@@ -128,41 +103,40 @@ watch(searchQuery, (value) => {
 });
 
 /**
- * All distinct view types present across the permission-filtered datasets.
+ * All distinct view types present across the permission-filtered views.
  *
  * @returns {ViewType[]} Sorted array of unique view types (e.g. ["alerts", "gallery", "map"]).
  */
 const availableViewTypes = computed<ViewType[]>(() => {
   const types = new Set<ViewType>();
-  groupedDatasets.value.forEach((group) => {
-    group.viewTypes.forEach((type) => types.add(type));
-  });
+  accessibleViews.value.forEach((row) => types.add(row.viewType));
   return Array.from(types).sort();
 });
 
 /**
- * Applies the active view-type filter on top of the already permission-filtered datasets.
+ * Applies the active view-type filter on top of the already permission-filtered views.
  *
- * @returns {DatasetGroup[]} Datasets whose view types include the active filter.
+ * @returns {ViewConfigRow[]} Views whose type matches the active filter.
  */
-const displayedDatasets = computed<DatasetGroup[]>(() => {
-  return groupedDatasets.value.filter((group) =>
-    matchesViewTypeFilter(activeViewFilter.value, group.viewTypes),
+const displayedViews = computed<ViewConfigRow[]>(() => {
+  return accessibleViews.value.filter((row) =>
+    matchesViewTypeFilter(activeViewFilter.value, row.viewType),
   );
 });
 
 /**
- * Applies search filtering on top of the view-type-filtered datasets.
- * Matches case-insensitively against display name (DATASET_TABLE or table name) and description.
+ * Applies search filtering on top of the view-type-filtered views.
+ * Matches case-insensitively against view name, primary dataset, and description.
  *
- * @returns {DatasetGroup[]} The search-filtered datasets.
+ * @returns {ViewConfigRow[]} The search-filtered views.
  */
-const searchedDatasets = computed<DatasetGroup[]>(() => {
-  return displayedDatasets.value.filter((group) =>
+const searchedViews = computed<ViewConfigRow[]>(() => {
+  return displayedViews.value.filter((row) =>
     matchesSearchQuery(
       searchQuery.value,
-      group.viewName,
-      group.config.VIEW_DESCRIPTION,
+      row.viewName,
+      row.primaryDataset,
+      row.viewConfig.VIEW_DESCRIPTION,
     ),
   );
 });
@@ -231,7 +205,7 @@ definePageMeta({ layout: "explorer" });
 
       <!-- View Type Filter & Manage Datasets -->
       <div
-        v-if="groupedDatasets.length"
+        v-if="accessibleViews.length"
         class="flex flex-wrap items-center justify-between gap-3 mb-4"
       >
         <ViewTypeFilter
@@ -250,16 +224,16 @@ definePageMeta({ layout: "explorer" });
 
       <!-- Project Cards Grid -->
       <div
-        v-if="searchedDatasets.length > 0"
+        v-if="searchedViews.length > 0"
         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 items-stretch"
       >
         <DatasetCard
-          v-for="dataset in searchedDatasets"
-          :key="dataset.tableName"
-          :table-name="dataset.tableName"
-          :view-name="dataset.viewName"
-          :config="dataset.config"
-          :view-types="dataset.viewTypes"
+          v-for="row in searchedViews"
+          :key="`${row.primaryDataset}-${row.viewType}`"
+          :table-name="row.primaryDataset"
+          :view-name="row.viewName"
+          :config="row.viewConfig"
+          :view-type="row.viewType"
         />
       </div>
 

--- a/tests/e2e/03-index.spec.ts
+++ b/tests/e2e/03-index.spec.ts
@@ -72,6 +72,37 @@ test("index page - displays available views and navigation flow", async ({
   expect(hasGallery || hasMap || hasAlerts).toBe(true);
 });
 
+test("index page - one card per view for datasets with multiple views", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='dataset-card']", {
+    timeout: 15000,
+  });
+
+  // Seed has bcmform_responses with both map and gallery views — expect one card each.
+  const bcmformCards = page.locator("[data-testid='dataset-card']").filter({
+    has: page.getByRole("heading", { name: /bcmform_responses/i }),
+  });
+  await expect(bcmformCards).toHaveCount(2);
+
+  const bcmformMapCards = bcmformCards.filter({
+    has: page.locator("[data-testid='view-tag-map']"),
+  });
+  const bcmformGalleryCards = bcmformCards.filter({
+    has: page.locator("[data-testid='view-tag-gallery']"),
+  });
+  await expect(bcmformMapCards).toHaveCount(1);
+  await expect(bcmformGalleryCards).toHaveCount(1);
+
+  // Each card shows exactly one view-type pill (not a multi-type group).
+  for (const card of await bcmformCards.all()) {
+    const tags = card.locator("[data-testid^='view-tag-']");
+    await expect(tags).toHaveCount(1);
+  }
+});
+
 test("index page - view type filter buttons are visible and functional", async ({
   authenticatedPageAsAdmin: page,
 }) => {


### PR DESCRIPTION
## Goal

Make the home index view-centric: one card per configured view, so datasets with multiple views (e.g. map + gallery on the same primary table) are no longer collapsed into a single card with an arbitrary display name. Closes #520 


## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-07-17 at 00 38 27" src="https://github.com/user-attachments/assets/bff62978-48a3-4213-86e6-a518a9c119b4" />


## What I changed and why

- Index page now renders one `DatasetCard` per `ViewConfigRow` instead of grouping by `primaryDataset` and picking the first row, so sibling views are no longer hidden behind a single card
- Cards are keyed by primary dataset plus view type, and each shows a single type pill matching how the config dashboard presents views
- Search now matches view name, primary dataset, and description


## How I convinced myself this is right

Manual validation in thr browser

## What I'm not doing here

- Anything extrenous


## LLM use disclosure

Used to help tests