### PR TITLE
Gallery: add dataset view title and description

### DIFF
--- a/components/GalleryView.vue
+++ b/components/GalleryView.vue
@@ -40,7 +40,14 @@ const props = defineProps<{
   mediaColumn?: string;
   table: string;
   timestampColumn?: string;
+  viewName?: string;
+  viewDescription?: string;
 }>();
+
+const displayName = computed(
+  () => props.viewName?.trim() || props.table?.trim() || "",
+);
+const fullDescription = computed(() => props.viewDescription?.trim() || "");
 
 const { fetchRecords, getCachedRecord, cacheSize } = useRecordCache();
 
@@ -229,6 +236,27 @@ const closeDetail = () => {
       @close="closeDetail"
     />
     <template v-else>
+      <header
+        v-if="displayName || fullDescription"
+        class="mb-4 space-y-1"
+        data-testid="gallery-view-header"
+      >
+        <h1
+          v-if="displayName"
+          class="text-2xl font-semibold tracking-tight text-gray-900 break-words"
+          style="overflow-wrap: anywhere; word-break: break-word"
+          data-testid="gallery-view-title"
+        >
+          {{ displayName }}
+        </h1>
+        <p
+          v-if="fullDescription"
+          class="text-sm text-gray-600"
+          data-testid="gallery-view-description"
+        >
+          {{ fullDescription }}
+        </p>
+      </header>
       <div
         v-if="filterColumn || timestampColumn"
         class="mb-4"

--- a/pages/gallery/[tablename].vue
+++ b/pages/gallery/[tablename].vue
@@ -24,6 +24,8 @@ const mapboxAccessToken = ref<string | undefined>();
 const mapboxStyle = ref<string | undefined>();
 const primaryDataset = ref(table);
 const timestampColumn = ref<string | undefined>();
+const viewName = ref<string | undefined>();
+const viewDescription = ref<string | undefined>();
 
 const { data, error, refresh } = await useFetch(`/api/${table}/gallery`, {
   params: { limit: rowLimit },
@@ -42,6 +44,8 @@ if (data.value && !error.value) {
   mediaColumn.value = data.value.mediaColumn;
   primaryDataset.value = data.value.primary_dataset;
   timestampColumn.value = data.value.timestampColumn;
+  viewName.value = data.value.viewName;
+  viewDescription.value = data.value.viewDescription;
 } else {
   console.error("Error fetching data:", error.value);
 }
@@ -85,6 +89,8 @@ definePageMeta({ layout: "explorer" });
         :media-column="mediaColumn"
         :table="primaryDataset"
         :timestamp-column="timestampColumn"
+        :view-name="viewName"
+        :view-description="viewDescription"
       />
       <div
         v-if="!mediaBasePath && dataFetched"

--- a/server/api/[table]/gallery.ts
+++ b/server/api/[table]/gallery.ts
@@ -127,6 +127,8 @@ export default defineEventHandler(async (event: H3Event) => {
       primary_dataset: primaryTable,
       table: primaryTable,
       timestampColumn: timestampColumn ?? undefined,
+      viewDescription: tableConfig.VIEW_DESCRIPTION || undefined,
+      viewName: tableConfig.DATASET_TABLE?.trim() || undefined,
       rowLimitReached: mainData.length >= limit,
       routeLevelPermission: tableConfig.ROUTE_LEVEL_PERMISSION,
     };

--- a/tests/unit/components/GalleryView.test.ts
+++ b/tests/unit/components/GalleryView.test.ts
@@ -100,6 +100,44 @@ describe("GalleryView empty states", () => {
     filterByDateAndCategoryMock.mockImplementation((data: Dataset) => data);
   });
 
+  it("shows view title and description above the grid", () => {
+    const wrapper = mount(GalleryView, {
+      props: {
+        ...baseProps,
+        galleryData: [{ _id: "1" }] as unknown as Dataset,
+        viewName: " Community gallery ",
+        viewDescription: "Photos and audio from the field.",
+        table: "bcmform_responses",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.get('[data-testid="gallery-view-title"]').text()).toBe(
+      "Community gallery",
+    );
+    expect(wrapper.get('[data-testid="gallery-view-description"]').text()).toBe(
+      "Photos and audio from the field.",
+    );
+  });
+
+  it("falls back to the table name when view title is missing", () => {
+    const wrapper = mount(GalleryView, {
+      props: {
+        ...baseProps,
+        galleryData: [{ _id: "1" }] as unknown as Dataset,
+        table: "bcmform_responses",
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.get('[data-testid="gallery-view-title"]').text()).toBe(
+      "bcmform_responses",
+    );
+    expect(
+      wrapper.find('[data-testid="gallery-view-description"]').exists(),
+    ).toBe(false);
+  });
+
   it("shows galleryEmpty when gallery has no items", () => {
     const wrapper = mount(GalleryView, {
       props: {

--- a/tests/unit/server/galleryEndpointDatasets.test.ts
+++ b/tests/unit/server/galleryEndpointDatasets.test.ts
@@ -108,4 +108,21 @@ describe("gallery endpoint datasets", () => {
     expect(response.table).toBe("gallery_dataset");
     expect(response.data).toEqual([{ _id: "record-1", photo: "one.jpg" }]);
   });
+
+  it("returns view title and description from the view config", async () => {
+    hoisted.fetchTableConfig.mockResolvedValue({
+      MEDIA_BASE_PATH: "/media",
+      MEDIA_COLUMN: "photo",
+      ROUTE_LEVEL_PERMISSION: "anyone",
+      DATASET_TABLE: " Community photos ",
+      VIEW_DESCRIPTION: "Field media from the survey.",
+    });
+
+    const response = await handleGalleryRequest({
+      context: { params: { table: "route_gallery" } },
+    });
+
+    expect(response.viewName).toBe("Community photos");
+    expect(response.viewDescription).toBe("Field media from the survey.");
+  });
 });


### PR DESCRIPTION

## Goal

Show the dataset view title and description at the top of the gallery. Closes #562 

## Screenshots
<img width="1470" height="956" alt="Screenshot 2026-08-05 at 12 46 09" src="https://github.com/user-attachments/assets/8440f4ca-6010-4302-88a7-e70230b5bbd6" />



## What I changed and why

- Return `viewName` and `viewDescription` from `/api/.../gallery` from view config.
- Pass them through `pages/gallery/[tablename].vue` into `GalleryView`.
- Render a simple top header (title preferred, else table name; optional description).

## How I convinced myself this is right

Manual verification 

## What I'm not doing here

Anything extrenous 

## LLM use disclosure

Cursor.