### PR TITLE
Rename gallery Image details to Media details

### DIFF
--- a/components/gallery/GalleryDetailPanel.vue
+++ b/components/gallery/GalleryDetailPanel.vue
@@ -59,7 +59,7 @@ onBeforeUnmount(() => {
           id="gallery-detail-title"
           class="text-lg font-semibold text-gray-900 sm:text-xl"
         >
-          {{ $t("galleryImageDetails") }}
+          {{ $t("galleryMediaDetails") }}
         </h2>
         <button
           type="button"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -99,7 +99,7 @@
   "galleryEmpty": "There are no items to show in this gallery yet.",
   "galleryFiles": "Files",
   "galleryGoToSlide": "Go to slide {number} of {total}",
-  "galleryImageDetails": "Image details",
+  "galleryImageDetails": "Media details",
   "galleryLocation": "Location",
   "galleryNextMedia": "Next media",
   "galleryPreviousMedia": "Previous media",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -99,7 +99,7 @@
   "galleryEmpty": "There are no items to show in this gallery yet.",
   "galleryFiles": "Files",
   "galleryGoToSlide": "Go to slide {number} of {total}",
-  "galleryImageDetails": "Media details",
+  "galleryMediaDetails": "Media details",
   "galleryLocation": "Location",
   "galleryNextMedia": "Next media",
   "galleryPreviousMedia": "Previous media",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -96,7 +96,7 @@
   "galleryEmpty": "Aún no hay elementos que mostrar en esta galería.",
   "galleryFiles": "Archivos",
   "galleryGoToSlide": "Ir a la diapositiva {number} de {total}",
-  "galleryImageDetails": "Detalles de la imagen",
+  "galleryImageDetails": "Detalles del medio",
   "galleryLocation": "Ubicación",
   "galleryNextMedia": "Medio siguiente",
   "galleryPreviousMedia": "Medio anterior",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -96,7 +96,7 @@
   "galleryEmpty": "Aún no hay elementos que mostrar en esta galería.",
   "galleryFiles": "Archivos",
   "galleryGoToSlide": "Ir a la diapositiva {number} de {total}",
-  "galleryImageDetails": "Detalles del medio",
+  "galleryMediaDetails": "Detalles del medio",
   "galleryLocation": "Ubicación",
   "galleryNextMedia": "Medio siguiente",
   "galleryPreviousMedia": "Medio anterior",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -97,7 +97,7 @@
   "galleryEmpty": "Er zijn nog geen items om in deze galerij te tonen.",
   "galleryFiles": "Bestanden",
   "galleryGoToSlide": "Ga naar dia {number} van {total}",
-  "galleryImageDetails": "Afbeeldingsdetails",
+  "galleryImageDetails": "Mediadetails",
   "galleryLocation": "Locatie",
   "galleryNextMedia": "Volgende media",
   "galleryPreviousMedia": "Vorige media",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -97,7 +97,7 @@
   "galleryEmpty": "Er zijn nog geen items om in deze galerij te tonen.",
   "galleryFiles": "Bestanden",
   "galleryGoToSlide": "Ga naar dia {number} van {total}",
-  "galleryImageDetails": "Mediadetails",
+  "galleryMediaDetails": "Mediadetails",
   "galleryLocation": "Locatie",
   "galleryNextMedia": "Volgende media",
   "galleryPreviousMedia": "Vorige media",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -96,7 +96,7 @@
   "galleryEmpty": "Ainda não há itens para mostrar nesta galeria.",
   "galleryFiles": "Arquivos",
   "galleryGoToSlide": "Ir para o slide {number} de {total}",
-  "galleryImageDetails": "Detalhes da mídia",
+  "galleryMediaDetails": "Detalhes da mídia",
   "galleryLocation": "Localização",
   "galleryNextMedia": "Mídia seguinte",
   "galleryPreviousMedia": "Mídia anterior",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -96,7 +96,7 @@
   "galleryEmpty": "Ainda não há itens para mostrar nesta galeria.",
   "galleryFiles": "Arquivos",
   "galleryGoToSlide": "Ir para o slide {number} de {total}",
-  "galleryImageDetails": "Detalhes da imagem",
+  "galleryImageDetails": "Detalhes da mídia",
   "galleryLocation": "Localização",
   "galleryNextMedia": "Mídia seguinte",
   "galleryPreviousMedia": "Mídia anterior",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -99,7 +99,7 @@
   "galleryEmpty": "Bado hakuna vipengele vya kuonyesha katika matunzio haya.",
   "galleryFiles": "Faili",
   "galleryGoToSlide": "Nenda kwenye slaidi {number} kati ya {total}",
-  "galleryImageDetails": "Maelezo ya picha",
+  "galleryImageDetails": "Maelezo ya midia",
   "galleryLocation": "Mahali",
   "galleryNextMedia": "Vyombo vya habari vinavyofuata",
   "galleryPreviousMedia": "Vyombo vya habari vilivyotangulia",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -99,7 +99,7 @@
   "galleryEmpty": "Bado hakuna vipengele vya kuonyesha katika matunzio haya.",
   "galleryFiles": "Faili",
   "galleryGoToSlide": "Nenda kwenye slaidi {number} kati ya {total}",
-  "galleryImageDetails": "Maelezo ya midia",
+  "galleryMediaDetails": "Maelezo ya midia",
   "galleryLocation": "Mahali",
   "galleryNextMedia": "Vyombo vya habari vinavyofuata",
   "galleryPreviousMedia": "Vyombo vya habari vilivyotangulia",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -99,7 +99,7 @@
   "galleryEmpty": "ยังไม่มีรายการให้แสดงในแกลเลอรีนี้",
   "galleryFiles": "ไฟล์",
   "galleryGoToSlide": "ไปที่สไลด์ {number} จาก {total}",
-  "galleryImageDetails": "รายละเอียดสื่อ",
+  "galleryMediaDetails": "รายละเอียดสื่อ",
   "galleryLocation": "ตำแหน่ง",
   "galleryNextMedia": "สื่อถัดไป",
   "galleryPreviousMedia": "สื่อก่อนหน้า",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -99,7 +99,7 @@
   "galleryEmpty": "ยังไม่มีรายการให้แสดงในแกลเลอรีนี้",
   "galleryFiles": "ไฟล์",
   "galleryGoToSlide": "ไปที่สไลด์ {number} จาก {total}",
-  "galleryImageDetails": "รายละเอียดรูปภาพ",
+  "galleryImageDetails": "รายละเอียดสื่อ",
   "galleryLocation": "ตำแหน่ง",
   "galleryNextMedia": "สื่อถัดไป",
   "galleryPreviousMedia": "สื่อก่อนหน้า",


### PR DESCRIPTION

## Goal

Rename the detail panel title so it is not image-only language. Closes #507 

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-08-05 at 12 44 18" src="https://github.com/user-attachments/assets/f3066b62-c876-4f8d-abf7-9f34a1f367fd" />


## What I changed and why

- Updated `galleryImageDetails` strings in all locales to “Media details” (and equivalents).

## How I convinced myself this is right

- Grep shows only locales + `GalleryDetailPanel` consumption of the key.
- Locale string spot-check in all 6 files.
- Checked manually 

## What I'm not doing here

- Renaming the i18n key itself.
- Other copy changes in the detail panel.

## LLM use disclosure

Cursor 