### PR TITLE
Refactor date utilities to use date-fns

### DIFF
--- a/components/shared/BasemapSelector.vue
+++ b/components/shared/BasemapSelector.vue
@@ -4,6 +4,7 @@ import "vue-datepicker-next/index.css";
 import type { PropType } from "vue";
 
 import type { Basemap, BasemapConfig, MapboxStyleConfig } from "@/types";
+import { formatPlanetMonth, getPlanetMaxMonth } from "@/utils/dateUtils";
 import { Layers } from "lucide-vue-next";
 
 const props = defineProps({
@@ -63,28 +64,15 @@ const toggleBasemapWindow = () => {
 // PlanetScope Monthly Select Basemaps
 // Reference: https://docs.planet.com/develop/apis/tiles/
 const minMonth = "2020_01"; // The first month we have PlanetScope Monthly Select Basemaps
-const maxMonth = computed(() => {
-  // If the current day is less than or equal to 15, maxMonth is two months ago.
-  // Otherwise, maxMonth is the previous month.
-  // This is because PlanetScope Monthly Select Basemaps for the previous month are published on the 15th of each month.
-  const date = new Date();
-  if (date.getDate() <= 15) {
-    date.setMonth(date.getMonth() - 2);
-  } else {
-    date.setMonth(date.getMonth() - 1);
-  }
-  const year = date.getFullYear();
-  const monthNumber = date.getMonth() + 1;
-  const formattedMonth = monthNumber < 10 ? `0${monthNumber}` : monthNumber;
-  return `${year}_${formattedMonth}`;
-});
+// If the current day is less than or equal to 15, maxMonth is two months ago.
+// Otherwise, maxMonth is the previous month.
+// This is because PlanetScope Monthly Select Basemaps for the previous month are published on the 15th of each month.
+const maxMonth = computed(() => getPlanetMaxMonth());
 const monthYear = ref<string>(maxMonth.value);
 const setPlanetDateRange = (date: Date) => {
   // minMonth and maxMonth are in format YYYY_MM, but date is a Date object
   // so we need to convert it to a string in the same format
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const formatted = `${year}_${month < 10 ? "0" + month : month}`;
+  const formatted = formatPlanetMonth(date);
   return formatted < minMonth || formatted > maxMonth.value;
 };
 

--- a/components/shared/TimestampFilter.vue
+++ b/components/shared/TimestampFilter.vue
@@ -1,4 +1,11 @@
 <script setup lang="ts">
+import {
+  compareAsc,
+  endOfMonth as getEndOfMonth,
+  format,
+  isValid,
+  startOfMonth,
+} from "date-fns";
 import VueSlider from "vue-3-slider-component";
 
 import type { Dataset } from "@/types";
@@ -30,7 +37,7 @@ const dateInfo = computed(() => {
       }
       if (value == null) return null;
       const date = new Date(String(value));
-      return Number.isNaN(date.getTime()) ? null : date;
+      return isValid(date) ? date : null;
     })
     .filter((date): date is Date => date !== null);
 
@@ -44,13 +51,11 @@ const dateInfo = computed(() => {
 
   const monthSet = new Set<string>();
   for (const d of dates) {
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, "0");
-    monthSet.add(`${y}-${m}`);
+    monthSet.add(format(d, "yyyy-MM"));
   }
   const options = [...monthSet].sort();
 
-  const sortedDates = [...dates].sort((a, b) => a.getTime() - b.getTime());
+  const sortedDates = [...dates].sort(compareAsc);
   return {
     min: sortedDates[0],
     max: sortedDates[sortedDates.length - 1],
@@ -63,8 +68,7 @@ const userInteracted = ref(false);
 
 /** Parse "YYYY-MM" to last moment of that month (23:59:59.999). */
 function endOfMonth(year: number, month1Based: number): Date {
-  const d = new Date(year, month1Based, 0, 23, 59, 59, 999);
-  return d;
+  return getEndOfMonth(new Date(year, month1Based - 1));
 }
 
 /** Emit filter when range changes (options are "YYYY-MM" months). */
@@ -77,7 +81,7 @@ const emitFilter = () => {
   }
   const [startY, startM] = startStr.split("-").map(Number);
   const [endY, endM] = endStr.split("-").map(Number);
-  const start = new Date(startY, startM - 1, 1, 0, 0, 0, 0);
+  const start = startOfMonth(new Date(startY, startM - 1));
   const end = endOfMonth(endY, endM);
   emit("filter", { start, end });
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@turf/turf": "^7.2.0",
     "@vojtechlanka/vue-tags-input": "^3.1.1",
     "chart.js": "^4.4.7",
+    "date-fns": "^4.4.0",
     "drizzle-orm": "^0.44.5",
     "lodash": "^4.18.1",
     "lucide-vue-next": "^0.516.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       chart.js:
         specifier: ^4.4.7
         version: 4.5.0
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       drizzle-orm:
         specifier: ^0.44.5
         version: 0.44.5(@types/pg@8.15.4)(pg@8.16.2)(postgres@3.4.7)
@@ -3121,6 +3124,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   date-format-parse@0.2.7:
     resolution: {integrity: sha512-/+lyMUKoRogMuTeOVii6lUwjbVlesN9YRYLzZT/g3TEZ3uD9QnpjResujeEqUW+OSNbT7T1+SYdyEkTcRv+KDQ==}
@@ -11038,6 +11044,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.4.0: {}
 
   date-format-parse@0.2.7: {}
 

--- a/server/dataProcessing/dataFilters.ts
+++ b/server/dataProcessing/dataFilters.ts
@@ -1,4 +1,5 @@
 import { hasValidCoordinates } from "@/utils/geoUtils";
+import { parseDateMs } from "@/utils/dateUtils";
 
 import type { ColumnEntry, DataEntry, AllowedFileExtensions } from "@/types";
 
@@ -148,16 +149,6 @@ export const filterToSelectedValues = (
   });
 };
 
-const parseDateValue = (value: unknown): number | null => {
-  if (value == null || value === "") return null;
-  const str = String(value).trim();
-  if (!str) return null;
-  const num = Number(str);
-  if (!Number.isNaN(num) && num > 0) return num;
-  const date = new Date(str);
-  return Number.isNaN(date.getTime()) ? null : date.getTime();
-};
-
 /**
  * Keeps only rows where the timestamp column value falls within [minDate, maxDate] (inclusive).
  *
@@ -176,13 +167,13 @@ export const filterByDateRange = (
   if (!timestampColumn || (!minDate && !maxDate)) {
     return data;
   }
-  const minMs = minDate ? parseDateValue(minDate) : null;
-  const maxMs = maxDate ? parseDateValue(maxDate) : null;
+  const minMs = minDate ? parseDateMs(minDate) : null;
+  const maxMs = maxDate ? parseDateMs(maxDate) : null;
   if (minDate && minMs == null) return data;
   if (maxDate && maxMs == null) return data;
 
   return data.filter((item) => {
-    const valueMs = parseDateValue(item[timestampColumn]);
+    const valueMs = parseDateMs(item[timestampColumn]);
     if (valueMs == null) return false;
     if (minMs != null && valueMs < minMs) return false;
     if (maxMs != null && valueMs > maxMs) return false;

--- a/server/dataProcessing/dataTransformers.ts
+++ b/server/dataProcessing/dataTransformers.ts
@@ -1,4 +1,13 @@
 import {
+  compareAsc,
+  format,
+  isAfter,
+  isEqual,
+  isWithinInterval,
+  setDate,
+} from "date-fns";
+
+import {
   calculateCentroidFromParsedCoords,
   tryParseDataEntryGeoCoordinates,
 } from "@/utils/geoUtils";
@@ -55,7 +64,7 @@ const prepareMinimalAlertEntries = (
       parseInt(formattedMonth) - 1,
     );
 
-    if (date > latestProprietaryDate) {
+    if (isAfter(date, latestProprietaryDate)) {
       latestProprietaryDate = date;
       latestProprietaryMonthStr = monthYearStr;
     }
@@ -64,7 +73,7 @@ const prepareMinimalAlertEntries = (
   let latestGfwDate = new Date(0);
   gfwData.forEach(({ item }) => {
     const date = new Date(item.date_end_t1);
-    if (date > latestGfwDate) latestGfwDate = date;
+    if (isAfter(date, latestGfwDate)) latestGfwDate = date;
   });
 
   const toMinimalEntry = (
@@ -112,7 +121,7 @@ const prepareMinimalAlertEntries = (
 
   gfwData.forEach(({ item, parsedCoords }) => {
     const date = new Date(item.date_end_t1);
-    if (date.getTime() === latestGfwDate.getTime()) {
+    if (isEqual(date, latestGfwDate)) {
       mostRecentAlerts.push(toMinimalEntry(item, parsedCoords));
     } else {
       previousAlerts.push(toMinimalEntry(item, parsedCoords));
@@ -199,7 +208,7 @@ const prepareAlertsStatistics = (
   // Handle empty data case - but still use metadata if available
   if (data.length === 0) {
     const now = new Date();
-    const currentDateStr = `${String(now.getMonth() + 1).padStart(2, "0")}-${now.getFullYear()}`;
+    const currentDateStr = format(now, "MM-yyyy");
 
     const dataProviders = getDataProvidersFromMetadata();
     const metadataDateRange = getDateRangeFromMetadata();
@@ -265,7 +274,7 @@ const prepareAlertsStatistics = (
   });
 
   // Sort dates to find the earliest and latest
-  formattedDates.sort((a, b) => a.date.getTime() - b.date.getTime());
+  formattedDates.sort((a, b) => compareAsc(a.date, b.date));
 
   let earliestDateStr, latestDateStr;
   let earliestDate: Date, latestDate: Date;
@@ -278,12 +287,10 @@ const prepareAlertsStatistics = (
     latestDateStr = metadataDateRange.latestDateStr;
   } else {
     // If metadata is null, calculate earliest and latest dates from data
-    earliestDate = formattedDates[0].date;
-    earliestDate.setDate(1);
+    earliestDate = setDate(formattedDates[0].date, 1);
     earliestDateStr = formattedDates[0].displayString;
 
-    latestDate = formattedDates[formattedDates.length - 1].date;
-    latestDate.setDate(28);
+    latestDate = setDate(formattedDates[formattedDates.length - 1].date, 28);
     latestDateStr = formattedDates[formattedDates.length - 1].displayString;
   }
 
@@ -304,7 +311,10 @@ const prepareAlertsStatistics = (
       const itemDate = new Date(
         `${item.year_detec}-${item.month_detec.padStart(2, "0")}-01`,
       );
-      return itemDate >= twelveMonthsBefore && itemDate <= latestDate;
+      return isWithinInterval(itemDate, {
+        start: twelveMonthsBefore,
+        end: latestDate,
+      });
     })
     .sort((a, b) => {
       const aDate = new Date(
@@ -313,12 +323,10 @@ const prepareAlertsStatistics = (
       const bDate = new Date(
         `${b.year_detec}-${b.month_detec.padStart(2, "0")}`,
       );
-      return aDate.getTime() - bDate.getTime();
+      return compareAsc(aDate, bDate);
     });
 
-  const twelveMonthsBeforeStr = `${
-    twelveMonthsBefore.getMonth() + 1
-  }-${twelveMonthsBefore.getFullYear()}`;
+  const twelveMonthsBeforeStr = format(twelveMonthsBefore, "M-yyyy");
 
   const getUpTo12MonthsForChart = (): string[] => {
     const months = [];

--- a/tests/unit/utils/dateUtils.test.ts
+++ b/tests/unit/utils/dateUtils.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect, vi } from "vitest";
 
-import { formatDate, formatLocaleDate } from "@/utils/dateUtils";
+import {
+  formatDate,
+  formatLocaleDate,
+  formatPlanetMonth,
+  getPlanetMaxMonth,
+  parseDateMs,
+} from "@/utils/dateUtils";
+
+describe("parseDateMs", () => {
+  it("parses numeric timestamps and date strings", () => {
+    expect(parseDateMs(1704067200000)).toBe(1704067200000);
+    expect(parseDateMs("2024-01-01T00:00:00.000Z")).toBe(1704067200000);
+  });
+
+  it("returns null for empty or invalid values", () => {
+    expect(parseDateMs(null)).toBeNull();
+    expect(parseDateMs("")).toBeNull();
+    expect(parseDateMs("not-a-date")).toBeNull();
+  });
+});
 
 describe("formatLocaleDate", () => {
   it("should format a date string to a locale date string", () => {
@@ -20,5 +39,19 @@ describe("formatDate", () => {
       .mockReturnValue("1/15/2024");
     expect(formatDate("2024-01-15T12:30:45.000Z")).toBe("1/15/2024");
     spy.mockRestore();
+  });
+});
+
+describe("Planet monthly basemap dates", () => {
+  it("formats dates as Planet month identifiers", () => {
+    expect(formatPlanetMonth(new Date(2024, 0, 1))).toBe("2024_01");
+  });
+
+  it("uses two months ago through the 15th", () => {
+    expect(getPlanetMaxMonth(new Date(2024, 0, 15, 12))).toBe("2023_11");
+  });
+
+  it("uses the previous month after the 15th", () => {
+    expect(getPlanetMaxMonth(new Date(2024, 0, 16, 12))).toBe("2023_12");
   });
 });

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -1,3 +1,5 @@
+import { format, getDate, isValid } from "date-fns";
+
 /**
  * Parses a value to milliseconds since epoch.
  * Accepts numeric timestamps (ms) or date strings (ISO or parseable by Date).
@@ -12,7 +14,7 @@ export const parseDateMs = (value: unknown): number | null => {
   const num = Number(str);
   if (!Number.isNaN(num) && num > 0) return num;
   const date = new Date(str);
-  return Number.isNaN(date.getTime()) ? null : date.getTime();
+  return isValid(date) ? date.getTime() : null;
 };
 
 /**
@@ -44,4 +46,28 @@ export const formatDate = (date: string): string => {
     ).toLocaleDateString();
   }
   return date;
+};
+
+/**
+ * Formats a Planet monthly basemap date as "YYYY_MM".
+ *
+ * @param date - Date to format.
+ * @returns Planet month identifier.
+ */
+export const formatPlanetMonth = (date: Date): string => {
+  return format(date, "yyyy_MM");
+};
+
+/**
+ * Returns the latest available Planet monthly basemap.
+ * The previous month's basemap becomes available after the 15th.
+ *
+ * @param date - Date used to determine availability.
+ * @returns Latest available Planet month identifier.
+ */
+export const getPlanetMaxMonth = (date: Date = new Date()): string => {
+  const monthsToSubtract = getDate(date) <= 15 ? 2 : 1;
+  const maxMonth = new Date(date);
+  maxMonth.setMonth(maxMonth.getMonth() - monthsToSubtract);
+  return formatPlanetMonth(maxMonth);
 };


### PR DESCRIPTION
## Goal

Adopt date-fns as the standard date manipulation library where it improves GC Explorer’s date logic, while preserving existing output and business logic. closes #509 

## Screenshots

N/A -- internal refactor with no UI changes.

## What I changed and why

- Added `date-fns` and used it for date validation, formatting, comparisons, sorting, and month boundaries across shared utilities, alert processing, timestamp filtering, and Planet basemap availability
- Removed the duplicate server-side timestamp parser in favor of the existing shared utility
- Planet's 15th-of-the-month availability rule is preserved as explicit and testable
- Native month rollover semantics are intentionally kept intact since replacing them with `date-fns` month subtraction would change output for month-end dates
- 
## How I convinced myself this is right

I compared the previous and refactored Planet calculations for every calendar date from 2020 through 2030 and confirmed zero output differences. The timestamp filter retains its existing permissive parsing, alert chart UTC logic remains untouched, output formats remain unchanged, and date-fns replacements use equivalent inclusive comparison and local-calendar behavior.

I also manually compared `explorer.cmistaging...` with the local development changes.

## What I'm not doing here

This does not replace native date usage where date-fns adds no value, including timers, cache expiry, ISO serialization, locale rendering, or the alert chart’s deliberate UTC month iteration. It also leaves the existing string-based `YYYYMM` alert filtering logic unchanged.

## LLM use disclosure

GPT 5.6 Sol helped