### PR TITLE
Support authStrategy=none with a local Admin session (quality-of-life DX improvement)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,11 @@ NUXT_DB_SSL=true
 # ==========================================
 # Authentication
 # ==========================================
-# Available auth strategy options: auth0 or none
-NUXT_PUBLIC_AUTH_STRATEGY="auth0"
+# auth0 — Auth0 login + RBAC (use in production or locally when working on auth/RBAC)
+# none  — skip Auth0, seeds a local Admin session (recommended for everyday local/dev)
+NUXT_PUBLIC_AUTH_STRATEGY="none"
 
-# Auth0 credentials (if using auth0 strategy)
+# Auth0 credentials (required when NUXT_PUBLIC_AUTH_STRATEGY=auth0)
 NUXT_OAUTH_AUTH0_DOMAIN=your_auth0_domain
 NUXT_OAUTH_AUTH0_CLIENT_ID=your_client_id
 NUXT_OAUTH_AUTH0_CLIENT_SECRET=your_client_secret

--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ NUXT_DB_SSL=true
 # ==========================================
 # auth0 — Auth0 login + RBAC (use in production or locally when working on auth/RBAC)
 # none  — skip Auth0, seeds a local Admin session (recommended for everyday local/dev)
-NUXT_PUBLIC_AUTH_STRATEGY="none"
+NUXT_PUBLIC_AUTH_STRATEGY="auth0"
 
 # Auth0 credentials (required when NUXT_PUBLIC_AUTH_STRATEGY=auth0)
 NUXT_OAUTH_AUTH0_DOMAIN=your_auth0_domain

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To get started, copy `.env.example` to `.env` and add your database and table in
 **Authentication strategy:** GuardianConnector Explorer supports three different authentication strategies: auth0, password (from an environmental var) with JWT key, or none. Set your authentication strategy in `NUXT_PUBLIC_AUTH_STRATEGY`.
 
 - If you are using an auth0 strategy, then you need to provide a domain, client ID, client secret, audience, and base URL.
+- If set to "none", the application will run in local/dev mode with a local Admin session seeded by the `local-auth` middleware.
 
 **Nuxt App API key:** Generate an API key to add to request headers made by the Nuxt front end. You can generate one by running `openssl rand -base64 42`.
 

--- a/middleware/oauth.global.ts
+++ b/middleware/oauth.global.ts
@@ -11,6 +11,12 @@ export default defineNuxtRouteMiddleware(async (to) => {
   } = useRuntimeConfig();
   const router = useRouter();
 
+  // Local/dev bypass when authStrategy is set to "none"
+  if (authStrategy === "none") {
+    if (to.path === "/login") return router.push("/");
+    return;
+  }
+
   // In order to redirect the user back to the page they were on when unauthenticated, we need to store the redirect url in session storage
   // We use the window object to get where the user was before they were redirected to the login page
   // Store it in the session storage and in the Auth0 component we grab and redirect

--- a/server/middleware/local-auth.ts
+++ b/server/middleware/local-auth.ts
@@ -3,10 +3,12 @@ import { Role } from "@/types";
 
 /**
  * When NUXT_PUBLIC_AUTH_STRATEGY=none, ensure every request has a local
- * Admin session so route/API RBAC works without Auth0 (local/dev/CI).
+ * Admin session so route/API RBAC works without Auth0.
  */
 export default defineEventHandler(async (event) => {
-  const { public: { authStrategy } } = useRuntimeConfig();
+  const {
+    public: { authStrategy },
+  } = useRuntimeConfig();
   if (authStrategy !== "none") return;
 
   const session = await getUserSession(event);

--- a/server/middleware/local-auth.ts
+++ b/server/middleware/local-auth.ts
@@ -1,0 +1,30 @@
+import type { User } from "@/types";
+import { Role } from "@/types";
+
+/**
+ * When NUXT_PUBLIC_AUTH_STRATEGY=none, ensure every request has a local
+ * Admin session so route/API RBAC works without Auth0 (local/dev/CI).
+ */
+export default defineEventHandler(async (event) => {
+  const { public: { authStrategy } } = useRuntimeConfig();
+  if (authStrategy !== "none") return;
+
+  const session = await getUserSession(event);
+  const typedUser = session.user as User | undefined;
+  if (typedUser?.userRole === Role.Admin) return;
+
+  await setUserSession(event, {
+    user: {
+      auth0: "local-dev@localhost",
+      roles: [
+        {
+          id: "local-admin",
+          name: "Admin",
+          description: "Local development admin (authStrategy=none)",
+        },
+      ],
+      userRole: Role.Admin,
+    },
+    loggedInAt: Date.now(),
+  });
+});

--- a/utils/accessControls.ts
+++ b/utils/accessControls.ts
@@ -38,8 +38,10 @@ export const validatePermissions = async (
   // Public access requires no authentication
   if (permission === "anyone") return;
 
-  // Local/dev: authStrategy=none grants full access (local-auth middleware seeds Admin)
-  const { public: { authStrategy } } = useRuntimeConfig();
+  // Local/dev: authStrategy=none grants full access
+  const {
+    public: { authStrategy },
+  } = useRuntimeConfig();
   if (authStrategy === "none") return;
 
   // Check if user is authenticated

--- a/utils/accessControls.ts
+++ b/utils/accessControls.ts
@@ -38,6 +38,10 @@ export const validatePermissions = async (
   // Public access requires no authentication
   if (permission === "anyone") return;
 
+  // Local/dev: authStrategy=none grants full access (local-auth middleware seeds Admin)
+  const { public: { authStrategy } } = useRuntimeConfig();
+  if (authStrategy === "none") return;
+
   // Check if user is authenticated
   const session = await getUserSession(event);
 


### PR DESCRIPTION
## Goal

Before, we supported `NUXT_PUBLIC_AUTH_STRATEGY=none`, but I think this broke when we introduced RBAC.

Having spent some time working on GC Explorer dev recently, I find it annoying to have to hop through auth0 every single time localhost runtime starts up. 

This PR restores full `authStrategy=none` support by seeding a local Admin session and skipping Auth0 route/API gates, so local dev no longer requires an Auth0 login hop. (But you can of course set `=auth0` if you _are_ working on RBAC related things.)