### PR TITLE
Index cards: header image, expandable description, admin edit gear

### DIFF
--- a/components/index/DatasetCard.vue
+++ b/components/index/DatasetCard.vue
@@ -1,16 +1,21 @@
 <script setup lang="ts">
 import type { ViewConfig, ViewType } from "@/types";
 import { formatDisplayName, CONFIG_LIMITS } from "@/utils";
-import { Images, Map, TriangleAlert } from "lucide-vue-next";
+import { Images, Map, Settings, TriangleAlert } from "lucide-vue-next";
 
 interface Props {
   tableName: string | number;
   viewName: string;
   config: ViewConfig;
   viewType: ViewType;
+  showAdminGear?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  showAdminGear: false,
+});
+
+const isDescriptionExpanded = ref(false);
 
 /**
  * Gets the formatted permission level for a table to display in the UI
@@ -43,86 +48,134 @@ const truncateDisplayName = (name: string): string => {
     : name;
 };
 
+const fullDescription = computed(() => props.config.VIEW_DESCRIPTION || "");
+
+const isDescriptionTruncated = computed(() => {
+  return fullDescription.value.length > CONFIG_LIMITS.VIEW_DESCRIPTION;
+});
+
 /**
- * Truncates the description if it exceeds the character limit
+ * Description shown on the card — full text when expanded, truncated otherwise.
  *
- * @param {string} desc - The description to truncate
- * @returns {string} The truncated description with ellipsis if needed
+ * @returns {string} Description text for display.
  */
-const truncateDescription = (desc: string): string => {
-  if (!desc) return "";
-  return desc.length > CONFIG_LIMITS.VIEW_DESCRIPTION
-    ? desc.substring(0, CONFIG_LIMITS.VIEW_DESCRIPTION) + "..."
-    : desc;
-};
+const displayDescription = computed(() => {
+  if (!fullDescription.value) return "";
+  if (isDescriptionExpanded.value || !isDescriptionTruncated.value) {
+    return fullDescription.value;
+  }
+  return (
+    fullDescription.value.substring(0, CONFIG_LIMITS.VIEW_DESCRIPTION) + "..."
+  );
+});
+
+const headerImage = computed(() => props.config.VIEW_HEADER_IMAGE || "");
+
+const configEditPath = computed(() => ({
+  path: `/config/${String(props.tableName)}`,
+  query: { view_type: props.viewType },
+}));
 </script>
 
 <template>
   <div
     data-testid="dataset-card"
-    class="bg-violet-50 rounded-lg p-4 sm:p-6 shadow-sm border border-violet-100 overflow-hidden flex flex-col h-full"
+    class="bg-violet-50 rounded-lg shadow-sm border border-violet-100 overflow-hidden flex flex-col h-full"
   >
-    <div class="flex items-start mb-3">
-      <div
-        class="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-violet-200 flex items-center justify-center text-white font-bold text-sm sm:text-base mr-3 flex-shrink-0"
-      >
-        {{ String(tableName).charAt(0).toUpperCase() }}
-      </div>
-      <div class="flex-1 min-w-0 max-w-full overflow-hidden">
-        <h2
-          class="text-lg sm:text-xl font-semibold text-gray-800 break-words max-w-full mb-2"
-          style="overflow-wrap: anywhere; word-break: break-word; hyphens: auto"
+    <div
+      v-if="headerImage"
+      data-testid="dataset-card-header-image"
+      class="relative w-full h-32 sm:h-40 overflow-hidden"
+    >
+      <img
+        :src="headerImage"
+        :alt="truncateDisplayName(viewName || String(tableName))"
+        class="w-full h-full object-cover"
+      />
+    </div>
+
+    <div class="p-4 sm:p-6 flex flex-col flex-1">
+      <div class="flex items-start mb-3">
+        <div
+          class="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-violet-200 flex items-center justify-center text-white font-bold text-sm sm:text-base mr-3 flex-shrink-0"
         >
