### PR TITLE
For alerts, select Mapeo data table as secondary dataset; not specify in ConfigAlerts

### DIFF
--- a/tests/unit/server/viewConfigModel.test.ts
+++ b/tests/unit/server/viewConfigModel.test.ts
@@ -70,6 +70,21 @@ describe("buildViewConfigColumns", () => {
     expect(galleryColumns.secondaryDataset).toBeNull();
   });
 
+  it("keeps alerts secondaryDataset null when omitted or blank", () => {
+    const config: ViewConfig = {
+      DATASET_TABLE: "Fake Alerts",
+    };
+
+    expect(
+      buildViewConfigColumns("fake_alerts", config, "alerts", null)
+        .secondaryDataset,
+    ).toBeNull();
+    expect(
+      buildViewConfigColumns("fake_alerts", config, "alerts", "  ")
+        .secondaryDataset,
+    ).toBeNull();
+  });
+
   it("falls back to primaryDataset for viewName when DATASET_TABLE is absent", () => {
     const config: ViewConfig = { MAPBOX_ZOOM: 16 };
 


### PR DESCRIPTION
## Goal

“Name of Mapeo data table” field is the sole source of Secondary dataset. Closes #531 

## Screenshots

## What I changed and why

By default the behaviour we want ALREADY exists so this PR just Added a unit test that `buildViewConfigColumns` for alerts leaves `secondaryDataset` null when the value is omitted or whitespace-only. The editable Mapeo table field in ConfigAlerts already writes that column on save (so the top Secondary dataset metadata matches after save); this test guards against reintroducing a hardcoded default. 

## How I convinced myself this is right

- `pnpm test:unit tests/unit/server/viewConfigModel.test.ts` passes, including the new blank/null case and the existing case that a typed secondary (e.g. a partner table name) is preserved.

## What I'm not doing here


## LLM use disclosure

Used Cursor to add the regression test