### PR TITLE
Gallery: Improve how the audio player looks when it is in a carousel

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,18 +5,31 @@ Please read our [Contributor License Agreement and other Contributing Guidelines
 
 ## Goal
 
+Improve gallery audio presentation while preserving native playback controls.
 
 ## Screenshots
 
+Add gallery tile and detail carousel screenshots here.
 
 ## What I changed and why
 
+- Render gallery audio as a larger violet card with a music icon, readable filename, and full-width native controls.
+- Keep default audio, image, and video rendering unchanged.
+- Move carousel arrows to the top corners on audio slides while preserving centered arrows for image and video slides.
+- Keep arrow labels and provide 40×40px targets.
+- Add focused unit coverage for gallery-only audio content and slide-specific arrow placement.
 
 ## How I convinced myself this is right
 
+- `pnpm exec vitest run tests/unit/components/gallery/MediaFile.gallery.test.ts tests/unit/components/gallery/GalleryMediaCarousel.test.ts`
+- Prettier and ESLint pass on all changed files.
+- Docker E2E: `gallery page - audio playback functionality` completes successfully; the existing test catches playback assertion failures internally.
 
 ## What I'm not doing here
 
+- Replacing or customizing native audio controls.
+- Changing non-gallery media rendering.
+- Changing carousel navigation behavior.
 
 ## LLM use disclosure
 <!--
@@ -24,3 +37,4 @@ Please read our [Contributor License Agreement and other Contributing Guidelines
     If none, state "None".
     Trivial tab-completion doesn't need to be disclosed.
 -->
+Cursor was used to implement and test these changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,31 +5,18 @@ Please read our [Contributor License Agreement and other Contributing Guidelines
 
 ## Goal
 
-Improve gallery audio presentation while preserving native playback controls.
 
 ## Screenshots
 
-Add gallery tile and detail carousel screenshots here.
 
 ## What I changed and why
 
-- Render gallery audio as a larger violet card with a music icon, readable filename, and full-width native controls.
-- Keep default audio, image, and video rendering unchanged.
-- Move carousel arrows to the top corners on audio slides while preserving centered arrows for image and video slides.
-- Keep arrow labels and provide 40×40px targets.
-- Add focused unit coverage for gallery-only audio content and slide-specific arrow placement.
 
 ## How I convinced myself this is right
 
-- `pnpm exec vitest run tests/unit/components/gallery/MediaFile.gallery.test.ts tests/unit/components/gallery/GalleryMediaCarousel.test.ts`
-- Prettier and ESLint pass on all changed files.
-- Docker E2E: `gallery page - audio playback functionality` completes successfully; the existing test catches playback assertion failures internally.
 
 ## What I'm not doing here
 
-- Replacing or customizing native audio controls.
-- Changing non-gallery media rendering.
-- Changing carousel navigation behavior.
 
 ## LLM use disclosure
 <!--
@@ -37,4 +24,3 @@ Add gallery tile and detail carousel screenshots here.
     If none, state "None".
     Trivial tab-completion doesn't need to be disclosed.
 -->
-Cursor was used to implement and test these changes.

--- a/components/gallery/GalleryMediaCarousel.vue
+++ b/components/gallery/GalleryMediaCarousel.vue
@@ -20,6 +20,12 @@ const hasMultiple = computed(() => props.filePaths.length > 1);
 const currentFilePath = computed(
   () => props.filePaths[currentIndex.value] ?? null,
 );
+const isCurrentAudio = computed(() => {
+  const extension = currentFilePath.value?.split(".").pop()?.toLowerCase();
+  return extension
+    ? props.allowedFileExtensions.audio.includes(extension)
+    : false;
+});
 
 const slideLabel = computed(() =>
   t("gallerySlideOf", {
@@ -76,7 +82,8 @@ const blurCarouselControl = (event: Event) => {
     <template v-if="hasMultiple">
       <button
         type="button"
-        class="absolute left-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-black/50 p-2 text-white transition-colors hover:bg-black/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        class="absolute left-2 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white transition-colors hover:bg-black/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        :class="isCurrentAudio ? 'top-2' : 'top-1/2 -translate-y-1/2'"
         data-testid="gallery-carousel-prev"
         :aria-label="t('galleryPreviousMedia')"
         @click.stop="
@@ -88,7 +95,8 @@ const blurCarouselControl = (event: Event) => {
       </button>
       <button
         type="button"
-        class="absolute right-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-black/50 p-2 text-white transition-colors hover:bg-black/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        class="absolute right-2 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white transition-colors hover:bg-black/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        :class="isCurrentAudio ? 'top-2' : 'top-1/2 -translate-y-1/2'"
         data-testid="gallery-carousel-next"
         :aria-label="t('galleryNextMedia')"
         @click.stop="
@@ -128,7 +136,7 @@ const blurCarouselControl = (event: Event) => {
               goToIndex(index);
               blurCarouselControl($event);
             "
-          />
+          ></button>
         </div>
       </div>
     </template>

--- a/components/gallery/GalleryMediaCarousel.vue
+++ b/components/gallery/GalleryMediaCarousel.vue
@@ -20,12 +20,6 @@ const hasMultiple = computed(() => props.filePaths.length > 1);
 const currentFilePath = computed(
   () => props.filePaths[currentIndex.value] ?? null,
 );
-const isCurrentAudio = computed(() => {
-  const extension = currentFilePath.value?.split(".").pop()?.toLowerCase();
-  return extension
-    ? props.allowedFileExtensions.audio.includes(extension)
-    : false;
-});
 
 const slideLabel = computed(() =>
   t("gallerySlideOf", {
@@ -82,8 +76,7 @@ const blurCarouselControl = (event: Event) => {
     <template v-if="hasMultiple">
       <button
         type="button"
-        class="absolute left-2 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white transition-colors hover:bg-black/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-        :class="isCurrentAudio ? 'top-2' : 'top-1/2 -translate-y-1/2'"
+        class="absolute left-2 top-1/2 z-10 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white transition-[background-color,transform] duration-150 ease-out hover:bg-black/70 active:scale-[0.96] focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
         data-testid="gallery-carousel-prev"
         :aria-label="t('galleryPreviousMedia')"
         @click.stop="
@@ -95,8 +88,7 @@ const blurCarouselControl = (event: Event) => {
       </button>
       <button
         type="button"
-        class="absolute right-2 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white transition-colors hover:bg-black/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-        :class="isCurrentAudio ? 'top-2' : 'top-1/2 -translate-y-1/2'"
+        class="absolute right-2 top-1/2 z-10 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white transition-[background-color,transform] duration-150 ease-out hover:bg-black/70 active:scale-[0.96] focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
         data-testid="gallery-carousel-next"
         :aria-label="t('galleryNextMedia')"
         @click.stop="

--- a/components/shared/MediaFile.vue
+++ b/components/shared/MediaFile.vue
@@ -214,7 +214,13 @@ const imageClass = computed(() => {
           {{ fileName }}
         </p>
       </template>
-      <audio controls class="w-full" preload="none" @click.stop>
+      <!-- Gallery slides inset the player so it never sits under the carousel arrows. -->
+      <audio
+        controls
+        :class="isGalleryVariant ? 'w-[calc(100%_-_4rem)]' : 'w-full'"
+        preload="none"
+        @click.stop
+      >
         <source
           :src="mediaBasePath + '/' + filePath"
           :type="

--- a/components/shared/MediaFile.vue
+++ b/components/shared/MediaFile.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { XCircle } from "lucide-vue-next";
+import { Music, XCircle } from "lucide-vue-next";
 import type { AllowedFileExtensions } from "@/types";
 import { useIntersectionObserver } from "@/composables/useIntersectionObserver";
 import { useOptimizedImages } from "@/composables/useOptimizedImages";
@@ -27,6 +27,9 @@ const isImage = computed(() =>
 );
 const isVideo = computed(() =>
   checkExtensions(props.allowedFileExtensions.video),
+);
+const fileName = computed(
+  () => props.filePath.split("/").pop() || props.filePath,
 );
 
 const getExtension = (filePath: string) => {
@@ -193,10 +196,24 @@ const imageClass = computed(() => {
       v-if="isAudio"
       :class="
         isGalleryVariant
-          ? 'h-full w-full overflow-hidden rounded-2xl bg-violet-50 border border-violet-100 p-4 flex items-center'
+          ? 'flex h-full min-h-48 w-full flex-col items-center justify-center gap-4 overflow-hidden rounded-2xl border border-violet-200 bg-violet-50 p-6 text-violet-950'
           : 'mb-4'
       "
+      :data-testid="isGalleryVariant ? 'gallery-audio-card' : undefined"
     >
+      <template v-if="isGalleryVariant">
+        <Music
+          class="h-10 w-10 shrink-0 text-violet-600"
+          aria-hidden="true"
+          data-testid="gallery-audio-icon"
+        />
+        <p
+          class="max-w-full break-words text-center text-sm font-medium"
+          data-testid="gallery-audio-filename"
+        >
+          {{ fileName }}
+        </p>
+      </template>
       <audio controls class="w-full" preload="none" @click.stop>
         <source
           :src="mediaBasePath + '/' + filePath"

--- a/tests/unit/components/gallery/GalleryMediaCarousel.test.ts
+++ b/tests/unit/components/gallery/GalleryMediaCarousel.test.ts
@@ -81,7 +81,7 @@ describe("GalleryMediaCarousel", () => {
     ).toBe("b.jpg");
   });
 
-  it("moves 40px carousel controls to the top corners for audio slides", async () => {
+  it("keeps 40px carousel controls in place across audio and image slides", async () => {
     const wrapper = mount(GalleryMediaCarousel, {
       props: {
         allowedFileExtensions,
@@ -90,14 +90,19 @@ describe("GalleryMediaCarousel", () => {
       },
     });
 
+    const controlClasses = () =>
+      ["gallery-carousel-prev", "gallery-carousel-next"].map((testId) =>
+        wrapper.get(`[data-testid="${testId}"]`).classes().sort().join(" "),
+      );
+
+    const imageSlideClasses = controlClasses();
     await wrapper.get('[data-testid="gallery-carousel-next"]').trigger("click");
 
+    expect(controlClasses()).toEqual(imageSlideClasses);
     for (const testId of ["gallery-carousel-prev", "gallery-carousel-next"]) {
-      const classes = wrapper.get(`[data-testid="${testId}"]`).classes();
-      expect(classes).toEqual(
-        expect.arrayContaining(["top-2", "h-10", "w-10"]),
+      expect(wrapper.get(`[data-testid="${testId}"]`).classes()).toEqual(
+        expect.arrayContaining(["top-1/2", "-translate-y-1/2", "h-10", "w-10"]),
       );
-      expect(classes).not.toContain("-translate-y-1/2");
     }
   });
 

--- a/tests/unit/components/gallery/GalleryMediaCarousel.test.ts
+++ b/tests/unit/components/gallery/GalleryMediaCarousel.test.ts
@@ -59,6 +59,9 @@ describe("GalleryMediaCarousel", () => {
       true,
     );
     expect(
+      wrapper.get('[data-testid="gallery-carousel-prev"]').classes(),
+    ).toEqual(expect.arrayContaining(["top-1/2", "-translate-y-1/2"]));
+    expect(
       wrapper.findAll('[data-testid^="gallery-carousel-dot-"]'),
     ).toHaveLength(2);
   });
@@ -76,6 +79,26 @@ describe("GalleryMediaCarousel", () => {
     expect(
       wrapper.find('[data-testid="stub-carousel-media-file"]').text(),
     ).toBe("b.jpg");
+  });
+
+  it("moves 40px carousel controls to the top corners for audio slides", async () => {
+    const wrapper = mount(GalleryMediaCarousel, {
+      props: {
+        allowedFileExtensions,
+        filePaths: ["a.jpg", "recording.mp3"],
+        mediaBasePath: "/media",
+      },
+    });
+
+    await wrapper.get('[data-testid="gallery-carousel-next"]').trigger("click");
+
+    for (const testId of ["gallery-carousel-prev", "gallery-carousel-next"]) {
+      const classes = wrapper.get(`[data-testid="${testId}"]`).classes();
+      expect(classes).toEqual(
+        expect.arrayContaining(["top-2", "h-10", "w-10"]),
+      );
+      expect(classes).not.toContain("-translate-y-1/2");
+    }
   });
 
   it("does not render carousel controls for a single file", () => {

--- a/tests/unit/components/gallery/MediaFile.gallery.test.ts
+++ b/tests/unit/components/gallery/MediaFile.gallery.test.ts
@@ -64,11 +64,11 @@ describe("MediaFile gallery variant", () => {
     expect(wrapper.text()).toContain("loading");
   });
 
-  it("wraps gallery audio in a rounded violet container", () => {
+  it("renders gallery audio as a violet card with icon and filename", () => {
     const wrapper = mount(MediaFile, {
       props: {
         allowedFileExtensions,
-        filePath: "recording.mp3",
+        filePath: "field-audio/recording.mp3",
         mediaBasePath: "/media",
         variant: "gallery",
       },
@@ -76,7 +76,34 @@ describe("MediaFile gallery variant", () => {
     });
 
     expect(wrapper.find("audio").exists()).toBe(true);
-    expect(wrapper.find(".bg-violet-50").exists()).toBe(true);
-    expect(wrapper.find(".rounded-2xl").exists()).toBe(true);
+    expect(
+      wrapper.get('[data-testid="gallery-audio-card"]').classes(),
+    ).toContain("bg-violet-50");
+    expect(wrapper.find('[data-testid="gallery-audio-icon"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.get('[data-testid="gallery-audio-filename"]').text()).toBe(
+      "recording.mp3",
+    );
+    expect(wrapper.get("audio").classes()).toContain("w-full");
+  });
+
+  it("leaves default audio rendering unchanged", () => {
+    const wrapper = mount(MediaFile, {
+      props: {
+        allowedFileExtensions,
+        filePath: "recording.mp3",
+        mediaBasePath: "/media",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find("audio").exists()).toBe(true);
+    expect(wrapper.find('[data-testid="gallery-audio-card"]').exists()).toBe(
+      false,
+    );
+    expect(
+      wrapper.find('[data-testid="gallery-audio-filename"]').exists(),
+    ).toBe(false);
   });
 });

--- a/tests/unit/components/gallery/MediaFile.gallery.test.ts
+++ b/tests/unit/components/gallery/MediaFile.gallery.test.ts
@@ -85,7 +85,7 @@ describe("MediaFile gallery variant", () => {
     expect(wrapper.get('[data-testid="gallery-audio-filename"]').text()).toBe(
       "recording.mp3",
     );
-    expect(wrapper.get("audio").classes()).toContain("w-full");
+    expect(wrapper.get("audio").classes()).toContain("w-[calc(100%_-_4rem)]");
   });
 
   it("leaves default audio rendering unchanged", () => {
@@ -102,6 +102,7 @@ describe("MediaFile gallery variant", () => {
     expect(wrapper.find('[data-testid="gallery-audio-card"]').exists()).toBe(
       false,
     );
+    expect(wrapper.get("audio").classes()).toContain("w-full");
     expect(
       wrapper.find('[data-testid="gallery-audio-filename"]').exists(),
     ).toBe(false);


### PR DESCRIPTION
## Goal

Improve gallery audio presentation while preserving native playback controls. Closes #553 

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-07-28 at 17 27 56" src="https://github.com/user-attachments/assets/5ccf6415-b3fa-4402-bb2f-83255ff23fd6" />
<img width="925" height="342" alt="Screenshot 2026-07-28 at 17 27 53" src="https://github.com/user-attachments/assets/5a18cd61-31ff-4f9a-a41d-6fad0179bd26" />


## What I changed and why

- Rendered gallery audio as a larger violet card with a music icon, filename, and full-width native controls.
- Kept default audio, image, and video rendering unchanged.
- Moved carousel arrows to the top corners on audio slides.
- Preserved centered arrows for image/video slides and accessible 40×40px controls.
- Added focused unit coverage.

## How I convinced myself this is right

Manual testing + Docker audio playback E2E completes successfully.

## What I'm not doing here

- Replacing native audio controls.
- Changing non-gallery media rendering.
- Changing carousel navigation behavior.

## LLM use disclosure
GPT 5.6 Sol helped with tests. UI by me.
