### PR TITLE
Fix export downloads for Unicode table and column names

### DIFF
--- a/server/api/[table]/export.get.ts
+++ b/server/api/[table]/export.get.ts
@@ -11,6 +11,7 @@ import {
 import { hasValidCoordinates } from "@/utils/geoUtils";
 import { validatePermissions } from "@/utils/accessControls";
 import { escapeCSVValue } from "@/utils/csvUtils";
+import { buildAttachmentContentDisposition } from "@/utils/identifierUtils";
 import { getTableParam } from "@/server/utils/dbHelpers";
 // @ts-expect-error - tokml does not have types
 import tokml from "tokml";
@@ -201,7 +202,7 @@ export default defineEventHandler(async (event: H3Event) => {
       setResponseHeader(
         event,
         "Content-Disposition",
-        `attachment; filename="${table}.csv"`,
+        buildAttachmentContentDisposition(`${table}.csv`),
       );
       return csv;
     }
@@ -216,7 +217,7 @@ export default defineEventHandler(async (event: H3Event) => {
       setResponseHeader(
         event,
         "Content-Disposition",
-        `attachment; filename="${table}.geojson"`,
+        buildAttachmentContentDisposition(`${table}.geojson`),
       );
       return geojson;
     }
@@ -232,7 +233,7 @@ export default defineEventHandler(async (event: H3Event) => {
       setResponseHeader(
         event,
         "Content-Disposition",
-        `attachment; filename="${table}.kml"`,
+        buildAttachmentContentDisposition(`${table}.kml`),
       );
       return kml;
     }

--- a/server/api/[table]/statistics-export.get.ts
+++ b/server/api/[table]/statistics-export.get.ts
@@ -13,6 +13,7 @@ import {
   filterAlertsStatisticsByDateRange,
   statisticsRowsToCsv,
 } from "@/utils/alertsStatistics";
+import { buildAttachmentContentDisposition } from "@/utils/identifierUtils";
 
 import type { H3Event } from "h3";
 import type { AlertsMetadata, DataEntry, ViewType } from "@/types";
@@ -103,7 +104,7 @@ export default defineEventHandler(async (event: H3Event) => {
     setResponseHeader(
       event,
       "Content-Disposition",
-      `attachment; filename="${table}-statistics.csv"`,
+      buildAttachmentContentDisposition(`${table}-statistics.csv`),
     );
     return csv;
   } catch (error) {

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -129,7 +129,8 @@ export const buildViewConfigColumns = (
   };
 };
 
-const VALID_COLUMN_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// Unicode letters/digits/marks (Thai tone marks are Mn) — sql.identifier quotes these.
+const VALID_COLUMN_NAME = /^[\p{L}_][\p{L}\p{N}\p{M}_]*$/u;
 
 /**
  * Normalizes and validates a projection list before a SQL read is built.

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -129,7 +129,7 @@ export const buildViewConfigColumns = (
   };
 };
 
-// Unicode letters/digits/marks (Thai tone marks are Mn) — sql.identifier quotes these.
+// Unicode letters/digits/marks. sql.identifier quotes these.
 const VALID_COLUMN_NAME = /^[\p{L}_][\p{L}\p{N}\p{M}_]*$/u;
 
 /**

--- a/tests/unit/utils/identifierUtils.test.ts
+++ b/tests/unit/utils/identifierUtils.test.ts
@@ -80,7 +80,9 @@ describe("buildAttachmentContentDisposition", () => {
   it("uses ASCII fallback plus RFC 8187 filename* for Thai table names", () => {
     const filename = "comapeo_แม่ยางมิ้น_สำรวจใหม่.csv";
     const header = buildAttachmentContentDisposition(filename);
-    expect(header).toMatch(/^attachment; filename="[^"]+\.csv"; filename\*=UTF-8''/);
+    expect(header).toMatch(
+      /^attachment; filename="[^"]+\.csv"; filename\*=UTF-8''/,
+    );
     expect(header).toContain(encodeURIComponent(filename));
     expect(header).not.toMatch(/filename="[^"]*[\u0E00-\u0E7F]/);
   });

--- a/tests/unit/utils/identifierUtils.test.ts
+++ b/tests/unit/utils/identifierUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAttachmentContentDisposition,
   camelToSnake,
   decodeDatasetNameFromUrl,
   encodeDatasetNameForUrl,
@@ -66,6 +67,22 @@ describe("sanitizeFilenameSegment", () => {
 
   it("uses fallback when the label is empty", () => {
     expect(sanitizeFilenameSegment("")).toBe("incident");
+  });
+});
+
+describe("buildAttachmentContentDisposition", () => {
+  it("keeps ASCII filenames in the legacy filename parameter", () => {
+    expect(buildAttachmentContentDisposition("my_table.csv")).toBe(
+      "attachment; filename=\"my_table.csv\"; filename*=UTF-8''my_table.csv",
+    );
+  });
+
+  it("uses ASCII fallback plus RFC 8187 filename* for Thai table names", () => {
+    const filename = "comapeo_แม่ยางมิ้น_สำรวจใหม่.csv";
+    const header = buildAttachmentContentDisposition(filename);
+    expect(header).toMatch(/^attachment; filename="[^"]+\.csv"; filename\*=UTF-8''/);
+    expect(header).toContain(encodeURIComponent(filename));
+    expect(header).not.toMatch(/filename="[^"]*[\u0E00-\u0E7F]/);
   });
 });
 

--- a/utils/identifierUtils.ts
+++ b/utils/identifierUtils.ts
@@ -61,6 +61,22 @@ export const sanitizeFilenameSegment = (
 };
 
 /**
+ * Builds a Content-Disposition attachment header safe for Unicode filenames.
+ * Node rejects non-Latin-1 header values; RFC 8187 `filename*` carries the real name
+ * while `filename` stays ASCII for legacy clients.
+ *
+ * @param filename - Download filename including extension (may contain Unicode).
+ * @returns Header value for Content-Disposition.
+ */
+export const buildAttachmentContentDisposition = (filename: string): string => {
+  const lastDot = filename.lastIndexOf(".");
+  const base = lastDot > 0 ? filename.slice(0, lastDot) : filename;
+  const ext = lastDot > 0 ? filename.slice(lastDot) : "";
+  const asciiName = `${sanitizeFilenameSegment(base, 120, "download")}${ext}`;
+  return `attachment; filename="${asciiName}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+};
+
+/**
  * Converts CamelCase to snake_case, aligned with gc-scripts-hub
  * `f/common_logic/identifier_utils.py` `camel_to_snake`.
  *


### PR DESCRIPTION
## Goal

D'oh, in working on https://github.com/ConservationMetrics/gc-explorer/pull/558, I forgot about export endpoints. Without handling Unicode filenames for Content-Disposition attachment headers, we were getting errors like `FetchError: [GET] "/api/comapeo_%E0%B9%81%E0%B8%A1%E0%B9%88%E0%B8%A2%E0%B8%B2%E0%B8%87%E0%B8%A1%E0%B8%B4%E0%B9%89%E0%B8%99/export?format=geojson&view_type=map&minDate=2025-10-01&maxDate=2026-06-01T03:59:59.999Z`. 

Table decode was fine but Node was rejecting Unicode in Content-Disposition: `Invalid character in header content ["Content-Disposition"]`.

## What I changed and why

So this PR fixes that adding `buildAttachmentContentDisposition()` to build a safe header, and using that in `export.get.ts` and `statistics-export.get.ts`

Also relaxing `VALID_COLUMN_NAME` requirements so tone marks don't fail full table export projections.

## How I convinced myself this is right

Tried it with a real dataset!

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Grok 4.5 did the work after prompting.