### PR TITLE
Allow leading digit in column projection

### DIFF
--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -129,8 +129,8 @@ export const buildViewConfigColumns = (
   };
 };
 
-// Unicode letters/digits/marks. sql.identifier quotes these.
-const VALID_COLUMN_NAME = /^[\p{L}_][\p{L}\p{N}\p{M}_]*$/u;
+// Unicode letters/digits/marks. sql.identifier quotes these (so leading digits are OK).
+const VALID_COLUMN_NAME = /^[\p{L}\p{N}_][\p{L}\p{N}\p{M}_]*$/u;
 
 /**
  * Normalizes and validates a projection list before a SQL read is built.


### PR DESCRIPTION
## Goal

We are working with a dataset that has columns that start with numbers (i.e. `1_Your_Name`, `2_Date`). Our `normalizeProjectionColumns` rejects this, and really shouldn't - this is valid Postgres column naming.

## What I changed and why

See the one-line code change.

## How I convinced myself this is right

Trying it in runtime.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None