### PR TITLE
Add view button shows on empty state

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -226,10 +226,12 @@ definePageMeta({ layout: "explorer" });
 
       <!-- View Type Filter & Add new dataset view -->
       <div
-        v-if="accessibleViews.length"
-        class="flex flex-wrap items-center justify-between gap-3 mb-4"
+        v-if="accessibleViews.length || shouldShowConfigLink"
+        class="flex flex-wrap items-center gap-3 mb-4"
+        :class="accessibleViews.length ? 'justify-between' : 'justify-end'"
       >
         <ViewTypeFilter
+          v-if="accessibleViews.length"
           v-model="activeViewFilter"
           :view-types="availableViewTypes"
         />

--- a/tests/e2e/03-index.spec.ts
+++ b/tests/e2e/03-index.spec.ts
@@ -162,6 +162,40 @@ test("index page - add new dataset view link navigates to create flow", async ({
   await page.waitForURL("**/config/new", { timeout: 10000 });
 });
 
+test("index page - add new dataset view button shown in empty state", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await page.route("**/api/config", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        views: [],
+        availableTables: [],
+        availableGeospatialTables: [],
+      }),
+    });
+  });
+
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("main", { timeout: 15000 });
+
+  await expect(
+    page.getByText(/no views have been configured yet/i),
+  ).toBeVisible({ timeout: 10000 });
+
+  const addButton = page.locator(
+    "main a[data-testid='add-new-dataset-view-button']",
+  );
+  await expect(addButton).toBeVisible({ timeout: 10000 });
+  await expect(addButton).toHaveAttribute("href", "/config/new");
+});
+
 test("index page - view type filter buttons are visible and functional", async ({
   authenticatedPageAsAdmin: page,
 }) => {

--- a/tests/e2e/03-index.spec.ts
+++ b/tests/e2e/03-index.spec.ts
@@ -162,40 +162,6 @@ test("index page - add new dataset view link navigates to create flow", async ({
   await page.waitForURL("**/config/new", { timeout: 10000 });
 });
 
-test("index page - add new dataset view button shown in empty state", async ({
-  authenticatedPageAsAdmin: page,
-}) => {
-  await page.route("**/api/config", async (route) => {
-    if (route.request().method() !== "GET") {
-      await route.continue();
-      return;
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        views: [],
-        availableTables: [],
-        availableGeospatialTables: [],
-      }),
-    });
-  });
-
-  await page.goto("/");
-  await page.waitForLoadState("networkidle");
-  await page.waitForSelector("main", { timeout: 15000 });
-
-  await expect(
-    page.getByText(/no views have been configured yet/i),
-  ).toBeVisible({ timeout: 10000 });
-
-  const addButton = page.locator(
-    "main a[data-testid='add-new-dataset-view-button']",
-  );
-  await expect(addButton).toBeVisible({ timeout: 10000 });
-  await expect(addButton).toHaveAttribute("href", "/config/new");
-});
-
 test("index page - view type filter buttons are visible and functional", async ({
   authenticatedPageAsAdmin: page,
 }) => {

--- a/tests/unit/pages/index.test.ts
+++ b/tests/unit/pages/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import {
   computed,
@@ -94,6 +94,8 @@ const mountIndex = async () => {
 describe("index page empty state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Page always shows the config link when CI is set; clear it so role checks apply.
+    vi.stubEnv("CI", "");
 
     useRuntimeConfigMock.mockReturnValue({
       public: { authStrategy: "none" },
@@ -116,6 +118,10 @@ describe("index page empty state", () => {
     useRouterMock.mockReturnValue({
       replace: vi.fn(),
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("shows add new dataset view button when there are no views", async () => {

--- a/tests/unit/pages/index.test.ts
+++ b/tests/unit/pages/index.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import {
+  computed,
+  defineComponent,
+  h,
+  onMounted,
+  ref,
+  Suspense,
+  watch,
+} from "vue";
+
+const useFetchMock = vi.fn();
+const useRuntimeConfigMock = vi.fn();
+const useUserSessionMock = vi.fn();
+const useToastMock = vi.fn();
+const useI18nMock = vi.fn();
+const useRouteMock = vi.fn();
+const useRouterMock = vi.fn();
+
+Object.assign(globalThis, {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  useFetch: (...args: unknown[]) => useFetchMock(...args),
+  useRuntimeConfig: () => useRuntimeConfigMock(),
+  useUserSession: () => useUserSessionMock(),
+  useToast: () => useToastMock(),
+  useI18n: () => useI18nMock(),
+  useRoute: () => useRouteMock(),
+  useRouter: () => useRouterMock(),
+  useHead: vi.fn(),
+  definePageMeta: vi.fn(),
+});
+
+vi.mock("#imports", () => ({
+  useFetch: (...args: unknown[]) => useFetchMock(...args),
+  useRuntimeConfig: () => useRuntimeConfigMock(),
+  useUserSession: () => useUserSessionMock(),
+  useToast: () => useToastMock(),
+  useI18n: () => useI18nMock(),
+  useRoute: () => useRouteMock(),
+  useRouter: () => useRouterMock(),
+  useHead: vi.fn(),
+  definePageMeta: vi.fn(),
+}));
+
+vi.mock("lucide-vue-next", () => ({
+  Plus: {
+    name: "Plus",
+    template: "<svg data-testid='plus-icon' />",
+  },
+}));
+
+const mountIndex = async () => {
+  // Dynamic import so Nuxt auto-import mocks on globalThis are registered first.
+  const { default: IndexPage } = await import("@/pages/index.vue");
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(Suspense, null, {
+          default: () => h(IndexPage),
+          fallback: () => h("div", { "data-testid": "suspense-fallback" }),
+        });
+    },
+  });
+
+  const wrapper = mount(Wrapper, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+      stubs: {
+        DataLoadError: true,
+        EmptyStateIllustration: {
+          props: ["variant"],
+          template: '<div data-testid="empty-illustration">{{ variant }}</div>',
+        },
+        SearchBar: true,
+        ViewTypeFilter: {
+          template: '<div data-testid="view-type-filter" />',
+        },
+        DatasetCard: true,
+      },
+    },
+  });
+
+  await flushPromises();
+  return wrapper;
+};
+
+describe("index page empty state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useRuntimeConfigMock.mockReturnValue({
+      public: { authStrategy: "none" },
+    });
+    useUserSessionMock.mockReturnValue({
+      loggedIn: ref(true),
+      user: ref({ userRole: 3 }),
+    });
+    useToastMock.mockReturnValue({
+      error: vi.fn(),
+      info: vi.fn(),
+    });
+    useI18nMock.mockReturnValue({
+      t: (key: string) => key,
+    });
+    useRouteMock.mockReturnValue({
+      query: {},
+      path: "/",
+    });
+    useRouterMock.mockReturnValue({
+      replace: vi.fn(),
+    });
+  });
+
+  it("shows add new dataset view button when there are no views", async () => {
+    useFetchMock.mockResolvedValue({
+      data: ref({ views: [], availableTables: [] }),
+      error: ref(null),
+      refresh: vi.fn(),
+    });
+
+    const wrapper = await mountIndex();
+
+    expect(wrapper.text()).toContain("noDatasetViewsAvailable");
+    expect(wrapper.find("[data-testid='view-type-filter']").exists()).toBe(
+      false,
+    );
+
+    const addButton = wrapper.get(
+      "[data-testid='add-new-dataset-view-button']",
+    );
+    expect(addButton.attributes("href")).toBe("/config/new");
+  });
+
+  it("hides add button in empty state when user cannot manage config", async () => {
+    useRuntimeConfigMock.mockReturnValue({
+      public: { authStrategy: "auth0" },
+    });
+    useUserSessionMock.mockReturnValue({
+      loggedIn: ref(true),
+      user: ref({ userRole: 0 }),
+    });
+    useFetchMock.mockResolvedValue({
+      data: ref({ views: [], availableTables: [] }),
+      error: ref(null),
+      refresh: vi.fn(),
+    });
+
+    const wrapper = await mountIndex();
+
+    expect(wrapper.text()).toContain("noDatasetViewsAvailable");
+    expect(
+      wrapper.find("[data-testid='add-new-dataset-view-button']").exists(),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Goal

The Add button was gated on `accessibleViews.length`, so it disappears in the empty state:

<img width="802" height="478" alt="image" src="https://github.com/user-attachments/assets/d177d840-4f91-47af-8ea9-33c2ef8b4c3f" />

## What I changed and why

- `v-if="accessibleViews.length || shouldShowConfigLink"`
- e2e test

## How I convinced myself this is right


## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor