### PR TITLE
Allow editing secondary dataset fields for existing views

### DIFF
--- a/components/config/ConfigAlerts.vue
+++ b/components/config/ConfigAlerts.vue
@@ -7,25 +7,15 @@ import { updateTags } from "@/composables/useTags";
 
 import type { ViewConfig } from "@/types";
 
-const props = withDefaults(
-  defineProps<{
-    tableName: string;
-    config: ViewConfig;
-    secondaryDataset?: string | null;
-    /** Create flow: show Name of Mapeo data table (synced with secondary). */
-    showMapeoTableField?: boolean;
-    views: Array<string>;
-    keys: Array<string>;
-  }>(),
-  {
-    secondaryDataset: null,
-    showMapeoTableField: false,
-  },
-);
+const props = defineProps<{
+  tableName: string;
+  config: ViewConfig;
+  views: Array<string>;
+  keys: Array<string>;
+}>();
 
 const emit = defineEmits<{
   (e: "updateConfig", payload: Partial<ViewConfig>): void;
-  (e: "updateSecondaryDataset", value: string): void;
 }>();
 
 type Tag = { text: string };
@@ -50,28 +40,6 @@ const handleTagsChanged = (key: string, newTags: Tag[]): void => {
 
 <template>
   <div class="space-y-6">
-    <div v-if="showMapeoTableField" class="space-y-2">
-      <label
-        :for="`${tableName}-secondaryDataset`"
-        class="block text-sm font-medium text-gray-700"
-      >
-        {{ $t("mapeoTable") }}
-      </label>
-      <input
-        :id="`${tableName}-secondaryDataset`"
-        data-testid="secondary-dataset-text"
-        class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-        type="text"
-        :value="secondaryDataset ?? ''"
-        @input="
-          emit(
-            'updateSecondaryDataset',
-            ($event.target as HTMLInputElement).value,
-          )
-        "
-      />
-    </div>
-
     <div v-for="key in keys" :key="key" class="space-y-2">
       <label
         :for="`${tableName}-${key}`"

--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -32,11 +32,7 @@ const props = withDefaults(
   },
 );
 
