### PR TITLE
Define view types once (e.g. Nuxt appConfig) and reuse everywhere

### DIFF
--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useAppConfig } from "#imports";
 import {
   supportsSecondaryDataset,
   type ViewConfig,
@@ -8,6 +9,8 @@ import { CONFIG_LIMITS } from "@/utils";
 import ConfigPermissions from "./ConfigPermissions.vue";
 import ConfigCollapsibleSection from "./ConfigCollapsibleSection.vue";
 import { Check, Trash2 } from "lucide-vue-next";
+
+const { viewTypes } = useAppConfig();
 
 const props = withDefaults(
   defineProps<{
@@ -144,10 +147,10 @@ const shouldShowConfigMap = computed(
   () => props.viewType === "alerts" || props.viewType === "map",
 );
 const shouldShowConfigMedia = computed(() =>
-  ["map", "gallery", "alerts"].includes(props.viewType),
+  (viewTypes as readonly ViewType[]).includes(props.viewType),
 );
 const shouldShowConfigFilters = computed(() =>
-  ["map", "gallery", "alerts"].includes(props.viewType),
+  (viewTypes as readonly ViewType[]).includes(props.viewType),
 );
 const shouldUseSecondaryDataset = computed(() =>
   supportsSecondaryDataset(props.viewType),

--- a/composables/useViewType.ts
+++ b/composables/useViewType.ts
@@ -1,3 +1,4 @@
+import { useAppConfig } from "#imports";
 import type { RecordFetchQuery, ViewType } from "@/types";
 import { decodeDatasetNameFromUrl } from "@/utils/identifierUtils";
 
@@ -18,10 +19,22 @@ import { decodeDatasetNameFromUrl } from "@/utils/identifierUtils";
  * `view_id`). Cross-table reads (e.g. alerts page fetching its Mapeo table) omit
  * `view_type` — see guard #1 below.
  */
-const VIEW_TYPE_BY_SEGMENT: Record<string, ViewType> = {
-  map: "map",
-  gallery: "gallery",
-  alerts: "alerts",
+
+/**
+ * Resolves a route path segment to a configured view type, if it matches one.
+ *
+ * @param {string | undefined} segment - First path segment (e.g. "map").
+ * @returns {ViewType | undefined} Matching view type, or undefined if unknown.
+ */
+const viewTypeFromSegment = (
+  segment: string | undefined,
+): ViewType | undefined => {
+  if (!segment) {
+    return undefined;
+  }
+  return (useAppConfig().viewTypes as readonly string[]).includes(segment)
+    ? (segment as ViewType)
+    : undefined;
 };
 
 /**
@@ -47,7 +60,7 @@ export function resolveViewTypeForTable(
   }
   // Guard #2: only known view route prefixes; e.g. /dataset/:tablename → undefined.
   const firstSegment = route.path.split("/").filter(Boolean)[0];
-  return firstSegment ? VIEW_TYPE_BY_SEGMENT[firstSegment] : undefined;
+  return viewTypeFromSegment(firstSegment);
 }
 
 /**
@@ -70,9 +83,7 @@ export const resolveRecordFetchQuery = (
       ? decodeDatasetNameFromUrl(route.params.tablename)
       : undefined;
   const firstSegment = route.path.split("/").filter(Boolean)[0];
-  const routeViewType = firstSegment
-    ? VIEW_TYPE_BY_SEGMENT[firstSegment]
-    : undefined;
+  const routeViewType = viewTypeFromSegment(firstSegment);
 
   if (!primaryDataset || !routeViewType) {
     return {};

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,12 @@
 import { defineNuxtConfig } from "nuxt/config";
 
+export const viewTypes = ["alerts", "map", "gallery"] as const;
+
 export default defineNuxtConfig({
   compatibilityDate: "2025-05-15",
+  appConfig: {
+    viewTypes: [...viewTypes],
+  },
   app: {
     head: {
       charset: "utf-8",

--- a/pages/config/new/[view_type].vue
+++ b/pages/config/new/[view_type].vue
@@ -7,9 +7,9 @@ import DataLoadError from "@/components/shared/DataLoadError.vue";
 import ViewTypePill from "@/components/shared/ViewTypePill.vue";
 import { useCopyConfig } from "@/composables/useCopyConfig";
 import { useDuplicateViewCheck } from "@/composables/useDuplicateViewCheck";
+import { useAppConfig } from "#imports";
 import {
   supportsSecondaryDataset,
-  VIEW_TYPES,
   type ViewConfig,
   type ViewConfigRow,
   type ViewType,
@@ -20,6 +20,7 @@ import { encodeDatasetNameForUrl } from "@/utils/identifierUtils";
 const route = useRoute();
 const { t } = useI18n();
 const { error: showErrorToast } = useToast();
+const { viewTypes } = useAppConfig();
 
 const viewTypeParam = computed(() => {
   const raw = route.params.view_type;
@@ -28,7 +29,7 @@ const viewTypeParam = computed(() => {
 
 const viewType = computed(() => viewTypeParam.value as ViewType);
 const isValidViewType = computed(() =>
-  VIEW_TYPES.some((type) => type === viewType.value),
+  viewTypes.some((type) => type === viewType.value),
 );
 
 if (!isValidViewType.value) {

--- a/pages/config/new/index.vue
+++ b/pages/config/new/index.vue
@@ -1,29 +1,33 @@
 <script setup lang="ts">
+import { useAppConfig } from "#imports";
 import DataLoadError from "@/components/shared/DataLoadError.vue";
 import type { ViewType } from "@/types";
 import { ChevronLeft, Images, Map, TriangleAlert } from "lucide-vue-next";
 
-const VIEW_TYPE_OPTIONS: {
-  type: ViewType;
-  icon: typeof Map;
-  descriptionKey: string;
-}[] = [
-  {
-    type: "map",
+const { viewTypes } = useAppConfig();
+
+const VIEW_TYPE_OPTION_META: Record<
+  ViewType,
+  { icon: typeof Map; descriptionKey: string }
+> = {
+  map: {
     icon: Map,
     descriptionKey: "viewDescriptionMap",
   },
-  {
-    type: "gallery",
+  gallery: {
     icon: Images,
     descriptionKey: "viewDescriptionGallery",
   },
-  {
-    type: "alerts",
+  alerts: {
     icon: TriangleAlert,
     descriptionKey: "viewDescriptionAlerts",
   },
-];
+};
+
+const VIEW_TYPE_OPTIONS = viewTypes.map((type) => ({
+  type,
+  ...VIEW_TYPE_OPTION_META[type],
+}));
 
 const { t } = useI18n();
 const selectedViewType = ref<ViewType | null>(null);

--- a/server/utils/dbHelpers.ts
+++ b/server/utils/dbHelpers.ts
@@ -1,31 +1,43 @@
-import { useRuntimeConfig } from "#imports";
+import { useAppConfig, useRuntimeConfig } from "#imports";
 import type { H3Event } from "h3";
-import { VIEW_TYPES, type ViewType } from "@/types";
+import type { ViewType } from "@/types";
 import {
   decodeDatasetNameFromUrl,
   normalizeTableName,
 } from "@/utils/identifierUtils";
 
 /**
- * Validates a raw `view_type` query value as exactly one of alerts, map, or gallery.
+ * Joins configured view types for validation error messages.
+ *
+ * @param {readonly string[]} viewTypes - Configured view type values.
+ * @returns {string} Human-readable list (e.g. "alerts, map, or gallery").
+ */
+const formatViewTypeOptionsText = (viewTypes: readonly string[]): string =>
+  `${viewTypes.slice(0, -1).join(", ")}, or ${viewTypes[viewTypes.length - 1]}`;
+
+/**
+ * Validates a raw `view_type` query value as exactly one of the configured view types.
  * Repeated query keys arrive as arrays and are rejected.
  *
  * @param {unknown} raw - Raw `view_type` from `getQuery`.
  * @returns {ViewType} The validated view type.
  */
 export const parseRequiredViewType = (raw: unknown): ViewType => {
+  const viewTypes = useAppConfig().viewTypes;
+  const viewTypeOptionsText = formatViewTypeOptionsText(viewTypes);
+
   if (Array.isArray(raw) || typeof raw !== "string" || raw === "") {
     throw Object.assign(
       new Error(
-        "view_type is required and must be a single value: alerts, map, or gallery",
+        `view_type is required and must be a single value: ${viewTypeOptionsText}`,
       ),
       { statusCode: 400 },
     );
   }
 
-  if (!(VIEW_TYPES as readonly string[]).includes(raw)) {
+  if (!(viewTypes as readonly string[]).includes(raw)) {
     throw Object.assign(
-      new Error("view_type must be one of: alerts, map, or gallery"),
+      new Error(`view_type must be one of: ${viewTypeOptionsText}`),
       { statusCode: 400 },
     );
   }

--- a/tests/unit/components/ConfigCard.secondaryDataset.test.ts
+++ b/tests/unit/components/ConfigCard.secondaryDataset.test.ts
@@ -3,7 +3,11 @@ import { mount } from "@vue/test-utils";
 import { computed, nextTick, ref, watch } from "vue";
 
 import ConfigCard from "@/components/config/ConfigCard.vue";
-import type { ViewConfig, ViewType } from "@/types";
+import {
+  SECONDARY_DATASET_VIEW_TYPES,
+  type ViewConfig,
+  type ViewType,
+} from "@/types";
 
 Object.assign(globalThis, {
   computed,
@@ -51,7 +55,7 @@ const mountConfigCard = (
     },
   });
 
-describe.each<ViewType>(["alerts", "map"])(
+describe.each<ViewType>([...SECONDARY_DATASET_VIEW_TYPES])(
   "ConfigCard %s secondary dataset",
   (viewType) => {
     it("submits when only the secondary dataset changes", async () => {

--- a/tests/unit/helpers/importsMock.ts
+++ b/tests/unit/helpers/importsMock.ts
@@ -1,11 +1,17 @@
 import { vi } from "vitest";
 
+import { viewTypes } from "../../../nuxt.config";
+
 // Mock the composables used in LoginScreen component
 export const useUserSession = vi.fn(() => ({
   loggedIn: { value: false },
   session: { value: {} },
   user: { value: null },
   fetch: vi.fn(),
+}));
+
+export const useAppConfig = vi.fn(() => ({
+  viewTypes,
 }));
 
 export const useCustomAuth = vi.fn(() => ({

--- a/tests/unit/helpers/importsMock.ts
+++ b/tests/unit/helpers/importsMock.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 
-import { viewTypes } from "../../../nuxt.config";
+import { viewTypes } from "@/nuxt.config";
 
 // Mock the composables used in LoginScreen component
 export const useUserSession = vi.fn(() => ({

--- a/tests/unit/server/parseRequiredViewType.test.ts
+++ b/tests/unit/server/parseRequiredViewType.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import { useAppConfig } from "#imports";
 import { parseRequiredViewType } from "@/server/utils/dbHelpers";
 
 describe("parseRequiredViewType", () => {
-  it("accepts alerts, map, and gallery", () => {
-    expect(parseRequiredViewType("alerts")).toBe("alerts");
-    expect(parseRequiredViewType("map")).toBe("map");
-    expect(parseRequiredViewType("gallery")).toBe("gallery");
+  it("accepts every configured view type", () => {
+    for (const viewType of useAppConfig().viewTypes) {
+      expect(parseRequiredViewType(viewType)).toBe(viewType);
+    }
   });
 
   it("rejects missing, empty, repeated, and unknown values with status 400", () => {
@@ -16,6 +17,9 @@ describe("parseRequiredViewType", () => {
         expect.unreachable(`expected rejection for ${JSON.stringify(raw)}`);
       } catch (error) {
         expect(error).toMatchObject({ statusCode: 400 });
+        for (const viewType of useAppConfig().viewTypes) {
+          expect((error as Error).message).toContain(viewType);
+        }
       }
     }
   });

--- a/tests/unit/utils/viewTypes.test.ts
+++ b/tests/unit/utils/viewTypes.test.ts
@@ -5,7 +5,7 @@ import {
   SECONDARY_DATASET_VIEW_TYPES,
   supportsSecondaryDataset,
 } from "@/types";
-import { viewTypes } from "../../../nuxt.config";
+import { viewTypes } from "@/nuxt.config";
 
 describe("view type capabilities", () => {
   it("exposes the nuxt.config viewTypes list via useAppConfig", () => {

--- a/tests/unit/utils/viewTypes.test.ts
+++ b/tests/unit/utils/viewTypes.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "vitest";
 
+import { useAppConfig } from "#imports";
 import {
   SECONDARY_DATASET_VIEW_TYPES,
   supportsSecondaryDataset,
-  VIEW_TYPES,
 } from "@/types";
+import { viewTypes } from "../../../nuxt.config";
 
 describe("view type capabilities", () => {
-  it("declares every supported view type", () => {
-    expect(VIEW_TYPES).toEqual(["alerts", "map", "gallery"]);
+  it("exposes the nuxt.config viewTypes list via useAppConfig", () => {
+    expect(viewTypes).toEqual(["alerts", "map", "gallery"]);
+    expect(useAppConfig().viewTypes).toEqual(viewTypes);
   });
 
   it("allows secondary datasets for alerts and map only", () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,6 +10,10 @@ import type {
   Position,
 } from "geojson";
 import type { StyleSpecification } from "mapbox-gl";
+import type { viewTypes } from "../nuxt.config";
+
+export type ViewType = (typeof viewTypes)[number];
+// Reused for props/signatures; runtime list lives in nuxt.config appConfig.viewTypes.
 
 /**
  * Geometry type names allowed on warehouse rows (`g__type`) for this app’s map
@@ -123,18 +127,10 @@ export interface Views {
   [key: string]: ViewConfig;
 }
 
-export type ViewType = "alerts" | "map" | "gallery";
-
 export type RecordFetchQuery = {
   view_type?: ViewType;
   primary_dataset?: string;
 };
-
-export const VIEW_TYPES = [
-  "alerts",
-  "map",
-  "gallery",
-] as const satisfies readonly ViewType[];
 
 export const SECONDARY_DATASET_VIEW_TYPES = [
   "alerts",


### PR DESCRIPTION
## Goal

Define view types once (e.g. Nuxt appConfig) and reuse everywhere. Closes #578 

## Screenshots

N/A

## What I changed and why

- View types are now declared once as `viewTypes` in `nuxt.config.ts` and exposed via `useAppConfig().viewTypes`, removing the old `VIEW_TYPES` constant from `types/index.ts`
- Validation (`parseRequiredViewType` and its error text), route-segment matching, `ConfigCard` media/filters visibility, and the create-view type picker all read from the single config list instead of repeating `"alerts"` / `"map"` / `"gallery"`
- Create-view page still holds icon and description metadata per type but builds the option list by mapping over `viewTypes`
- `ViewType` remains importable from `@/types` as a type derived from the same const, for use in props and function signatures only
- Secondary dataset support stays as a separate subset, unchanged

## How I convinced myself this is right

`nuxt.config` is now the single source of truth for view types, with everything using `useAppConfig()` instead of a separate `VIEW_TYPES` list. Tests verify that valid types work, invalid ones list all configured types, and the mock matches the config. Existing alerts, map, and gallery values are unchanged, and all 562 unit tests pass.


## What I'm not doing here

- Not putting secondary-dataset view types on `appConfig`
- Not rewriting every place that intentionally uses a single view type (route handlers, fixtures, MediaFile `variant`, DOM `#map`)
- Not changing alerts / map / gallery behavior beyond reading the shared list

## LLM use disclosure

Used Cursor Grok 4.5 for implementation, after a `grill-me` design pass against #578.