### PR TITLE
Improve map intro panel and date filter UX

### DIFF
--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -67,6 +67,9 @@ const props = defineProps<{
   planetApiKey?: string;
   table: string;
   timestampColumn?: string;
+  logoUrl?: string;
+  viewName?: string;
+  viewDescription?: string;
 }>();
 
 /** Safe exaggeration for Mapbox terrain (see {@link resolveTerrainExaggeration}). */
@@ -633,6 +636,10 @@ onBeforeUnmount(() => {
       :show-icons="showIcons"
       :can-toggle-icons="canToggleIcons"
       :loading-icons="loadingIcons"
+      :logo-url="logoUrl"
+      :table-name="table"
+      :view-name="viewName"
+      :view-description="viewDescription"
       @close="handleSidebarClose"
       @toggle-icons="handleToggleIcons"
     />

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -584,7 +584,9 @@ onBeforeUnmount(() => {
     >
       {{ $t("resetMap") }}
     </button>
-    <div class="absolute top-16 sm:top-4 right-14 z-10 flex flex-col gap-0.5">
+    <div
+      class="absolute top-16 sm:top-4 right-14 z-10 flex flex-col gap-0.5 hidden sm:flex"
+    >
       <DataFilter
         v-if="filterColumn"
         :key="`filter-${filterResetKey}`"

--- a/components/map/MapIntroPanel.vue
+++ b/components/map/MapIntroPanel.vue
@@ -45,7 +45,8 @@ const fullDescription = computed(() => props.viewDescription?.trim() || "");
         />
         <h2
           v-if="displayName"
-          class="text-2xl font-semibold tracking-tight"
+          class="pr-10 text-2xl font-semibold tracking-tight break-words"
+          style="overflow-wrap: anywhere; word-break: break-word"
           data-testid="map-intro-title"
         >
           {{ displayName }}

--- a/components/map/MapIntroPanel.vue
+++ b/components/map/MapIntroPanel.vue
@@ -16,25 +16,20 @@ const props = defineProps<{
   showIcons?: boolean;
   canToggleIcons?: boolean;
   loadingIcons?: boolean;
+  tableName?: string;
+  viewName?: string;
+  viewDescription?: string;
 }>();
 
 const emit = defineEmits<{
   (e: "toggleIcons"): void;
 }>();
-/** Get data source from first item if available */
-const dataSource = computed(() => {
-  if (props.mapFeatureCollection.features.length === 0) return null;
 
-  const firstProps = props.mapFeatureCollection.features[0].properties;
-  if (!firstProps) return null;
+const displayName = computed(
+  () => props.viewName?.trim() || props.tableName?.trim() || "",
+);
 
-  // Look for a column that contains "data source" (case insensitive)
-  const dataSourceKey = Object.keys(firstProps).find((key) =>
-    key.toLowerCase().includes("data source"),
-  );
-
-  return dataSourceKey ? firstProps[dataSourceKey] : null;
-});
+const fullDescription = computed(() => props.viewDescription?.trim() || "");
 </script>
 
 <template>
@@ -48,9 +43,20 @@ const dataSource = computed(() => {
           alt="Logo"
           loading="eager"
         />
-        <h2 v-if="dataSource" class="text-2xl font-semibold tracking-tight">
-          {{ dataSource }} {{ $t("data") }}
+        <h2
+          v-if="displayName"
+          class="text-2xl font-semibold tracking-tight"
+          data-testid="map-intro-title"
+        >
+          {{ displayName }}
         </h2>
+        <p
+          v-if="fullDescription"
+          class="text-sm text-muted-foreground"
+          data-testid="map-intro-description"
+        >
+          {{ fullDescription }}
+        </p>
         <div class="space-y-2 text-sm text-muted-foreground">
           <p class="italic">🗺️ {{ $t("clickOnFeaturesForMoreInfo") }}.</p>
         </div>

--- a/components/shared/TimestampFilter.vue
+++ b/components/shared/TimestampFilter.vue
@@ -133,6 +133,7 @@ const resetDateRange = () => {
 
 <template>
   <div
+    v-if="dateInfo.options.length > 1"
     class="mb-2 min-w-[325px] max-w-[500px] rounded-xl bg-gray-100 p-2.5 shadow-md"
     data-testid="timestamp-filter"
   >
@@ -153,7 +154,7 @@ const resetDateRange = () => {
         {{ $t("reset") }}
       </button>
     </div>
-    <div v-if="dateInfo.options.length > 0" class="px-2.5 py-2.5 pb-8">
+    <div class="px-2.5 py-2.5 pb-8">
       <VueSlider
         v-model="selectedRange"
         class="mt-2.5 date-slider"
@@ -169,13 +170,6 @@ const resetDateRange = () => {
         data-testid="date-slider"
         @drag-start="userInteracted = true"
       />
-    </div>
-    <div
-      v-else
-      class="py-2.5 italic text-gray-400"
-      data-testid="no-data-message"
-    >
-      {{ $t("noColumnEntry") }}
     </div>
   </div>
 </template>

--- a/components/shared/ViewSidebar.vue
+++ b/components/shared/ViewSidebar.vue
@@ -48,6 +48,9 @@ const props = defineProps<{
   showSlider?: boolean;
   statsExportMinDate?: string;
   statsExportMaxDate?: string;
+  tableName?: string;
+  viewName?: string;
+  viewDescription?: string;
 }>();
 
 const isScrollable = ref(false);
@@ -161,6 +164,9 @@ onBeforeUnmount(() => {
           :show-icons="showIcons"
           :can-toggle-icons="canToggleIcons"
           :loading-icons="loadingIcons"
+          :table-name="tableName"
+          :view-name="viewName"
+          :view-description="viewDescription"
           @toggle-icons="emit('toggle-icons')"
         />
         <div

--- a/components/shared/ViewSidebar.vue
+++ b/components/shared/ViewSidebar.vue
@@ -115,7 +115,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div
-    class="fixed top-0 left-0 h-full w-[400px] bg-white shadow-lg transform transition-transform duration-300 ease-in-out overflow-y-auto z-50 sidebar"
+    class="fixed top-0 left-0 h-full max-w-full w-[400px] bg-white shadow-lg transform transition-transform duration-300 ease-in-out overflow-y-auto z-50 sidebar"
     :class="{ 'translate-x-0': showSidebar, '-translate-x-full': !showSidebar }"
   >
     <div class="relative h-full">

--- a/pages/map/[tablename].vue
+++ b/pages/map/[tablename].vue
@@ -48,6 +48,9 @@ const mediaColumn = ref();
 const planetApiKey = ref();
 const primaryDataset = ref(table);
 const timestampColumn = ref<string | undefined>();
+const logoUrl = ref<string | undefined>();
+const viewName = ref<string | undefined>();
+const viewDescription = ref<string | undefined>();
 
 const { data, error, refresh } = await useFetch(`/api/${tablePath}/map`, {
   params: { limit: rowLimit },
@@ -81,6 +84,9 @@ if (data.value && !error.value) {
   planetApiKey.value = data.value.planetApiKey;
   primaryDataset.value = data.value.primary_dataset;
   timestampColumn.value = data.value.timestampColumn;
+  logoUrl.value = data.value.logoUrl;
+  viewName.value = data.value.viewName;
+  viewDescription.value = data.value.viewDescription;
 } else {
   console.error("Error fetching data:", error.value);
 }
@@ -137,6 +143,9 @@ useHead({
         :planet-api-key="planetApiKey"
         :table="primaryDataset"
         :timestamp-column="timestampColumn"
+        :logo-url="logoUrl"
+        :view-name="viewName"
+        :view-description="viewDescription"
       />
     </ClientOnly>
   </div>

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -99,6 +99,7 @@ export default defineEventHandler(async (event: H3Event) => {
       filterColumn,
       iconColumn,
       timestampColumn: timestampColumn ?? undefined,
+      logoUrl: tableConfig.LOGO_URL,
       mapLegendLayerIds: tableConfig.MAP_LEGEND_LAYER_IDS,
       mapStatistics,
       mapbox3d: tableConfig.MAPBOX_3D ?? false,
@@ -120,6 +121,8 @@ export default defineEventHandler(async (event: H3Event) => {
       planetApiKey: tableConfig.PLANET_API_KEY,
       primary_dataset: primaryTable,
       table: primaryTable,
+      viewDescription: tableConfig.VIEW_DESCRIPTION || undefined,
+      viewName: tableConfig.DATASET_TABLE?.trim() || undefined,
       rowLimitReached: mainData.length >= limit,
       routeLevelPermission: tableConfig.ROUTE_LEVEL_PERMISSION,
     };

--- a/server/dataProcessing/dataTransformers.ts
+++ b/server/dataProcessing/dataTransformers.ts
@@ -11,7 +11,7 @@ import {
   calculateCentroidFromParsedCoords,
   tryParseDataEntryGeoCoordinates,
 } from "@/utils/geoUtils";
-import { formatLocaleDate } from "@/utils/dateUtils";
+import { formatDateOnly, formatLocaleDate } from "@/utils/dateUtils";
 import type {
   AlertsMetadata,
   AlertsPerMonth,
@@ -526,7 +526,9 @@ const prepareMapStatistics = (data: DataEntry[]): MapStatistics => {
       .sort();
 
     if (dates.length > 0) {
-      dateRange = `${dates[0]} to ${dates[dates.length - 1]}`;
+      const start = String(dates[0]);
+      const end = String(dates[dates.length - 1]);
+      dateRange = `${formatDateOnly(start)} to ${formatDateOnly(end)}`;
     }
   }
 

--- a/tests/unit/components/MapIntroPanel.test.ts
+++ b/tests/unit/components/MapIntroPanel.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { computed, ref } from "vue";
+import MapIntroPanel from "@/components/map/MapIntroPanel.vue";
+import type { FeatureCollection } from "geojson";
+
+Object.assign(globalThis, { ref, computed });
+
+vi.mock("@/components/shared/DownloadMapData.vue", () => ({
+  default: { name: "DownloadMapData", template: "<div />" },
+}));
+
+const emptyCollection: FeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
+
+const globalConfig = {
+  mocks: {
+    $t: (key: string) => key,
+    $n: (n: number) => String(n),
+  },
+};
+
+describe("MapIntroPanel", () => {
+  it("shows viewName when provided", () => {
+    const wrapper = mount(MapIntroPanel, {
+      props: {
+        mapStatistics: { totalFeatures: 2 },
+        mapFeatureCollection: emptyCollection,
+        viewName: "Friendly Map",
+        tableName: "raw_table",
+        viewDescription: "Places worth exploring.",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find('[data-testid="map-intro-title"]').text()).toBe(
+      "Friendly Map",
+    );
+    expect(wrapper.find('[data-testid="map-intro-description"]').text()).toBe(
+      "Places worth exploring.",
+    );
+  });
+
+  it("falls back to tableName when viewName is missing", () => {
+    const wrapper = mount(MapIntroPanel, {
+      props: {
+        mapStatistics: { totalFeatures: 1 },
+        mapFeatureCollection: emptyCollection,
+        tableName: "raw_table",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find('[data-testid="map-intro-title"]').text()).toBe(
+      "raw_table",
+    );
+    expect(wrapper.find('[data-testid="map-intro-description"]').exists()).toBe(
+      false,
+    );
+  });
+});

--- a/tests/unit/components/MapView.test.ts
+++ b/tests/unit/components/MapView.test.ts
@@ -859,6 +859,27 @@ describe("MapView component", () => {
     expect(sidebar.props("showIcons")).toBe(false);
   });
 
+  it("passes view name and description to ViewSidebar", async () => {
+    const wrapper = mount(MapView, {
+      props: {
+        ...baseProps,
+        viewName: "Friendly Map",
+        viewDescription: "Places worth exploring.",
+        logoUrl: "https://example.com/logo.png",
+      },
+      global: globalConfig,
+    });
+
+    mapboxMock.fireLoad();
+    await flushPromises();
+
+    const sidebar = wrapper.findComponent({ name: "ViewSidebar" });
+    expect(sidebar.props("viewName")).toBe("Friendly Map");
+    expect(sidebar.props("viewDescription")).toBe("Places worth exploring.");
+    expect(sidebar.props("tableName")).toBe("test_table");
+    expect(sidebar.props("logoUrl")).toBe("https://example.com/logo.png");
+  });
+
   it("handles toggle-icons event from ViewSidebar", async () => {
     const propsWithIcons = {
       ...baseProps,

--- a/tests/unit/components/TimestampFilter.test.ts
+++ b/tests/unit/components/TimestampFilter.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref, computed, watch, nextTick } from "vue";
+import TimestampFilter from "@/components/shared/TimestampFilter.vue";
+import type { Dataset } from "@/types";
+
+Object.assign(globalThis, {
+  ref,
+  computed,
+  watch,
+  nextTick,
+});
+
+vi.mock("vue-3-slider-component", () => ({
+  default: {
+    name: "VueSlider",
+    template: "<div></div>",
+  },
+}));
+
+const mockT = (key: string) => key;
+
+const globalConfig = {
+  mocks: {
+    $t: mockT,
+  },
+};
+
+function mountFilter(data: Dataset, timestampColumn = "timestamp") {
+  return mount(TimestampFilter, {
+    props: { data, timestampColumn },
+    global: globalConfig,
+  });
+}
+
+describe("TimestampFilter component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders when data spans multiple months", () => {
+    const wrapper = mountFilter([
+      { id: "1", timestamp: "2024-01-15T12:00:00Z" },
+      { id: "2", timestamp: "2024-03-01T12:00:00Z" },
+    ] as Dataset);
+
+    expect(wrapper.find('[data-testid="timestamp-filter"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="date-slider"]').exists()).toBe(true);
+  });
+
+  it("hides when all dates fall in a single month", () => {
+    const wrapper = mountFilter([
+      { id: "1", timestamp: "2024-01-05T12:00:00Z" },
+      { id: "2", timestamp: "2024-01-28T12:00:00Z" },
+    ] as Dataset);
+
+    expect(wrapper.find('[data-testid="timestamp-filter"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("hides when there are no valid dates", () => {
+    const wrapper = mountFilter([
+      { id: "1", timestamp: null },
+      { id: "2", timestamp: "not-a-date" },
+    ] as Dataset);
+
+    expect(wrapper.find('[data-testid="timestamp-filter"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("emits full range on mount when multiple months exist", async () => {
+    const wrapper = mountFilter([
+      { id: "1", timestamp: "2024-01-15T12:00:00Z" },
+      { id: "2", timestamp: "2024-02-10T12:00:00Z" },
+    ] as Dataset);
+
+    await nextTick();
+
+    const filterEvents = wrapper.emitted("filter");
+    expect(filterEvents).toBeTruthy();
+    expect(filterEvents!.length).toBeGreaterThanOrEqual(1);
+
+    const [{ start, end }] = filterEvents![0] as [
+      { start: Date; end: Date },
+    ];
+    expect(start.getFullYear()).toBe(2024);
+    expect(start.getMonth()).toBe(0);
+    expect(end.getFullYear()).toBe(2024);
+    expect(end.getMonth()).toBe(1);
+  });
+});

--- a/tests/unit/components/TimestampFilter.test.ts
+++ b/tests/unit/components/TimestampFilter.test.ts
@@ -84,9 +84,7 @@ describe("TimestampFilter component", () => {
     expect(filterEvents).toBeTruthy();
     expect(filterEvents!.length).toBeGreaterThanOrEqual(1);
 
-    const [{ start, end }] = filterEvents![0] as [
-      { start: Date; end: Date },
-    ];
+    const [{ start, end }] = filterEvents![0] as [{ start: Date; end: Date }];
     expect(start.getFullYear()).toBe(2024);
     expect(start.getMonth()).toBe(0);
     expect(end.getFullYear()).toBe(2024);

--- a/tests/unit/dataProcessing/dataTransformers.test.ts
+++ b/tests/unit/dataProcessing/dataTransformers.test.ts
@@ -38,6 +38,25 @@ describe("prepareMapStatistics", () => {
 
     expect(result.dateRange).toBeUndefined();
   });
+
+  it("formats ISO timestamps in date range as yyyy-MM-dd", () => {
+    const result = prepareMapStatistics([
+      {
+        ID: "1",
+        geocoordinates: "[-1.0, 1.0]",
+        geotype: "Point",
+        created_at: "2026-07-23T07:42:48.795Z",
+      },
+      {
+        ID: "2",
+        geocoordinates: "[-1.0, 1.0]",
+        geotype: "Point",
+        created_at: "2026-07-29T03:45:32.260Z",
+      },
+    ]);
+
+    expect(result.dateRange).toBe("2026-07-23 to 2026-07-29");
+  });
 });
 
 describe("prepareAlertsStatistics", () => {

--- a/tests/unit/server/mapEndpointDatasets.test.ts
+++ b/tests/unit/server/mapEndpointDatasets.test.ts
@@ -90,6 +90,9 @@ describe("map endpoint datasets", () => {
       COLOR_COLUMN: "status",
       FRONT_END_FILTER_COLUMN: "category",
       ROUTE_LEVEL_PERMISSION: "anyone",
+      DATASET_TABLE: "Friendly Map Name",
+      VIEW_DESCRIPTION: "A map of interesting places.",
+      LOGO_URL: "https://example.com/logo.png",
     });
     hoisted.fetchViewTables.mockResolvedValue({
       primaryTable: "map_dataset",
@@ -151,6 +154,9 @@ describe("map endpoint datasets", () => {
     });
     expect(response.primary_dataset).toBe("map_dataset");
     expect(response.table).toBe("map_dataset");
+    expect(response.viewName).toBe("Friendly Map Name");
+    expect(response.viewDescription).toBe("A map of interesting places.");
+    expect(response.logoUrl).toBe("https://example.com/logo.png");
     expect(response.data).toEqual({ type: "FeatureCollection", features: [] });
   });
 

--- a/tests/unit/utils/dateUtils.test.ts
+++ b/tests/unit/utils/dateUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 
 import {
   formatDate,
+  formatDateOnly,
   formatLocaleDate,
   formatPlanetMonth,
   getPlanetMaxMonth,
@@ -25,6 +26,19 @@ describe("formatLocaleDate", () => {
   it("should format a date string to a locale date string", () => {
     expect(formatLocaleDate(1, 2024)).toBe("01-2024");
     expect(formatLocaleDate(1, 2024, 1)).toBe("01-01-2024");
+  });
+});
+
+describe("formatDateOnly", () => {
+  it("formats ISO datetimes to yyyy-MM-dd using the UTC calendar day", () => {
+    expect(formatDateOnly("2026-07-23T07:42:48.795Z")).toBe("2026-07-23");
+    expect(formatDateOnly("2026-07-29T03:45:32.260Z")).toBe("2026-07-29");
+  });
+
+  it("leaves plain dates and non-ISO values unchanged", () => {
+    expect(formatDateOnly("2025-01-10")).toBe("2025-01-10");
+    expect(formatDateOnly("3/9/2024")).toBe("3/9/2024");
+    expect(formatDateOnly("not-a-timestamp")).toBe("not-a-timestamp");
   });
 });
 

--- a/tests/unit/utils/geoUtils.test.ts
+++ b/tests/unit/utils/geoUtils.test.ts
@@ -572,4 +572,24 @@ describe("mapStatisticsFromFeatureCollection", () => {
     expect(result.totalFeatures).toBe(2);
     expect(result.dateRange).toBe("2025-01-01 to 2025-01-01");
   });
+
+  it("formats ISO timestamps in dateRange as yyyy-MM-dd", () => {
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [0, 0] },
+          properties: { created_at: "2026-07-23T07:42:48.795Z" },
+        },
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [1, 1] },
+          properties: { created_at: "2026-07-29T03:45:32.260Z" },
+        },
+      ],
+    };
+    const result = mapStatisticsFromFeatureCollection(collection);
+    expect(result.dateRange).toBe("2026-07-23 to 2026-07-29");
+  });
 });

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -1,4 +1,4 @@
-import { format, getDate, isValid } from "date-fns";
+import { format, getDate, isValid, parseISO } from "date-fns";
 
 /**
  * Parses a value to milliseconds since epoch.
@@ -15,6 +15,23 @@ export const parseDateMs = (value: unknown): number | null => {
   if (!Number.isNaN(num) && num > 0) return num;
   const date = new Date(str);
   return isValid(date) ? date.getTime() : null;
+};
+
+/**
+ * Formats ISO datetime strings (containing "T") as yyyy-MM-dd using the UTC
+ * calendar day. Leaves other values unchanged (e.g. "2025-01-10", "3/9/2024").
+ *
+ * @param value - Raw date-like string.
+ * @returns yyyy-MM-dd for ISO datetimes; otherwise the original value.
+ */
+export const formatDateOnly = (value: string): string => {
+  if (!value.includes("T")) return value;
+  const date = parseISO(value);
+  if (!isValid(date)) return value;
+  return format(
+    new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    "yyyy-MM-dd",
+  );
 };
 
 /**

--- a/utils/geoUtils.ts
+++ b/utils/geoUtils.ts
@@ -18,6 +18,7 @@ import { DATA_ENTRY_GEOMETRY_TYPES } from "@/types";
 import murmurhash from "murmurhash";
 
 import { getRandomColor } from "@/utils";
+import { formatDateOnly } from "@/utils/dateUtils";
 
 export interface SpatialDataOptions {
   idField?: string;
@@ -506,7 +507,7 @@ export const mapStatisticsFromFeatureCollection = (
       .sort();
 
     if (dates.length > 0) {
-      dateRange = `${dates[0]} to ${dates[dates.length - 1]}`;
+      dateRange = `${formatDateOnly(dates[0])} to ${formatDateOnly(dates[dates.length - 1])}`;
     }
   }
 


### PR DESCRIPTION
## Goal

While doing screenshares with partners recently, I noticed a few minor things for the `MapView` component (and children) that could be improved. This PR implements them. They are all relatively small so I thought to make this one PR, but happy to cherry pick.

## Screenshots

<img width="395" height="452" alt="image" src="https://github.com/user-attachments/assets/8ce1ae8a-4149-4515-9737-1bbf65d21622" />

_Title and description on `MapIntroPanel`_

<img width="395" height="237" alt="image" src="https://github.com/user-attachments/assets/6efa61d0-0ab1-466b-bcd5-ca1feaf53568" />

_Formatted ISO to YYYY-MM-DD_

## What I changed and why

- https://github.com/ConservationMetrics/gc-explorer/commit/7c0867aaad96f9521b5fa399938e504772709a2c - hide filters in mobile viewports as they take up too much real estate
- https://github.com/ConservationMetrics/gc-explorer/commit/9c096ada5c0dfff5aa9c62cdeb8f7da02be097a0 Add `max-w-full` on Sidebar class, as I noticed on phones the sidebar doesn't adjust to the max width.
- https://github.com/ConservationMetrics/gc-explorer/commit/6f5d7569ff20cbb2b04fa7afb5d7678896d6690c The `TimestampFilter` shows even if there is one date, which makes it pretty useless and actually throws errors in console.
- https://github.com/ConservationMetrics/gc-explorer/commit/d903e1133cac1e200cb7f0c3f5951694ed3c4c1d Sometimes the Date Range is in ISO format and it'd be better for it to be YYYY-MM-DD, this commit uses a helper fn from `date-fns` to improve how we format this in `geoUtils`.
- https://github.com/ConservationMetrics/gc-explorer/commit/e6ff67f68c5e6c69f8daf2c6fa2d476549c422ab - Wiring the dataset view title and description to the `MapIntroPanel`

## How I convinced myself this is right

Testing in runtime, and unit tests.

## What I'm not doing here

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Mix of me, Ctrl-K in Cursor to make quick fixes like Tailwind classes, and Cursor Grok 4.5 for unit test generation.