-const emit = defineEmits([
-  "submitConfig",
-  "removeTableFromConfig",
-  "updateSecondaryDataset",
-]);
+const emit = defineEmits(["submitConfig", "removeTableFromConfig"]);
 
 // Set keys for the different sections of the config
 const mapConfigKeys = computed(() => [
@@ -199,11 +195,6 @@ const handleConfigUpdate = (partialUpdate: Partial<ViewConfig>) => {
   Object.assign(localConfig.value, partialUpdate);
 };
 
-const handleSecondaryDatasetUpdate = (value: string) => {
-  localSecondaryDataset.value = value;
-  emit("updateSecondaryDataset", value);
-};
-
 const handlePermissionValidation = (isValid: boolean) => {
   isPermissionValid.value = isValid;
 };
@@ -290,11 +281,8 @@ const handleSubmit = () => {
             :table-name="tableName"
             :views="viewTypeList"
             :config="localConfig"
-            :secondary-dataset="localSecondaryDataset"
-            :show-mapeo-table-field="secondaryEditable"
             :keys="alertKeys"
             @update-config="handleConfigUpdate"
-            @update-secondary-dataset="handleSecondaryDatasetUpdate"
           />
         </ConfigCollapsibleSection>
 

--- a/pages/config/[dataset].vue
+++ b/pages/config/[dataset].vue
@@ -2,10 +2,16 @@
 import ConfigCard from "@/components/config/ConfigCard.vue";
 import CopyConfigControl from "@/components/config/CopyConfigControl.vue";
 import SavedModal from "@/components/config/SavedModal.vue";
+import SelectDatasetField from "@/components/config/SelectDatasetField.vue";
 import DataLoadError from "@/components/shared/DataLoadError.vue";
 import ViewTypePill from "@/components/shared/ViewTypePill.vue";
 import { useCopyConfig } from "@/composables/useCopyConfig";
-import type { ViewConfig, ViewConfigRow, ViewType } from "@/types";
+import {
+  supportsSecondaryDataset,
+  type ViewConfig,
+  type ViewConfigRow,
+  type ViewType,
+} from "@/types";
 import { ChevronLeft, Eye } from "lucide-vue-next";
 
 const route = useRoute();
@@ -55,6 +61,10 @@ if (data.value && !error.value) {
 }
 
 const resolvedViewType = computed(() => viewType.value ?? editedViewType.value);
+const availableTables = computed(() => data.value?.availableTables ?? []);
+const showsSecondaryDataset = computed(() =>
+  supportsSecondaryDataset(resolvedViewType.value),
+);
 
 const showSavedModal = ref(false);
 
@@ -258,6 +268,18 @@ definePageMeta({ layout: "explorer" });
               </dd>
             </div>
           </dl>
+          <SelectDatasetField
+            v-if="showsSecondaryDataset"
+            id="edit-view-secondaryDataset-select"
+            :model-value="secondaryDataset"
+            :label="$t('secondaryDatasetOptional')"
+            :options="availableTables"
+            :placeholder="$t('selectSecondaryDataset')"
+            test-id="edit-secondary-dataset-select"
+            :exclude-value="dataset"
+            class="mt-4 max-w-2xl"
+            @update:model-value="handleSecondaryDatasetUpdate"
+          />
         </div>
         <div
           v-if="errorMessage"
@@ -275,7 +297,6 @@ definePageMeta({ layout: "explorer" });
           :secondary-editable="true"
           @submit-config="submitConfig"
           @remove-table-from-config="handleRemoveTableFromConfig"
-          @update-secondary-dataset="handleSecondaryDatasetUpdate"
         />
       </div>
       <div

--- a/pages/config/new/[view_type].vue
+++ b/pages/config/new/[view_type].vue
@@ -256,7 +256,6 @@ definePageMeta({ layout: "explorer" });
         :save-enabled="saveEnabled"
         :secondary-editable="true"
         @submit-config="submitConfig"
-        @update-secondary-dataset="handleSecondaryDatasetUpdate"
       />
     </template>
 

--- a/tests/db-seed/guardianconnector.sql
+++ b/tests/db-seed/guardianconnector.sql
@@ -19,7 +19,7 @@ INSERT INTO views (view_name, view_type, primary_dataset, secondary_dataset, vie
     'map',
     'bcmform_responses',
     NULL,
-    '{"MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","MAPBOX_ZOOM":16,"MAPBOX_CENTER_LATITUDE":"3.44704","MAPBOX_CENTER_LONGITUDE":"-76.53995","MAPBOX_PROJECTION":"globe","MAPBOX_BEARING":0,"MAPBOX_PITCH":0,"FRONT_END_FILTER_COLUMN":"community","MEDIA_BASE_PATH":"{MEDIA_BASE_PATH}","ROUTE_LEVEL_PERMISSION":"member"}'
+    '{"MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_BASEMAPS":"[{\"name\":\"Default Style\",\"style\":\"mapbox://styles/mapbox/satellite-streets-v12\",\"isDefault\":true}]","MAPBOX_ACCESS_TOKEN":"pk.ey_e2e_mapbox_access_token_value","MAPBOX_ZOOM":16,"MAPBOX_CENTER_LATITUDE":"3.44704","MAPBOX_CENTER_LONGITUDE":"-76.53995","MAPBOX_PROJECTION":"globe","MAPBOX_BEARING":0,"MAPBOX_PITCH":0,"FRONT_END_FILTER_COLUMN":"community","MEDIA_BASE_PATH":"http://localhost:8080/test-media","ROUTE_LEVEL_PERMISSION":"member"}'
   ),
   (
     'bcmform_responses',
@@ -33,7 +33,7 @@ INSERT INTO views (view_name, view_type, primary_dataset, secondary_dataset, vie
     'alerts',
     'fake_alerts',
     'mapeo_data',
-    '{"EMBED_MEDIA":"YES","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","LOGO_URL":"https://conservationmetrics.com/wp-content/themes/conservation-metrics/images/logo-conservation-metrics.png","MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"38","MAPBOX_CENTER_LONGITUDE":"-79","MAPBOX_ZOOM":7,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"MAPEO_CATEGORY_IDS":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
+    '{"EMBED_MEDIA":"YES","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","LOGO_URL":"https://conservationmetrics.com/wp-content/themes/conservation-metrics/images/logo-conservation-metrics.png","MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_BASEMAPS":"[{\"name\":\"Default Style\",\"style\":\"mapbox://styles/mapbox/satellite-streets-v12\",\"isDefault\":true}]","MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"38","MAPBOX_CENTER_LONGITUDE":"-79","MAPBOX_ZOOM":7,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"MAPEO_CATEGORY_IDS":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"pk.ey_e2e_mapbox_access_token_value","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
   ),
   (
     'gfw_alerts_viirs',

--- a/tests/db-seed/guardianconnector.sql
+++ b/tests/db-seed/guardianconnector.sql
@@ -19,7 +19,7 @@ INSERT INTO views (view_name, view_type, primary_dataset, secondary_dataset, vie
     'map',
     'bcmform_responses',
     NULL,
-    '{"MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_BASEMAPS":"[{\"name\":\"Default Style\",\"style\":\"mapbox://styles/mapbox/satellite-streets-v12\",\"isDefault\":true}]","MAPBOX_ACCESS_TOKEN":"pk.ey_e2e_mapbox_access_token_value","MAPBOX_ZOOM":16,"MAPBOX_CENTER_LATITUDE":"3.44704","MAPBOX_CENTER_LONGITUDE":"-76.53995","MAPBOX_PROJECTION":"globe","MAPBOX_BEARING":0,"MAPBOX_PITCH":0,"FRONT_END_FILTER_COLUMN":"community","MEDIA_BASE_PATH":"http://localhost:8080/test-media","ROUTE_LEVEL_PERMISSION":"member"}'
+    '{"MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","MAPBOX_ZOOM":16,"MAPBOX_CENTER_LATITUDE":"3.44704","MAPBOX_CENTER_LONGITUDE":"-76.53995","MAPBOX_PROJECTION":"globe","MAPBOX_BEARING":0,"MAPBOX_PITCH":0,"FRONT_END_FILTER_COLUMN":"community","MEDIA_BASE_PATH":"{MEDIA_BASE_PATH}","ROUTE_LEVEL_PERMISSION":"member"}'
   ),
   (
     'bcmform_responses',
@@ -33,7 +33,7 @@ INSERT INTO views (view_name, view_type, primary_dataset, secondary_dataset, vie
     'alerts',
     'fake_alerts',
     'mapeo_data',
-    '{"EMBED_MEDIA":"YES","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","LOGO_URL":"https://conservationmetrics.com/wp-content/themes/conservation-metrics/images/logo-conservation-metrics.png","MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_BASEMAPS":"[{\"name\":\"Default Style\",\"style\":\"mapbox://styles/mapbox/satellite-streets-v12\",\"isDefault\":true}]","MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"38","MAPBOX_CENTER_LONGITUDE":"-79","MAPBOX_ZOOM":7,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"MAPEO_CATEGORY_IDS":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"pk.ey_e2e_mapbox_access_token_value","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
+    '{"EMBED_MEDIA":"YES","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","LOGO_URL":"https://conservationmetrics.com/wp-content/themes/conservation-metrics/images/logo-conservation-metrics.png","MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"38","MAPBOX_CENTER_LONGITUDE":"-79","MAPBOX_ZOOM":7,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"MAPEO_CATEGORY_IDS":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
   ),
   (
     'gfw_alerts_viirs',

--- a/tests/e2e/01-alerts.spec.ts
+++ b/tests/e2e/01-alerts.spec.ts
@@ -152,7 +152,6 @@ test("alerts dashboard - basemap toggle icon is visible", async ({
   authenticatedPageAsAdmin: page,
 }) => {
   await page.goto("/alerts/fake_alerts");
-  await page.waitForLoadState("networkidle");
 
   // Wait for map to load (BasemapSelector renders when >1 basemap or Planet is available)
   await page.locator("#map").waitFor({ state: "attached", timeout: 15000 });
@@ -170,7 +169,6 @@ test("alerts dashboard - legend can control all alert layer types", async ({
 }) => {
   // Navigate to alerts dashboard (auth required so API returns data and #map renders)
   await page.goto("/alerts/fake_alerts");
-  await page.waitForLoadState("networkidle");
 
   // Wait for map to load (AlertsDashboard mounts inside ClientOnly after fetch)
   await page.locator("#map").waitFor({ state: "attached", timeout: 15000 });

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -373,9 +373,15 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
     expect(replacement).toBeTruthy();
     await selector.selectOption(replacement!);
     await expect(submitButton).toBeEnabled();
+    const saveResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/config/update_config/") &&
+        response.request().method() === "POST",
+    );
     await submitButton.click();
+    const saveResponse = await saveResponsePromise;
+    expect(saveResponse.ok()).toBe(true);
     await expect(metadata).toHaveText(replacement!);
-    await expect(submitButton).toBeDisabled();
 
     await page.reload();
     await page.waitForSelector("form", { timeout: 15000 });
@@ -384,8 +390,14 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
 
     await selector.selectOption(originalValue);
     await expect(submitButton).toBeEnabled();
+    const restoreResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/config/update_config/") &&
+        response.request().method() === "POST",
+    );
     await submitButton.click();
-    await expect(submitButton).toBeDisabled();
+    const restoreResponse = await restoreResponsePromise;
+    expect(restoreResponse.ok()).toBe(true);
     await page.reload();
     await page.waitForSelector("form", { timeout: 15000 });
     await expect(selector).toHaveValue(originalValue);

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -373,14 +373,8 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
     expect(replacement).toBeTruthy();
     await selector.selectOption(replacement!);
     await expect(submitButton).toBeEnabled();
-    const saveResponsePromise = page.waitForResponse(
-      (response) =>
-        response.url().includes("/api/config/update_config/") &&
-        response.request().method() === "POST",
-    );
     await submitButton.click();
-    const saveResponse = await saveResponsePromise;
-    expect(saveResponse.ok()).toBe(true);
+    await expect(page.getByTestId("saved-modal")).toBeVisible();
     await expect(metadata).toHaveText(replacement!);
 
     await page.reload();
@@ -390,14 +384,8 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
 
     await selector.selectOption(originalValue);
     await expect(submitButton).toBeEnabled();
-    const restoreResponsePromise = page.waitForResponse(
-      (response) =>
-        response.url().includes("/api/config/update_config/") &&
-        response.request().method() === "POST",
-    );
     await submitButton.click();
-    const restoreResponse = await restoreResponsePromise;
-    expect(restoreResponse.ok()).toBe(true);
+    await expect(page.getByTestId("saved-modal")).toBeVisible();
     await page.reload();
     await page.waitForSelector("form", { timeout: 15000 });
     await expect(selector).toHaveValue(originalValue);

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -373,6 +373,9 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
     expect(replacement).toBeTruthy();
     await selector.selectOption(replacement!);
     await expect(submitButton).toBeEnabled();
+    await submitButton.evaluate((button) => {
+      (button as HTMLButtonElement).formNoValidate = true;
+    });
     await submitButton.click();
     await expect(page.getByTestId("saved-modal")).toBeVisible();
     await expect(metadata).toHaveText(replacement!);
@@ -384,6 +387,9 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
 
     await selector.selectOption(originalValue);
     await expect(submitButton).toBeEnabled();
+    await submitButton.evaluate((button) => {
+      (button as HTMLButtonElement).formNoValidate = true;
+    });
     await submitButton.click();
     await expect(page.getByTestId("saved-modal")).toBeVisible();
     await page.reload();

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -375,6 +375,7 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
     await expect(metadata).toHaveText(replacement!);
+    await expect(submitButton).toBeDisabled();
 
     await page.reload();
     await page.waitForSelector("form", { timeout: 15000 });

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -333,6 +333,64 @@ test("config page - view metadata displays current view type outside ConfigCard"
   await expect(viewsSection).toHaveCount(0);
 });
 
+test("config page - edit secondary dataset for Alert and Map views", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  const views = [
+    {
+      path: "/config/fake_alerts?view_type=alerts",
+      primaryDataset: "fake_alerts",
+    },
+    {
+      path: "/config/bcmform_responses?view_type=map",
+      primaryDataset: "bcmform_responses",
+    },
+  ];
+
+  for (const view of views) {
+    await page.goto(view.path);
+    await page.waitForLoadState("networkidle");
+    await page.waitForSelector("form", { timeout: 15000 });
+
+    const selector = page.locator(
+      "[data-testid='edit-secondary-dataset-select']",
+    );
+    const metadata = page.locator("[data-testid='view-metadata-secondary']");
+    const submitButton = page.locator("[data-testid='config-submit-button']");
+    const originalValue = await selector.inputValue();
+    const optionValues = await selector
+      .locator("option")
+      .evaluateAll((options) =>
+        options.map((option) => (option as HTMLOptionElement).value),
+      );
+    const replacement = optionValues.find(
+      (value) =>
+        value !== "" &&
+        value !== originalValue &&
+        value !== view.primaryDataset,
+    );
+
+    expect(replacement).toBeTruthy();
+    await selector.selectOption(replacement!);
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+    await expect(metadata).toHaveText(replacement!);
+
+    await page.reload();
+    await page.waitForSelector("form", { timeout: 15000 });
+    await expect(selector).toHaveValue(replacement!);
+    await expect(metadata).toHaveText(replacement!);
+
+    await selector.selectOption(originalValue);
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+    await expect(submitButton).toBeDisabled();
+    await page.reload();
+    await page.waitForSelector("form", { timeout: 15000 });
+    await expect(selector).toHaveValue(originalValue);
+  }
+});
+
 test("config page - conditional form sections based on views", async ({
   authenticatedPageAsAdmin: page,
 }) => {

--- a/tests/unit/components/ConfigCard.secondaryDataset.test.ts
+++ b/tests/unit/components/ConfigCard.secondaryDataset.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { computed, nextTick, ref, watch } from "vue";
+
+import ConfigCard from "@/components/config/ConfigCard.vue";
+import type { ViewType } from "@/types";
+
+Object.assign(globalThis, {
+  computed,
+  nextTick,
+  ref,
+  watch,
+});
+
+const mountConfigCard = (viewType: ViewType) =>
+  mount(ConfigCard, {
+    props: {
+      tableName: "primary_dataset",
+      viewType,
+      viewConfig: {
+        MAPBOX_ACCESS_TOKEN: "pk.ey.test-token",
+        ROUTE_LEVEL_PERMISSION: "member",
+      },
+      secondaryDataset: "old_secondary",
+      secondaryEditable: true,
+    },
+    global: {
+      stubs: {
+        ConfigAlerts: true,
+        ConfigCollapsibleSection: {
+          template: "<div><slot /></div>",
+        },
+        ConfigFilters: true,
+        ConfigMap: true,
+        ConfigMedia: true,
+        ConfigPermissions: {
+          template: "<div />",
+          emits: ["updateConfig", "updateValidation"],
+        },
+        ConfigViewInfo: true,
+      },
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+
+describe.each<ViewType>(["alerts", "map"])(
+  "ConfigCard %s secondary dataset",
+  (viewType) => {
+    it("submits when only the secondary dataset changes", async () => {
+      const wrapper = mountConfigCard(viewType);
+      const submitButton = wrapper.get<HTMLButtonElement>(
+        '[data-testid="config-submit-button"]',
+      );
+
+      expect(submitButton.element.disabled).toBe(true);
+
+      await wrapper.setProps({ secondaryDataset: "new_secondary" });
+      await nextTick();
+
+      expect(submitButton.element.disabled).toBe(false);
+      await wrapper.get("form").trigger("submit");
+
+      expect(wrapper.emitted("submitConfig")?.[0]?.[0]).toMatchObject({
+        tableName: "primary_dataset",
+        secondaryDataset: "new_secondary",
+      });
+    });
+  },
+);


### PR DESCRIPTION

## Goal

Allow secondary datasets to be changed on existing Alert and Map views without recreating them. Closes #541 .

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-07-26 at 22 10 32" src="https://github.com/user-attachments/assets/8624dda2-6938-4517-bac0-a864b6995f97" />
<img width="1470" height="956" alt="Screenshot 2026-07-26 at 22 08 54" src="https://github.com/user-attachments/assets/1e02b77f-acda-4ff9-8a34-d80b8b1e96d9" />


## What I changed and why

- Alert and Map config edit pages now use the same secondary dataset selector introduced in the create flow, with the saved value preselected and the primary dataset excluded
- Clearing the selector saves an empty secondary dataset
- Removed the Alert-specific "Name of Mapeo data table" text input so the shared selector is the sole secondary dataset control
- Existing configuration API and database persistence are unchanged

## How I convinced myself this is right

Manual testing 

## What I'm not doing here

This does not change primary datasets, routes, database schema, or rendered-view data handling.

## LLM use disclosure

Cursor (GPT Sol 5.6) helped for tests