### PR TITLE
 Make "Copy config from dataset" view-type aware

### DIFF
--- a/composables/useCopyConfig.ts
+++ b/composables/useCopyConfig.ts
@@ -1,29 +1,60 @@
-import type { Views, ViewConfig } from "@/types";
+import type { ViewConfig, ViewConfigRow, ViewType } from "@/types";
+
+export type CopyConfigSource = {
+  key: string;
+  label: string;
+  viewConfig: ViewConfig;
+};
 
 /**
- * Composable for copying configuration from one dataset to another.
- * Manages modal state, dataset selection, and config cloning.
+ * Builds a stable lookup key for a view copy source.
  *
- * @param {Ref<Views>} viewsConfig - Reactive reference to all dataset configs.
- * @param {string} currentDataset - The current dataset key to exclude from the list.
+ * @param {string} primaryDataset - Primary dataset table name.
+ * @param {ViewType} viewType - View type of the source row.
+ * @returns {string} Key unique per (dataset, view type).
+ */
+export const copySourceKey = (
+  primaryDataset: string,
+  viewType: ViewType,
+): string => `${primaryDataset}::${viewType}`;
+
+/**
+ * Composable for copying configuration from another same-type view.
+ * Manages modal state, source selection, and config cloning.
+ *
+ * @param {Ref<ViewConfigRow[]>} viewRows - All configured view rows.
+ * @param {string} currentDataset - Primary dataset of the view being edited.
+ * @param {Ref<ViewType | undefined>} currentViewType - View type of the view being edited.
  * @returns {object} Reactive state and handlers for the copy config modal.
  */
 export const useCopyConfig = (
-  viewsConfig: Ref<Views>,
+  viewRows: Ref<ViewConfigRow[]>,
   currentDataset: string,
+  currentViewType: Ref<ViewType | undefined>,
 ) => {
   const showCopyModal = ref(false);
   const selectedCopySource = ref<string>("");
   const configToCopy = ref<ViewConfig | null>(null);
 
-  const otherDatasets = computed(() => {
-    return Object.keys(viewsConfig.value)
+  const otherCopySources = computed<CopyConfigSource[]>(() => {
+    const type = currentViewType.value;
+    if (!type) {
+      return [];
+    }
+
+    return viewRows.value
       .filter(
-        (key) =>
-          key !== currentDataset &&
-          Object.keys(viewsConfig.value[key]).length > 0,
+        (row) =>
+          row.viewType === type &&
+          row.primaryDataset !== currentDataset &&
+          Object.keys(row.viewConfig).length > 0,
       )
-      .sort();
+      .map((row) => ({
+        key: copySourceKey(row.primaryDataset, row.viewType),
+        label: row.viewName || row.primaryDataset,
+        viewConfig: row.viewConfig,
+      }))
+      .sort((first, second) => first.label.localeCompare(second.label));
   });
 
   const handleOpenCopyModal = () => {
@@ -33,9 +64,11 @@ export const useCopyConfig = (
 
   const handleConfirmCopy = () => {
     if (!selectedCopySource.value) return;
-    const sourceConfig = viewsConfig.value[selectedCopySource.value];
-    if (sourceConfig) {
-      configToCopy.value = JSON.parse(JSON.stringify(sourceConfig));
+    const source = otherCopySources.value.find(
+      (candidate) => candidate.key === selectedCopySource.value,
+    );
+    if (source) {
+      configToCopy.value = JSON.parse(JSON.stringify(source.viewConfig));
     }
     showCopyModal.value = false;
   };
@@ -49,7 +82,7 @@ export const useCopyConfig = (
     showCopyModal,
     selectedCopySource,
     configToCopy,
-    otherDatasets,
+    otherCopySources,
     handleOpenCopyModal,
     handleConfirmCopy,
     handleCancelCopy,

--- a/pages/config/[dataset].vue
+++ b/pages/config/[dataset].vue
@@ -2,7 +2,7 @@
 import ConfigCard from "@/components/config/ConfigCard.vue";
 import DataLoadError from "@/components/shared/DataLoadError.vue";
 import { useCopyConfig } from "@/composables/useCopyConfig";
-import type { ViewConfig, ViewConfigRow, Views, ViewType } from "@/types";
+import type { ViewConfig, ViewConfigRow, ViewType } from "@/types";
 import {
   CheckCircle2,
   ChevronLeft,
@@ -20,7 +20,6 @@ const dataset = Array.isArray(datasetRaw)
   : String(datasetRaw || "");
 const viewType = computed(() => route.query.view_type as ViewType | undefined);
 
-const viewsConfig = ref<Views>({});
 const viewRows = ref<ViewConfigRow[]>([]);
 const tableNames = ref();
 const dataFetched = ref(false);
@@ -40,11 +39,6 @@ if (data.value && !error.value) {
   const allViewRows = data.value.views;
   viewRows.value = allViewRows;
   tableNames.value = data.value.availableTables;
-
-  viewsConfig.value = allViewRows.reduce((acc, row) => {
-    acc[row.primaryDataset] = row.viewConfig;
-    return acc;
-  }, {} as Views);
 
   const editedViewRow = allViewRows.find(
     (row) =>
@@ -179,15 +173,11 @@ const {
   showCopyModal,
   selectedCopySource,
   configToCopy,
-  otherDatasets,
+  otherCopySources,
   handleOpenCopyModal,
   handleConfirmCopy,
   handleCancelCopy,
-} = useCopyConfig(viewsConfig, dataset);
-
-const getCopySourceLabel = (configKey: string) => {
-  return viewsConfig.value[configKey]?.DATASET_TABLE || configKey;
-};
+} = useCopyConfig(viewRows, dataset, resolvedViewType);
 
 const { t } = useI18n();
 const { error: showErrorToast } = useToast();
@@ -240,7 +230,7 @@ definePageMeta({ layout: "explorer" });
               {{ $t("configuration") }} - {{ pageDisplayName }}
             </h1>
             <button
-              v-if="otherDatasets.length > 0"
+              v-if="otherCopySources.length > 0"
               data-testid="copy-config-button"
               class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
               @click="handleOpenCopyModal"
@@ -361,11 +351,11 @@ definePageMeta({ layout: "explorer" });
               {{ $t("selectDataset") }}
             </option>
             <option
-              v-for="dsName in otherDatasets"
-              :key="dsName"
-              :value="dsName"
+              v-for="source in otherCopySources"
+              :key="source.key"
+              :value="source.key"
             >
-              {{ getCopySourceLabel(dsName) }}
+              {{ source.label }}
             </option>
           </select>
           <div class="flex gap-3 justify-end">

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -1369,25 +1369,24 @@ test("config page - color column configuration", async ({
   }
 });
 
-test("config page - copy config from another dataset", async ({
+test("config page - copy config from another same-type view", async ({
   authenticatedPageAsAdmin: page,
 }) => {
+  // Seed has two gallery views (bcmform_responses, seed_survey_data). Edit the
+  // bcmform gallery card so the copy modal has a same-type peer to pick from.
   await page.goto("/config");
   await page.waitForLoadState("networkidle");
   await page.locator(".grid").waitFor({ state: "attached", timeout: 10000 });
 
-  const datasetCards = page.locator("[data-testid='config-dataset-card']");
-  const cardCount = await datasetCards.count();
+  const galleryCard = page
+    .locator("[data-testid='config-dataset-card']")
+    .filter({ has: page.locator("[data-testid='config-view-tag-gallery']") })
+    .filter({ hasText: /bcmform_responses/i })
+    .first();
 
-  if (cardCount < 2) {
-    test.skip();
-    return;
-  }
-
-  const firstCard = datasetCards.first();
-  const editLink = firstCard.locator("[data-testid='edit-dataset-view-link']");
-  await editLink.click();
-  await page.waitForURL(/\/config\/\w+/, { timeout: 10000 });
+  await expect(galleryCard).toBeVisible({ timeout: 10000 });
+  await galleryCard.locator("[data-testid='edit-dataset-view-link']").click();
+  await page.waitForURL(/\/config\/bcmform_responses/, { timeout: 10000 });
   await page.waitForLoadState("networkidle");
   await page.waitForSelector("form", { timeout: 15000 });
 
@@ -1405,8 +1404,14 @@ test("config page - copy config from another dataset", async ({
   await expect(confirmButton).toBeDisabled();
 
   const dropdown = page.locator("[data-testid='copy-config-select']");
-  const options = await dropdown.locator("option:not([disabled])").all();
-  expect(options.length).toBeGreaterThan(0);
+  const optionLabels = await dropdown
+    .locator("option:not([disabled])")
+    .allTextContents();
+  expect(optionLabels.length).toBeGreaterThan(0);
+  // Same-type only: gallery peer is present; the map sibling on bcmform is not a source.
+  expect(optionLabels.some((label) => /seed_survey_data/i.test(label))).toBe(
+    true,
+  );
 
   await dropdown.selectOption({ index: 1 });
   await expect(confirmButton).toBeEnabled();
@@ -1425,17 +1430,13 @@ test("config page - copy config modal cancel closes modal", async ({
   await page.waitForLoadState("networkidle");
   await page.locator(".grid").waitFor({ state: "attached", timeout: 10000 });
 
-  const datasetCards = page.locator("[data-testid='config-dataset-card']");
-  const cardCount = await datasetCards.count();
+  const galleryCard = page
+    .locator("[data-testid='config-dataset-card']")
+    .filter({ has: page.locator("[data-testid='config-view-tag-gallery']") })
+    .first();
 
-  if (cardCount < 2) {
-    test.skip();
-    return;
-  }
-
-  const firstCard = datasetCards.first();
-  const editLink = firstCard.locator("[data-testid='edit-dataset-view-link']");
-  await editLink.click();
+  await expect(galleryCard).toBeVisible({ timeout: 10000 });
+  await galleryCard.locator("[data-testid='edit-dataset-view-link']").click();
   await page.waitForURL(/\/config\/\w+/, { timeout: 10000 });
   await page.waitForLoadState("networkidle");
   await page.waitForSelector("form", { timeout: 15000 });

--- a/tests/unit/composables/useCopyConfig.test.ts
+++ b/tests/unit/composables/useCopyConfig.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ref, computed } from "vue";
+import type { ViewConfig, ViewConfigRow, ViewType } from "@/types";
+import { copySourceKey, useCopyConfig } from "@/composables/useCopyConfig";
+
+Object.assign(globalThis, { ref, computed });
+
+const makeRow = ({
+  viewId,
+  primaryDataset,
+  viewType,
+  viewName,
+  viewConfig,
+}: {
+  viewId: number;
+  primaryDataset: string;
+  viewType: ViewType;
+  viewName: string;
+  viewConfig: ViewConfig;
+}): ViewConfigRow => ({
+  viewId,
+  primaryDataset,
+  viewType,
+  viewName,
+  secondaryDataset: null,
+  viewConfig,
+});
+
+describe("useCopyConfig", () => {
+  const mapConfigA: ViewConfig = { MAPBOX_ZOOM: 10, DATASET_TABLE: "Map A" };
+  const galleryConfigA: ViewConfig = {
+    EMBED_MEDIA: "YES",
+    DATASET_TABLE: "Gallery A",
+  };
+  const mapConfigB: ViewConfig = { MAPBOX_ZOOM: 5, DATASET_TABLE: "Map B" };
+  const galleryConfigB: ViewConfig = {
+    EMBED_MEDIA: "NO",
+    DATASET_TABLE: "Gallery B",
+  };
+
+  let viewRows: ReturnType<typeof ref<ViewConfigRow[]>>;
+
+  beforeEach(() => {
+    viewRows = ref([
+      makeRow({
+        viewId: 1,
+        primaryDataset: "dataset_a",
+        viewType: "map",
+        viewName: "Dataset A Map",
+        viewConfig: mapConfigA,
+      }),
+      makeRow({
+        viewId: 2,
+        primaryDataset: "dataset_a",
+        viewType: "gallery",
+        viewName: "Dataset A Gallery",
+        viewConfig: galleryConfigA,
+      }),
+      makeRow({
+        viewId: 3,
+        primaryDataset: "dataset_b",
+        viewType: "map",
+        viewName: "Dataset B Map",
+        viewConfig: mapConfigB,
+      }),
+      makeRow({
+        viewId: 4,
+        primaryDataset: "dataset_b",
+        viewType: "gallery",
+        viewName: "Dataset B Gallery",
+        viewConfig: galleryConfigB,
+      }),
+    ]);
+  });
+
+  it("offers only same-type sources when a dataset has multiple views", () => {
+    const currentViewType = ref<ViewType | undefined>("map");
+    const { otherCopySources } = useCopyConfig(
+      viewRows,
+      "dataset_a",
+      currentViewType,
+    );
+
+    expect(otherCopySources.value.map((source) => source.key)).toEqual([
+      copySourceKey("dataset_b", "map"),
+    ]);
+    expect(otherCopySources.value[0].label).toBe("Dataset B Map");
+  });
+
+  it("copies the matching view config, not a sibling type on the same dataset", () => {
+    const currentViewType = ref<ViewType | undefined>("gallery");
+    const {
+      otherCopySources,
+      selectedCopySource,
+      handleConfirmCopy,
+      configToCopy,
+    } = useCopyConfig(viewRows, "dataset_a", currentViewType);
+
+    expect(otherCopySources.value).toHaveLength(1);
+    selectedCopySource.value = otherCopySources.value[0].key;
+    handleConfirmCopy();
+
+    expect(configToCopy.value).toEqual(galleryConfigB);
+    expect(configToCopy.value).not.toEqual(mapConfigB);
+  });
+
+  it("excludes the current view and empty configs", () => {
+    viewRows.value.push(
+      makeRow({
+        viewId: 5,
+        primaryDataset: "empty_map",
+        viewType: "map",
+        viewName: "Empty",
+        viewConfig: {},
+      }),
+    );
+
+    const currentViewType = ref<ViewType | undefined>("map");
+    const { otherCopySources } = useCopyConfig(
+      viewRows,
+      "dataset_a",
+      currentViewType,
+    );
+
+    expect(otherCopySources.value.map((source) => source.key)).not.toContain(
+      copySourceKey("dataset_a", "map"),
+    );
+    expect(otherCopySources.value.map((source) => source.key)).not.toContain(
+      copySourceKey("empty_map", "map"),
+    );
+  });
+
+  it("returns no sources when the current view type is unset", () => {
+    const currentViewType = ref<ViewType | undefined>(undefined);
+    const { otherCopySources } = useCopyConfig(
+      viewRows,
+      "dataset_a",
+      currentViewType,
+    );
+
+    expect(otherCopySources.value).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Goal

Make “Copy Config from Another View” view-type aware so a map edit cannot pull gallery settings (or vice versa), and so a dataset with multiple views copies the matching type’s config instead of whichever row last won a dataset-keyed lookup. Closes #510 


## Screenshots

<img width="1440" height="700" alt="Screenshot 2026-07-20 at 10 40 11" src="https://github.com/user-attachments/assets/a0b1b81a-c5fc-4510-8452-85c5c6c1bc21" />
<img width="1440" height="700" alt="Screenshot 2026-07-20 at 10 39 55" src="https://github.com/user-attachments/assets/e39f2812-dbe1-421b-b7c2-f83ced956c54" />


## What I changed and why

- Fixed `useCopyConfig` building a map keyed only by `primaryDataset`, which caused last-write-wins behavior when a table had two views, potentially offering the wrong sibling or a mismatched view type in the copy modal
- Composable now reads `ViewConfigRow[]`, filters to rows matching the current `viewType`, excludes the current primary dataset, and looks up the chosen source by `primaryDataset::viewType`
- Config edit page drops the dataset-keyed reduce and passes `viewRows` and `resolvedViewType` into the composable directly
- Modal options render source labels from the filtered rows


## How I convinced myself this is right

Tested it myself and the e2e path opens the seeded bcmform gallery card (which has a gallery peer) and checks the modal lists seed_survey_data, so the happy path still exercises a real same-type copy in CI.


## What I'm not doing here

- anything extrenous

## LLM use disclosure

Cursor Grok 4.5 Helped 