-          {{ truncateDisplayName(viewName || String(tableName)) }}
-        </h2>
-        <div class="h-10 mb-4">
-          <p
-            v-if="config.VIEW_DESCRIPTION"
-            class="text-sm sm:text-base text-gray-600 line-clamp-2"
-            style="
-              display: -webkit-box;
-              -webkit-line-clamp: 2;
-              line-clamp: 2;
-              -webkit-box-orient: vertical;
-              overflow: hidden;
-              text-overflow: ellipsis;
-            "
-          >
-            {{ truncateDescription(config.VIEW_DESCRIPTION) }}
-          </p>
+          {{ String(tableName).charAt(0).toUpperCase() }}
+        </div>
+        <div class="flex-1 min-w-0 max-w-full overflow-hidden">
+          <div class="flex items-start gap-2 mb-2">
+            <h2
+              class="text-lg sm:text-xl font-semibold text-gray-800 break-words max-w-full flex-1"
+              style="
+                overflow-wrap: anywhere;
+                word-break: break-word;
+                hyphens: auto;
+              "
+            >
+              {{ truncateDisplayName(viewName || String(tableName)) }}
+            </h2>
+            <NuxtLink
+              v-if="showAdminGear"
+              :to="configEditPath"
+              data-testid="dataset-card-config-gear"
+              class="flex-shrink-0 p-1.5 text-gray-500 hover:text-violet-700 hover:bg-violet-100 rounded-lg transition-colors"
+              :aria-label="$t('editConfiguration')"
+              @click.stop
+            >
+              <Settings class="w-4 h-4" />
+            </NuxtLink>
+          </div>
+          <div class="mb-4">
+            <template v-if="fullDescription">
+              <p
+                class="text-sm sm:text-base text-gray-600"
+                data-testid="dataset-card-description"
+              >
+                {{ displayDescription }}
+              </p>
+              <button
+                v-if="isDescriptionTruncated"
+                type="button"
+                data-testid="dataset-card-description-toggle"
+                class="text-violet-600 hover:text-violet-800 text-sm font-medium underline mt-1"
+                @click="isDescriptionExpanded = !isDescriptionExpanded"
+              >
+                {{ isDescriptionExpanded ? $t("showLess") : $t("showMore") }}
+              </button>
+            </template>
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="flex flex-wrap gap-1.5 mb-4 overflow-hidden">
-      <span
-        :data-testid="`view-tag-${viewType}`"
-        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-violet-100 text-violet-800 rounded-full flex-shrink-0"
+      <div class="flex flex-wrap gap-1.5 mb-4 overflow-hidden">
+        <span
+          :data-testid="`view-tag-${viewType}`"
+          class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-violet-100 text-violet-800 rounded-full flex-shrink-0"
+        >
+          <Map v-if="viewType === 'map'" class="w-3 h-3" />
+          <Images v-else-if="viewType === 'gallery'" class="w-3 h-3" />
+          <TriangleAlert v-else-if="viewType === 'alerts'" class="w-3 h-3" />
+          {{ $t(viewType) }}
+        </span>
+      </div>
+
+      <div v-if="getPermissionLevel()" class="flex items-center gap-2 mb-4">
+        <span class="text-sm text-gray-600 font-medium">
+          {{ $t("permissionLevel") }}:
+        </span>
+        <span
+          class="text-xs px-2 py-1 rounded bg-blue-100 text-blue-800 whitespace-nowrap"
+        >
+          {{ getPermissionLevel() }}
+        </span>
+      </div>
+
+      <NuxtLink
+        :to="`/${viewType}/${String(tableName)}`"
+        data-testid="open-dataset-view-link"
+        class="mt-auto block w-full text-center px-4 py-2 sm:py-3 bg-violet-700 hover:bg-violet-800 text-white font-medium rounded-lg transition-colors duration-200"
       >
-        <Map v-if="viewType === 'map'" class="w-3 h-3" />
-        <Images v-else-if="viewType === 'gallery'" class="w-3 h-3" />
-        <TriangleAlert v-else-if="viewType === 'alerts'" class="w-3 h-3" />
-        {{ $t(viewType) }}
-      </span>
+        {{ $t("openProject") }}
+      </NuxtLink>
     </div>
-
-    <div v-if="getPermissionLevel()" class="flex items-center gap-2 mb-4">
-      <span class="text-sm text-gray-600 font-medium">
-        {{ $t("permissionLevel") }}:
-      </span>
-      <span
-        class="text-xs px-2 py-1 rounded bg-blue-100 text-blue-800 whitespace-nowrap"
-      >
-        {{ getPermissionLevel() }}
-      </span>
-    </div>
-
-    <NuxtLink
-      :to="`/${viewType}/${String(tableName)}`"
-      data-testid="open-dataset-view-link"
-      class="mt-auto block w-full text-center px-4 py-2 sm:py-3 bg-violet-700 hover:bg-violet-800 text-white font-medium rounded-lg transition-colors duration-200"
-    >
-      {{ $t("openProject") }}
-    </NuxtLink>
   </div>
 </template>

--- a/components/index/DatasetCard.vue
+++ b/components/index/DatasetCard.vue
@@ -50,12 +50,15 @@ const truncateDisplayName = (name: string): string => {
 
 const fullDescription = computed(() => props.config.VIEW_DESCRIPTION || "");
 
+/** Preview length for collapsed card descriptions (~two lines). Not the config field max. */
+const CARD_DESCRIPTION_PREVIEW = 120;
+
 const isDescriptionTruncated = computed(() => {
-  return fullDescription.value.length > CONFIG_LIMITS.VIEW_DESCRIPTION;
+  return fullDescription.value.length > CARD_DESCRIPTION_PREVIEW;
 });
 
 /**
- * Description shown on the card — full text when expanded, truncated otherwise.
+ * Description shown on the card — short preview when collapsed, full text when expanded.
  *
  * @returns {string} Description text for display.
  */
@@ -65,7 +68,7 @@ const displayDescription = computed(() => {
     return fullDescription.value;
   }
   return (
-    fullDescription.value.substring(0, CONFIG_LIMITS.VIEW_DESCRIPTION) + "..."
+    fullDescription.value.substring(0, CARD_DESCRIPTION_PREVIEW).trimEnd() + "…"
   );
 });
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -257,6 +257,8 @@
   "selectDatasetToAdd": "Select dataset to add",
   "selectMoreOptions": "Select more options",
   "showIcons": "Show Icons",
