### PR TITLE
Require view_type on delete_table endpoint

### DIFF
--- a/pages/config/[dataset].vue
+++ b/pages/config/[dataset].vue
@@ -147,9 +147,7 @@ const handleConfirmRemove = async () => {
         `/api/config/delete_table/${encodeDatasetNameForUrl(tableNameToRemove.value)}`,
         {
           method: "POST",
-          query: resolvedViewType.value
-            ? { view_type: resolvedViewType.value }
-            : undefined,
+          query: { view_type: resolvedViewType.value },
         },
       );
       // Hide buttons and update message to show success

--- a/server/api/config/delete_table/[table].post.ts
+++ b/server/api/config/delete_table/[table].post.ts
@@ -1,13 +1,12 @@
 import { removeTableFromConfig } from "@/server/database/dbOperations";
-import { getTableParam } from "@/server/utils/dbHelpers";
+import { getTableParam, parseRequiredViewType } from "@/server/utils/dbHelpers";
 import { validatePermissions } from "@/utils/accessControls";
 
 import type { H3Event } from "h3";
-import type { ViewType } from "@/types";
 
 export default defineEventHandler(async (event: H3Event) => {
   const table = getTableParam(event);
-  const viewType = getQuery(event).view_type as ViewType | undefined;
+  const viewType = parseRequiredViewType(getQuery(event).view_type);
 
   try {
     await validatePermissions(event, "admin");
@@ -20,7 +19,13 @@ export default defineEventHandler(async (event: H3Event) => {
         "Error removing table from config on API side:",
         error.message,
       );
-      return sendError(event, new Error(error.message));
+      // Preserve any HTTP metadata set upstream instead of flattening every
+      // failure to a generic 500.
+      const statusCode = (error as { statusCode?: number }).statusCode ?? 500;
+      return sendError(
+        event,
+        createError({ statusCode, statusMessage: error.message }),
+      );
     } else {
       console.error(
         "Unknown error removing table from config on API side:",

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -809,23 +809,27 @@ export const addNewTableToConfig = async (
   }
 };
 
+/**
+ * Deletes the view config row for the given primary dataset and view type.
+ * If that was the dataset's last remaining view, also removes it from public_views.
+ *
+ * @param {string} tableName - Primary dataset / table name.
+ * @param {ViewType} viewType - View type whose config row to delete.
+ * @returns {Promise<void>}
+ */
 export const removeTableFromConfig = async (
   tableName: string,
-  viewType?: ViewType,
+  viewType: ViewType,
 ): Promise<void> => {
   const normalizedTable = normalizeTableName(tableName);
   try {
-    // Delete just the targeted view; without a view type fall back to removing
-    // every view of the dataset.
     await configDb
       .delete(viewConfig)
       .where(
-        viewType
-          ? and(
-              eq(viewConfig.primaryDataset, normalizedTable),
-              eq(viewConfig.viewType, viewType),
-            )
-          : eq(viewConfig.primaryDataset, normalizedTable),
+        and(
+          eq(viewConfig.primaryDataset, normalizedTable),
+          eq(viewConfig.viewType, viewType),
+        ),
       );
 
     // Only drop the dataset's public_views entry once no views remain for it.

--- a/server/utils/dbHelpers.ts
+++ b/server/utils/dbHelpers.ts
@@ -1,9 +1,37 @@
 import { useRuntimeConfig } from "#imports";
 import type { H3Event } from "h3";
+import { VIEW_TYPES, type ViewType } from "@/types";
 import {
   decodeDatasetNameFromUrl,
   normalizeTableName,
 } from "@/utils/identifierUtils";
+
+/**
+ * Validates a raw `view_type` query value as exactly one of alerts, map, or gallery.
+ * Repeated query keys arrive as arrays and are rejected.
+ *
+ * @param {unknown} raw - Raw `view_type` from `getQuery`.
+ * @returns {ViewType} The validated view type.
+ */
+export const parseRequiredViewType = (raw: unknown): ViewType => {
+  if (Array.isArray(raw) || typeof raw !== "string" || raw === "") {
+    throw Object.assign(
+      new Error(
+        "view_type is required and must be a single value: alerts, map, or gallery",
+      ),
+      { statusCode: 400 },
+    );
+  }
+
+  if (!(VIEW_TYPES as readonly string[]).includes(raw)) {
+    throw Object.assign(
+      new Error("view_type must be one of: alerts, map, or gallery"),
+      { statusCode: 400 },
+    );
+  }
+
+  return raw as ViewType;
+};
 
 /**
  * Reads and normalizes the `[table]` path param (percent-decode + strip quotes).

--- a/tests/unit/server/parseRequiredViewType.test.ts
+++ b/tests/unit/server/parseRequiredViewType.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRequiredViewType } from "@/server/utils/dbHelpers";
+
+describe("parseRequiredViewType", () => {
+  it("accepts alerts, map, and gallery", () => {
+    expect(parseRequiredViewType("alerts")).toBe("alerts");
+    expect(parseRequiredViewType("map")).toBe("map");
+    expect(parseRequiredViewType("gallery")).toBe("gallery");
+  });
+
+  it("rejects missing, empty, repeated, and unknown values with status 400", () => {
+    for (const raw of [undefined, "", ["alerts", "map"], "dashboard", 1]) {
+      try {
+        parseRequiredViewType(raw);
+        expect.unreachable(`expected rejection for ${JSON.stringify(raw)}`);
+      } catch (error) {
+        expect(error).toMatchObject({ statusCode: 400 });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Goal

Require `view_type` on dataset-view deletion so only one `(primary_dataset, view_type)` row is removed. Closes #511 


## Screenshots

N/A — API and config only

## What I changed and why

- Delete-table route now validates `view_type` as exactly one of `alerts`, `map`, or `gallery`, rejecting missing, empty, repeated, and unknown values
- `removeTableFromConfig` always deletes by primary dataset and view type together
- Config edit page always sends the resolved view type on delete so the client matches the server contract

## How I convinced myself this is right

Because `view_type` is now required and validated before reaching `removeTableFromConfig`. Deleting one view type only removes that type, and `public_views` is kept until the last view is deleted. The validation is tested directly using the same `400` error format used elsewhere in dbHelpers, without mocking the database or Nitro handler.

## What I'm not doing here

No changes to `update_config` and no cleanup of unrelated config pages.


## LLM use disclosure

Cursor Grok for tests