+  "showLess": "Show less",
+  "showMore": "Show more",
   "showPoints": "Show Points",
   "submit": "Submit",
   "table": "Table",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -253,6 +253,8 @@
   "selectDatasetToAdd": "Seleccione el conjunto de datos para agregar",
   "selectMoreOptions": "Seleccionar más opciones",
   "showIcons": "Mostrar Iconos",
+  "showLess": "Mostrar menos",
+  "showMore": "Mostrar más",
   "showPoints": "Mostrar Puntos",
   "submit": "Enviar",
   "table": "Tabla",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -254,6 +254,8 @@
   "selectDatasetToAdd": "Selecteer dataset om toe te voegen",
   "selectMoreOptions": "Meer opties selecteren",
   "showIcons": "Toon Iconen",
+  "showLess": "Toon minder",
+  "showMore": "Toon meer",
   "showPoints": "Toon Punten",
   "submit": "Toevoegen",
   "table": "Tafel",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -253,6 +253,8 @@
   "selectDatasetToAdd": "Selecione o conjunto de dados para adicionar",
   "selectMoreOptions": "Selecionar mais opções",
   "showIcons": "Mostrar Ícones",
+  "showLess": "Mostrar menos",
+  "showMore": "Mostrar mais",
   "showPoints": "Mostrar Pontos",
   "submit": "Enviar",
   "table": "Tabela",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -257,6 +257,8 @@
   "selectDatasetToAdd": "Chagua seti ya data la kuongeza",
   "selectMoreOptions": "Chagua chaguo zaidi",
   "showIcons": "Onyesha Ikoni",
+  "showLess": "Onyesha chini",
+  "showMore": "Onyesha zaidi",
   "showPoints": "Onyesha Nukta",
   "submit": "Wasilisha",
   "table": "Jedwali",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -257,6 +257,8 @@
   "selectDatasetToAdd": "เลือกชุดข้อมูลที่จะเพิ่ม",
   "selectMoreOptions": "เลือกตัวเลือกเพิ่มเติม",
   "showIcons": "แสดงไอคอน",
+  "showLess": "แสดงน้อยลง",
+  "showMore": "แสดงเพิ่มเติม",
   "showPoints": "แสดงจุด",
   "submit": "ส่ง",
   "table": "ตาราง",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -234,6 +234,7 @@ definePageMeta({ layout: "explorer" });
           :view-name="row.viewName"
           :config="row.viewConfig"
           :view-type="row.viewType"
+          :show-admin-gear="shouldShowConfigLink"
         />
       </div>
 

--- a/tests/e2e/03-index.spec.ts
+++ b/tests/e2e/03-index.spec.ts
@@ -108,6 +108,26 @@ test("index page - one card per view for datasets with multiple views", async ({
   }
 });
 
+test("index page - admin gear links to config edit for that view", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("[data-testid='dataset-card']", {
+    timeout: 15000,
+  });
+
+  const gear = page.locator("[data-testid='dataset-card-config-gear']").first();
+  await expect(gear).toBeVisible({ timeout: 5000 });
+
+  const href = await gear.getAttribute("href");
+  expect(href).toMatch(/^\/config\/\w+\?view_type=(alerts|gallery|map)$/);
+
+  await gear.click();
+  await page.waitForURL(/\/config\/\w+\?view_type=/, { timeout: 15000 });
+  await expect(page.locator("form")).toBeVisible({ timeout: 15000 });
+});
+
 test("index page - view type filter buttons are visible and functional", async ({
   authenticatedPageAsAdmin: page,
 }) => {


### PR DESCRIPTION
## Goal

Make index cards carry enough context and admin entry points that the index can replace both the old dataset hub and, later, the config dashboard listing: header image, expandable description, and an admin-only gear to the matching config edit route. Closes #522 


## Screenshots

<img width="1410" height="822" alt="Screenshot 2026-07-20 at 15 29 10" src="https://github.com/user-attachments/assets/f6627909-1711-4c05-8ffe-1de8c66e1ad3" />
<img width="1407" height="711" alt="Screenshot 2026-07-20 at 15 28 57" src="https://github.com/user-attachments/assets/51c8ac99-6c9a-46aa-81ab-97691b48a223" />

## What I changed and why

- `DatasetCard` now shows `VIEW_HEADER_IMAGE` when set
- Long descriptions expand and collapse in place via `showMore` / `showLess` controls, with i18n keys added across all six locales
- Admin gear icon linking to `/config/{dataset}?view_type={type}` is rendered when the admin gate is true, letting admins navigate directly to the config edit page from the index card
- Index page passes the admin flag as `showAdminGear` so `DatasetCard` stays unaware of auth logic

## How I convinced myself this is right

Manual testing

## What I'm not doing here

- Anything extrenous
- Non-admin gear visibility tests in e2e (admin fixture only; hidden when `showAdminGear` is false)


## LLM use disclosure

Cursor Grok 4.5 helped with tests