### PR TITLE
Config: implement 2x2 grid design across Config dashboard

### DIFF
--- a/assets/config-tags.css
+++ b/assets/config-tags.css
@@ -1,0 +1,6 @@
+/* VueTagsInput scoped CSS caps the control at 450px. These selectors
+   stay at 0,3,0 so the field can fill its grid cell. */
+.tag-field.vue-tags-input.vue-tags-input {
+  width: 100%;
+  max-width: none;
+}

--- a/components/config/ConfigFilters.vue
+++ b/components/config/ConfigFilters.vue
@@ -56,7 +56,7 @@ const handleInput = (key: string, value: string): void => {
     <div
       v-for="key in keys"
       :key="key"
-      class="space-y-2"
+      class="space-y-2 min-w-0"
       :class="{
         'md:col-span-2':
           key === 'SECONDARY_FILTER_VALUES' || key === 'UNWANTED_COLUMNS',
@@ -105,7 +105,7 @@ const handleInput = (key: string, value: string): void => {
           {{ $t(toCamelCase(key)) }}
         </label>
         <VueTagsInput
-          class="tag-field"
+          class="tag-field w-full"
           :tags="tags[key]"
           @tags-changed="(newTags: Tag[]) => handleTagsChanged(key, newTags)"
         />

--- a/components/config/ConfigFilters.vue
+++ b/components/config/ConfigFilters.vue
@@ -49,8 +49,19 @@ const handleInput = (key: string, value: string): void => {
 </script>
 
 <template>
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-    <div v-for="key in keys" :key="key" class="space-y-2">
+  <div
+    class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6"
+    data-testid="config-field-grid"
+  >
+    <div
+      v-for="key in keys"
+      :key="key"
+      class="space-y-2"
+      :class="{
+        'md:col-span-2':
+          key === 'SECONDARY_FILTER_VALUES' || key === 'UNWANTED_COLUMNS',
+      }"
+    >
       <template v-if="key === 'FRONT_END_FILTER_COLUMN'">
         <label
           :for="`${tableName}-${key}`"

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -228,11 +228,27 @@ const handleDrop = (e: DragEvent, dropIndex: number) => {
   ensureDefault();
   saveBasemaps();
 };
+
+const fullWidthKeys = [
+  "MAPBOX_STYLE",
+  "MAPBOX_ACCESS_TOKEN",
+  "MAPBOX_3D",
+  "MAP_LEGEND_LAYER_IDS",
+  "PLANET_API_KEY",
+];
 </script>
 
 <template>
-  <div class="space-y-6">
-    <div v-for="key in keys" :key="key" class="space-y-2">
+  <div
+    class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6"
+    data-testid="config-field-grid"
+  >
+    <div
+      v-for="key in keys"
+      :key="key"
+      class="space-y-2"
+      :class="{ 'md:col-span-2': fullWidthKeys.includes(key) }"
+    >
       <!-- Mapbox Basemaps -->
       <template v-if="key === 'MAPBOX_STYLE'">
         <label class="block text-sm font-medium text-gray-700 mb-2">

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -243,330 +243,356 @@ const fullWidthKeys = [
     class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6"
     data-testid="config-field-grid"
   >
-    <div
-      v-for="key in keys"
-      :key="key"
-      class="space-y-2"
-      :class="{ 'md:col-span-2': fullWidthKeys.includes(key) }"
-    >
-      <!-- Mapbox Basemaps -->
-      <template v-if="key === 'MAPBOX_STYLE'">
-        <label class="block text-sm font-medium text-gray-700 mb-2">
-          {{ $t("mapboxBackgroundMaps") }}
-        </label>
-        <p class="text-sm text-gray-500 mb-4">
-          {{ $t("basemapsDescription") }}
-        </p>
-        <div class="space-y-4" data-testid="basemaps-container">
-          <div
-            v-for="(basemap, index) in basemaps"
-            :key="index"
-            :data-testid="`basemap-item-${index}`"
-            class="p-4 border-2 rounded-lg transition-colors"
-            :class="
-              index === 0
-                ? 'border-violet-300 bg-violet-50'
-                : 'border-gray-200 bg-white hover:border-violet-200'
-            "
-            draggable="true"
-            @dragstart="handleDragStart(index)"
-            @dragover="handleDragOver($event, index)"
-            @drop="handleDrop($event, index)"
-          >
-            <div class="flex items-start gap-3">
-              <div class="flex-shrink-0 pt-2 text-gray-400 cursor-move">☰</div>
-              <div class="flex-1 space-y-3">
-                <div>
+    <template v-for="key in keys" :key="key">
+      <div
+        v-if="key !== 'MAPBOX_3D_TERRAIN_EXAGGERATION'"
+        class="space-y-2 min-w-0"
+        :class="{ 'md:col-span-2': fullWidthKeys.includes(key) }"
+      >
+        <!-- Mapbox Basemaps -->
+        <template v-if="key === 'MAPBOX_STYLE'">
+          <label class="block text-sm font-medium text-gray-700 mb-2">
+            {{ $t("mapboxBackgroundMaps") }}
+          </label>
+          <p class="text-sm text-gray-500 mb-4">
+            {{ $t("basemapsDescription") }}
+          </p>
+          <div class="space-y-4" data-testid="basemaps-container">
+            <div
+              v-for="(basemap, index) in basemaps"
+              :key="index"
+              :data-testid="`basemap-item-${index}`"
+              class="p-4 border-2 rounded-lg transition-colors"
+              :class="
+                index === 0
+                  ? 'border-violet-300 bg-violet-50'
+                  : 'border-gray-200 bg-white hover:border-violet-200'
+              "
+              draggable="true"
+              @dragstart="handleDragStart(index)"
+              @dragover="handleDragOver($event, index)"
+              @drop="handleDrop($event, index)"
+            >
+              <div class="flex items-start gap-3">
+                <div class="flex-shrink-0 pt-2 text-gray-400 cursor-move">
+                  ☰
+                </div>
+                <div class="flex-1 space-y-3">
+                  <div>
+                    <input
+                      :id="`${tableName}-basemap-name-${index}`"
+                      class="w-full px-4 py-2 border rounded-lg transition-colors"
+                      :class="{
+                        'border-red-300 focus:ring-red-500 focus:border-red-500':
+                          !isNameValid(index, basemap.name),
+                        'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
+                          isNameValid(index, basemap.name) || !basemap.name,
+                      }"
+                      :placeholder="$t('basemapName')"
+                      :value="basemap.name"
+                      required
+                      @input="
+                        updateBasemap(
+                          index,
+                          'name',
+                          ($event.target as HTMLInputElement).value,
+                        )
+                      "
+                    />
+                    <span
+                      v-if="basemap.name && !isNameValid(index, basemap.name)"
+                      class="block mt-1 text-sm text-red-600"
+                    >
+                      {{ getValidationError(index, basemap.name) }}
+                    </span>
+                  </div>
                   <input
-                    :id="`${tableName}-basemap-name-${index}`"
-                    class="w-full px-4 py-2 border rounded-lg transition-colors"
-                    :class="{
-                      'border-red-300 focus:ring-red-500 focus:border-red-500':
-                        !isNameValid(index, basemap.name),
-                      'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
-                        isNameValid(index, basemap.name) || !basemap.name,
-                    }"
-                    :placeholder="$t('basemapName')"
-                    :value="basemap.name"
+                    :id="`${tableName}-basemap-style-${index}`"
+                    class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+                    pattern="^mapbox:\/\/styles\/[^\/]+\/[^\/]+$"
+                    placeholder="mapbox://styles/user/styleId"
+                    :title="
+                      $t('pleaseMatchFormat') +
+                      ': mapbox://styles/username/styleid'
+                    "
+                    :value="basemap.style"
                     required
                     @input="
                       updateBasemap(
                         index,
-                        'name',
+                        'style',
                         ($event.target as HTMLInputElement).value,
                       )
                     "
                   />
-                  <span
-                    v-if="basemap.name && !isNameValid(index, basemap.name)"
-                    class="block mt-1 text-sm text-red-600"
-                  >
-                    {{ getValidationError(index, basemap.name) }}
-                  </span>
                 </div>
-                <input
-                  :id="`${tableName}-basemap-style-${index}`"
-                  class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-                  pattern="^mapbox:\/\/styles\/[^\/]+\/[^\/]+$"
-                  placeholder="mapbox://styles/user/styleId"
-                  :title="
-                    $t('pleaseMatchFormat') +
-                    ': mapbox://styles/username/styleid'
-                  "
-                  :value="basemap.style"
-                  required
-                  @input="
-                    updateBasemap(
-                      index,
-                      'style',
-                      ($event.target as HTMLInputElement).value,
-                    )
-                  "
-                />
+                <button
+                  v-if="index !== 0"
+                  type="button"
+                  :data-testid="`basemap-remove-button-${index}`"
+                  class="flex-shrink-0 px-3 py-2 text-sm font-medium text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
+                  @click="removeBasemap(index)"
+                >
+                  {{ $t("remove") }}
+                </button>
               </div>
-              <button
-                v-if="index !== 0"
-                type="button"
-                :data-testid="`basemap-remove-button-${index}`"
-                class="flex-shrink-0 px-3 py-2 text-sm font-medium text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
-                @click="removeBasemap(index)"
-              >
-                {{ $t("remove") }}
-              </button>
             </div>
+            <button
+              type="button"
+              data-testid="basemap-add-button"
+              class="w-full px-4 py-2 text-sm font-medium text-violet-700 bg-violet-50 border border-violet-200 rounded-lg hover:bg-violet-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              :disabled="!canAddBasemap"
+              @click="addBasemap"
+            >
+              + {{ $t("addBackgroundMapOption") }}
+            </button>
           </div>
-          <button
-            type="button"
-            data-testid="basemap-add-button"
-            class="w-full px-4 py-2 text-sm font-medium text-violet-700 bg-violet-50 border border-violet-200 rounded-lg hover:bg-violet-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            :disabled="!canAddBasemap"
-            @click="addBasemap"
+        </template>
+
+        <!-- Access Token -->
+        <template v-else-if="key === 'MAPBOX_ACCESS_TOKEN'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
           >
-            + {{ $t("addBackgroundMapOption") }}
-          </button>
-        </div>
-      </template>
-
-      <!-- Access Token -->
-      <template v-else-if="key === 'MAPBOX_ACCESS_TOKEN'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }} <span class="text-red-500">*</span>
-        </label>
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          pattern="^pk\.ey.*"
-          placeholder="pk.ey…"
-          :title="$t('pleaseMatchFormat') + ': pk.ey… '"
-          :value="config[key]"
-          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
-        />
-      </template>
-
-      <!-- Numbers -->
-      <template
-        v-else-if="
-          [
-            'MAPBOX_BEARING',
-            'MAPBOX_CENTER_LATITUDE',
-            'MAPBOX_CENTER_LONGITUDE',
-            'MAPBOX_PITCH',
-            'MAPBOX_ZOOM',
-          ].includes(key)
-        "
-      >
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="number"
-          step="any"
-          :min="
-            key === 'MAPBOX_BEARING'
-              ? -180
-              : key === 'MAPBOX_CENTER_LATITUDE'
-                ? -90
-                : key === 'MAPBOX_CENTER_LONGITUDE'
-                  ? -180
-                  : 0
-          "
-          :max="
-            key === 'MAPBOX_BEARING'
-              ? 180
-              : key === 'MAPBOX_CENTER_LATITUDE'
-                ? 90
-                : key === 'MAPBOX_CENTER_LONGITUDE'
-                  ? 180
-                  : key === 'MAPBOX_PITCH'
-                    ? 85
-                    : key === 'MAPBOX_ZOOM'
-                      ? 22
-                      : 0
-          "
-          :value="config[key]"
-          @input="
-            (e) => {
-              const raw = (e.target as HTMLInputElement).value;
-              if (raw === '' || raw === '-' || raw === '.' || raw === '-.')
-                return;
-              handleInput(key, parseFloat(raw));
-            }
-          "
-          @wheel="(e) => e.target && (e.target as HTMLInputElement).blur()"
-        />
-      </template>
-
-      <!-- Projection -->
-      <template v-else-if="key === 'MAPBOX_PROJECTION'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <select
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
-          :value="config[key]"
-          @change="
-            (e) => handleInput(key, (e.target as HTMLSelectElement).value)
-          "
-        >
-          <option value="mercator">Mercator</option>
-          <option value="albers">Albers</option>
-          <option value="equalEarth">Equal Earth</option>
-          <option value="equirectangular">Equirectangular</option>
-          <option value="lambertConformalConic">Lambert Conformal Conic</option>
-          <option value="naturalEarth">Natural Earth</option>
-          <option value="winkelTripel">Winkel Tripel</option>
-          <option value="globe">Globe</option>
-        </select>
-      </template>
-
-      <!-- 3D -->
-      <template v-else-if="key === 'MAPBOX_3D'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700 mb-2"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <label class="flex items-center gap-2 cursor-pointer group">
+            {{ $t(toCamelCase(key)) }} <span class="text-red-500">*</span>
+          </label>
           <input
             :id="`${tableName}-${key}`"
-            type="checkbox"
-            class="w-5 h-5 text-violet-600 border-gray-300 rounded focus:ring-violet-500 focus:ring-2"
-            :checked="Boolean(config[key])"
-            @change="
-              (e) => handleInput(key, (e.target as HTMLInputElement).checked)
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            pattern="^pk\.ey.*"
+            placeholder="pk.ey…"
+            :title="$t('pleaseMatchFormat') + ': pk.ey… '"
+            :value="config[key]"
+            @input="
+              (e) => handleInput(key, (e.target as HTMLInputElement).value)
             "
           />
-          <span
-            class="text-gray-700 font-medium group-hover:text-violet-700 transition-colors"
+        </template>
+
+        <!-- Numbers -->
+        <template
+          v-else-if="
+            [
+              'MAPBOX_BEARING',
+              'MAPBOX_CENTER_LATITUDE',
+              'MAPBOX_CENTER_LONGITUDE',
+              'MAPBOX_PITCH',
+              'MAPBOX_ZOOM',
+            ].includes(key)
+          "
+        >
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
           >
-            {{ $t("enable") }}
-          </span>
-        </label>
-
-        <!-- Terrain Exaggeration Slider (shown when 3D is enabled) -->
-        <div v-if="Boolean(config['MAPBOX_3D'])" class="mt-4 space-y-2">
-          <label class="block text-sm font-medium text-gray-700">
-            3D {{ $t("terrainExaggeration") }}
+            {{ $t(toCamelCase(key)) }}
           </label>
-          <div class="mt-2 mb-10">
-            <VueSlider
-              v-model="terrainExaggeration"
-              :min="0"
-              :max="22"
-              :interval="0.1"
-              :height="10"
-              :tooltip="'always'"
-              :tooltip-placement="'bottom'"
-            />
+          <input
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            type="number"
+            step="any"
+            :min="
+              key === 'MAPBOX_BEARING'
+                ? -180
+                : key === 'MAPBOX_CENTER_LATITUDE'
+                  ? -90
+                  : key === 'MAPBOX_CENTER_LONGITUDE'
+                    ? -180
+                    : 0
+            "
+            :max="
+              key === 'MAPBOX_BEARING'
+                ? 180
+                : key === 'MAPBOX_CENTER_LATITUDE'
+                  ? 90
+                  : key === 'MAPBOX_CENTER_LONGITUDE'
+                    ? 180
+                    : key === 'MAPBOX_PITCH'
+                      ? 85
+                      : key === 'MAPBOX_ZOOM'
+                        ? 22
+                        : 0
+            "
+            :value="config[key]"
+            @input="
+              (e) => {
+                const raw = (e.target as HTMLInputElement).value;
+                if (raw === '' || raw === '-' || raw === '.' || raw === '-.')
+                  return;
+                handleInput(key, parseFloat(raw));
+              }
+            "
+            @wheel="(e) => e.target && (e.target as HTMLInputElement).blur()"
+          />
+        </template>
+
+        <!-- Projection -->
+        <template v-else-if="key === 'MAPBOX_PROJECTION'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t(toCamelCase(key)) }}
+          </label>
+          <select
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
+            :value="config[key]"
+            @change="
+              (e) => handleInput(key, (e.target as HTMLSelectElement).value)
+            "
+          >
+            <option value="mercator">Mercator</option>
+            <option value="albers">Albers</option>
+            <option value="equalEarth">Equal Earth</option>
+            <option value="equirectangular">Equirectangular</option>
+            <option value="lambertConformalConic">
+              Lambert Conformal Conic
+            </option>
+            <option value="naturalEarth">Natural Earth</option>
+            <option value="winkelTripel">Winkel Tripel</option>
+            <option value="globe">Globe</option>
+          </select>
+        </template>
+
+        <!-- 3D -->
+        <template v-else-if="key === 'MAPBOX_3D'">
+          <div
+            class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4"
+            data-testid="config-3d-grid"
+          >
+            <div class="space-y-2">
+              <label
+                :for="`${tableName}-${key}`"
+                class="block text-sm font-medium text-gray-700"
+              >
+                {{ $t(toCamelCase(key)) }}
+              </label>
+              <label
+                class="flex min-h-10 items-center gap-2 cursor-pointer group"
+              >
+                <input
+                  :id="`${tableName}-${key}`"
+                  type="checkbox"
+                  class="w-5 h-5 text-violet-600 border-gray-300 rounded focus:ring-violet-500 focus:ring-2"
+                  :checked="Boolean(config[key])"
+                  @change="
+                    (e) =>
+                      handleInput(key, (e.target as HTMLInputElement).checked)
+                  "
+                />
+                <span
+                  class="text-gray-700 font-medium group-hover:text-violet-700 transition-colors"
+                >
+                  {{ $t("enable") }}
+                </span>
+              </label>
+            </div>
+
+            <div v-if="Boolean(config['MAPBOX_3D'])" class="space-y-2 min-w-0">
+              <label
+                :for="`${tableName}-MAPBOX_3D_TERRAIN_EXAGGERATION`"
+                class="block text-sm font-medium text-gray-700"
+              >
+                3D {{ $t("terrainExaggeration") }}
+              </label>
+              <div class="pt-2 pb-8">
+                <VueSlider
+                  :id="`${tableName}-MAPBOX_3D_TERRAIN_EXAGGERATION`"
+                  v-model="terrainExaggeration"
+                  :min="0"
+                  :max="22"
+                  :interval="0.1"
+                  :height="10"
+                  :tooltip="'always'"
+                  :tooltip-placement="'bottom'"
+                />
+              </div>
+            </div>
           </div>
-        </div>
-      </template>
+        </template>
 
-      <!-- Legend Layers -->
-      <template v-else-if="key === 'MAP_LEGEND_LAYER_IDS'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <VueTagsInput
-          class="tag-field"
-          :tags="tags[key]"
-          @tags-changed="(newTags: Tag[]) => handleTagsChanged(key, newTags)"
-        />
-      </template>
+        <!-- Legend Layers -->
+        <template v-else-if="key === 'MAP_LEGEND_LAYER_IDS'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t(toCamelCase(key)) }}
+          </label>
+          <VueTagsInput
+            class="tag-field w-full"
+            :tags="tags[key]"
+            @tags-changed="(newTags: Tag[]) => handleTagsChanged(key, newTags)"
+          />
+        </template>
 
-      <!-- Planet API Key -->
-      <template v-else-if="key === 'PLANET_API_KEY'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="text"
-          :value="config[key]"
-          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
-        />
-      </template>
+        <!-- Planet API Key -->
+        <template v-else-if="key === 'PLANET_API_KEY'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t(toCamelCase(key)) }}
+          </label>
+          <input
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            type="text"
+            :value="config[key]"
+            @input="
+              (e) => handleInput(key, (e.target as HTMLInputElement).value)
+            "
+          />
+        </template>
 
-      <!-- Color Column -->
-      <template v-else-if="key === 'COLOR_COLUMN'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="text"
-          placeholder="color"
-          :value="config[key]"
-          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
-        />
-        <p class="field-description">{{ $t("colorColumnDescription") }}</p>
-      </template>
+        <!-- Color Column -->
+        <template v-else-if="key === 'COLOR_COLUMN'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t(toCamelCase(key)) }}
+          </label>
+          <input
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            type="text"
+            placeholder="color"
+            :value="config[key]"
+            @input="
+              (e) => handleInput(key, (e.target as HTMLInputElement).value)
+            "
+          />
+          <p class="field-description">{{ $t("colorColumnDescription") }}</p>
+        </template>
 
-      <!-- Icon Column -->
-      <template v-else-if="key === 'ICON_COLUMN'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="text"
-          placeholder="icon"
-          :value="config[key]"
-          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
-        />
-        <p class="text-xs text-gray-500 mt-1">
-          {{ $t("iconColumnDescription") }}
-        </p>
-      </template>
-    </div>
+        <!-- Icon Column -->
+        <template v-else-if="key === 'ICON_COLUMN'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t(toCamelCase(key)) }}
+          </label>
+          <input
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            type="text"
+            placeholder="icon"
+            :value="config[key]"
+            @input="
+              (e) => handleInput(key, (e.target as HTMLInputElement).value)
+            "
+          />
+          <p class="text-xs text-gray-500 mt-1">
+            {{ $t("iconColumnDescription") }}
+          </p>
+        </template>
+      </div>
+    </template>
   </div>
 </template>
 

--- a/components/config/ConfigMedia.vue
+++ b/components/config/ConfigMedia.vue
@@ -223,302 +223,320 @@ watch(
 </script>
 
 <template>
-  <div class="space-y-6">
+  <div
+    class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6"
+    data-testid="config-field-grid"
+  >
     <!-- MEDIA_BASE_PATH -->
-    <div v-if="keys.includes('MEDIA_BASE_PATH')" class="space-y-4">
+    <div
+      v-if="keys.includes('MEDIA_BASE_PATH')"
+      class="space-y-4 md:col-span-2"
+    >
       <label class="block text-sm font-medium text-gray-700">
         {{ $t(toCamelCase("MEDIA_BASE_PATH")) }}
       </label>
 
-      <div class="space-y-2">
-        <label
-          :for="`${tableName}-provider-basePath`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t("mediaProvider") }}
-        </label>
-        <select
-          :id="`${tableName}-provider-basePath`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
-          :value="providerBasePath"
-          @change="
-            handleProviderChange(
-              'basePath',
-              ($event.target as HTMLSelectElement).value as MediaProvider,
-            )
-          "
-        >
-          <option value="filebrowser">
-            {{ $t("mediaFilebrowserDefault") }}
-          </option>
-          <option value="generic">{{ $t("mediaGenericHttpBaseUrl") }}</option>
-        </select>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+        <div class="space-y-2">
+          <label
+            :for="`${tableName}-provider-basePath`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t("mediaProvider") }}
+          </label>
+          <select
+            :id="`${tableName}-provider-basePath`"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
+            :value="providerBasePath"
+            @change="
+              handleProviderChange(
+                'basePath',
+                ($event.target as HTMLSelectElement).value as MediaProvider,
+              )
+            "
+          >
+            <option value="filebrowser">
+              {{ $t("mediaFilebrowserDefault") }}
+            </option>
+            <option value="generic">{{ $t("mediaGenericHttpBaseUrl") }}</option>
+          </select>
+        </div>
+
+        <template v-if="providerBasePath === 'filebrowser'">
+          <div class="space-y-2">
+            <label
+              :for="`${tableName}-share-basePath`"
+              class="block text-sm font-medium text-gray-700"
+            >
+              {{ $t("mediaPasteFilebrowserShareUrlOrHash") }}
+            </label>
+            <input
+              :id="`${tableName}-share-basePath`"
+              class="w-full px-4 py-2 border rounded-lg transition-colors"
+              :class="{
+                'border-red-300 focus:ring-red-500 focus:border-red-500':
+                  !isBasePathValid && shareInputBasePath,
+                'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
+                  isBasePathValid || !shareInputBasePath,
+              }"
+              type="text"
+              :value="shareInputBasePath"
+              placeholder="https://files.example.com/share/abc123 or abc123"
+              @input="
+                handleInput(
+                  'basePath',
+                  ($event.target as HTMLInputElement).value,
+                )
+              "
+            />
+            <p
+              v-if="!isBasePathValid && shareInputBasePath"
+              class="text-sm text-red-600"
+            >
+              {{ $t("mediaInvalidFormat") }}
+            </p>
+            <p class="text-xs text-gray-500">
+              <strong>{{ $t("mediaAccepts") }}</strong>
+              <code class="px-1 py-0.5 bg-gray-100 rounded"
+                >https://files.example.com/share/abc123</code
+              >,
+              <code class="px-1 py-0.5 bg-gray-100 rounded"
+                >https://files.example.com/api/public/dl/abc123</code
+              >,
+              {{ $t("or") }}
+              <code class="px-1 py-0.5 bg-gray-100 rounded">abc123</code>
+            </p>
+          </div>
+        </template>
+
+        <template v-else>
+          <div class="space-y-2">
+            <label
+              :for="`${tableName}-baseUrl-generic-basePath`"
+              class="block text-sm font-medium text-gray-700"
+            >
+              {{ $t("mediaBaseUrl") }}
+            </label>
+            <input
+              :id="`${tableName}-baseUrl-generic-basePath`"
+              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+              type="url"
+              :value="shareInputBasePath"
+              placeholder="https://your-files-host.example/api/public/dl/"
+              @input="
+                handleInput(
+                  'basePath',
+                  ($event.target as HTMLInputElement).value,
+                )
+              "
+            />
+          </div>
+        </template>
       </div>
-
-      <template v-if="providerBasePath === 'filebrowser'">
-        <div class="space-y-2">
-          <label
-            :for="`${tableName}-share-basePath`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t("mediaPasteFilebrowserShareUrlOrHash") }}
-          </label>
-          <input
-            :id="`${tableName}-share-basePath`"
-            class="w-full px-4 py-2 border rounded-lg transition-colors"
-            :class="{
-              'border-red-300 focus:ring-red-500 focus:border-red-500':
-                !isBasePathValid && shareInputBasePath,
-              'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
-                isBasePathValid || !shareInputBasePath,
-            }"
-            type="text"
-            :value="shareInputBasePath"
-            placeholder="https://files.example.com/share/abc123 or abc123"
-            @input="
-              handleInput('basePath', ($event.target as HTMLInputElement).value)
-            "
-          />
-          <p
-            v-if="!isBasePathValid && shareInputBasePath"
-            class="text-sm text-red-600"
-          >
-            {{ $t("mediaInvalidFormat") }}
-          </p>
-          <p class="text-xs text-gray-500">
-            <strong>{{ $t("mediaAccepts") }}</strong>
-            <code class="px-1 py-0.5 bg-gray-100 rounded"
-              >https://files.example.com/share/abc123</code
-            >,
-            <code class="px-1 py-0.5 bg-gray-100 rounded"
-              >https://files.example.com/api/public/dl/abc123</code
-            >,
-            {{ $t("or") }}
-            <code class="px-1 py-0.5 bg-gray-100 rounded">abc123</code>
-          </p>
-        </div>
-      </template>
-
-      <template v-else>
-        <div class="space-y-2">
-          <label
-            :for="`${tableName}-baseUrl-generic-basePath`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t("mediaBaseUrl") }}
-          </label>
-          <input
-            :id="`${tableName}-baseUrl-generic-basePath`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-            type="url"
-            :value="shareInputBasePath"
-            placeholder="https://your-files-host.example/api/public/dl/"
-            @input="
-              handleInput('basePath', ($event.target as HTMLInputElement).value)
-            "
-          />
-        </div>
-      </template>
     </div>
 
     <!-- MEDIA_BASE_PATH_ALERTS -->
     <div
       v-if="keys.includes('MEDIA_BASE_PATH_ALERTS') && views.includes('alerts')"
-      class="space-y-4"
+      class="space-y-4 md:col-span-2"
     >
       <label class="block text-sm font-medium text-gray-700">
         {{ $t(toCamelCase("MEDIA_BASE_PATH_ALERTS")) }}
       </label>
 
-      <div class="space-y-2">
-        <label
-          :for="`${tableName}-provider-alerts`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t("mediaProvider") }}
-        </label>
-        <select
-          :id="`${tableName}-provider-alerts`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
-          :value="providerAlerts"
-          @change="
-            handleProviderChange(
-              'alerts',
-              ($event.target as HTMLSelectElement).value as MediaProvider,
-            )
-          "
-        >
-          <option value="filebrowser">
-            {{ $t("mediaFilebrowserDefault") }}
-          </option>
-          <option value="generic">{{ $t("mediaGenericHttpBaseUrl") }}</option>
-        </select>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+        <div class="space-y-2">
+          <label
+            :for="`${tableName}-provider-alerts`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t("mediaProvider") }}
+          </label>
+          <select
+            :id="`${tableName}-provider-alerts`"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
+            :value="providerAlerts"
+            @change="
+              handleProviderChange(
+                'alerts',
+                ($event.target as HTMLSelectElement).value as MediaProvider,
+              )
+            "
+          >
+            <option value="filebrowser">
+              {{ $t("mediaFilebrowserDefault") }}
+            </option>
+            <option value="generic">{{ $t("mediaGenericHttpBaseUrl") }}</option>
+          </select>
+        </div>
+
+        <template v-if="providerAlerts === 'filebrowser'">
+          <div class="space-y-2">
+            <label
+              :for="`${tableName}-share-alerts`"
+              class="block text-sm font-medium text-gray-700"
+            >
+              {{ $t("mediaPasteFilebrowserShareUrlOrHash") }}
+            </label>
+            <input
+              :id="`${tableName}-share-alerts`"
+              class="w-full px-4 py-2 border rounded-lg transition-colors"
+              :class="{
+                'border-red-300 focus:ring-red-500 focus:border-red-500':
+                  !isAlertsValid && shareInputAlerts,
+                'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
+                  isAlertsValid || !shareInputAlerts,
+              }"
+              type="text"
+              :value="shareInputAlerts"
+              placeholder="https://files.example.com/share/abc123 or abc123"
+              @input="
+                handleInput('alerts', ($event.target as HTMLInputElement).value)
+              "
+            />
+            <p
+              v-if="!isAlertsValid && shareInputAlerts"
+              class="text-sm text-red-600"
+            >
+              {{ $t("mediaInvalidFormat") }}
+            </p>
+            <p class="text-xs text-gray-500">
+              <strong>{{ $t("mediaAccepts") }}</strong>
+              <code class="px-1 py-0.5 bg-gray-100 rounded"
+                >https://files.example.com/share/abc123</code
+              >,
+              <code class="px-1 py-0.5 bg-gray-100 rounded"
+                >https://files.example.com/api/public/dl/abc123</code
+              >,
+              {{ $t("or") }}
+              <code class="px-1 py-0.5 bg-gray-100 rounded">abc123</code>
+            </p>
+          </div>
+        </template>
+
+        <template v-else>
+          <div class="space-y-2">
+            <label
+              :for="`${tableName}-baseUrl-generic-alerts`"
+              class="block text-sm font-medium text-gray-700"
+            >
+              {{ $t("mediaBaseUrl") }}
+            </label>
+            <input
+              :id="`${tableName}-baseUrl-generic-alerts`"
+              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+              type="url"
+              :value="shareInputAlerts"
+              placeholder="https://your-files-host.example/api/public/dl/"
+              @input="
+                handleInput('alerts', ($event.target as HTMLInputElement).value)
+              "
+            />
+          </div>
+        </template>
       </div>
-
-      <template v-if="providerAlerts === 'filebrowser'">
-        <div class="space-y-2">
-          <label
-            :for="`${tableName}-share-alerts`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t("mediaPasteFilebrowserShareUrlOrHash") }}
-          </label>
-          <input
-            :id="`${tableName}-share-alerts`"
-            class="w-full px-4 py-2 border rounded-lg transition-colors"
-            :class="{
-              'border-red-300 focus:ring-red-500 focus:border-red-500':
-                !isAlertsValid && shareInputAlerts,
-              'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
-                isAlertsValid || !shareInputAlerts,
-            }"
-            type="text"
-            :value="shareInputAlerts"
-            placeholder="https://files.example.com/share/abc123 or abc123"
-            @input="
-              handleInput('alerts', ($event.target as HTMLInputElement).value)
-            "
-          />
-          <p
-            v-if="!isAlertsValid && shareInputAlerts"
-            class="text-sm text-red-600"
-          >
-            {{ $t("mediaInvalidFormat") }}
-          </p>
-          <p class="text-xs text-gray-500">
-            <strong>{{ $t("mediaAccepts") }}</strong>
-            <code class="px-1 py-0.5 bg-gray-100 rounded"
-              >https://files.example.com/share/abc123</code
-            >,
-            <code class="px-1 py-0.5 bg-gray-100 rounded"
-              >https://files.example.com/api/public/dl/abc123</code
-            >,
-            {{ $t("or") }}
-            <code class="px-1 py-0.5 bg-gray-100 rounded">abc123</code>
-          </p>
-        </div>
-      </template>
-
-      <template v-else>
-        <div class="space-y-2">
-          <label
-            :for="`${tableName}-baseUrl-generic-alerts`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t("mediaBaseUrl") }}
-          </label>
-          <input
-            :id="`${tableName}-baseUrl-generic-alerts`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-            type="url"
-            :value="shareInputAlerts"
-            placeholder="https://your-files-host.example/api/public/dl/"
-            @input="
-              handleInput('alerts', ($event.target as HTMLInputElement).value)
-            "
-          />
-        </div>
-      </template>
     </div>
 
     <!-- MEDIA_BASE_PATH_ICONS -->
     <div
       v-if="keys.includes('MEDIA_BASE_PATH_ICONS') && views.includes('map')"
-      class="space-y-4"
+      class="space-y-4 md:col-span-2"
     >
       <label class="block text-sm font-medium text-gray-700">
         {{ $t(toCamelCase("MEDIA_BASE_PATH_ICONS")) }}
       </label>
 
-      <div class="space-y-2">
-        <label
-          :for="`${tableName}-provider-icons`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t("mediaProvider") }}
-        </label>
-        <select
-          :id="`${tableName}-provider-icons`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
-          :value="providerIcons"
-          @change="
-            handleProviderChange(
-              'icons',
-              ($event.target as HTMLSelectElement).value as MediaProvider,
-            )
-          "
-        >
-          <option value="filebrowser">
-            {{ $t("mediaFilebrowserDefault") }}
-          </option>
-          <option value="generic">{{ $t("mediaGenericHttpBaseUrl") }}</option>
-        </select>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+        <div class="space-y-2">
+          <label
+            :for="`${tableName}-provider-icons`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t("mediaProvider") }}
+          </label>
+          <select
+            :id="`${tableName}-provider-icons`"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
+            :value="providerIcons"
+            @change="
+              handleProviderChange(
+                'icons',
+                ($event.target as HTMLSelectElement).value as MediaProvider,
+              )
+            "
+          >
+            <option value="filebrowser">
+              {{ $t("mediaFilebrowserDefault") }}
+            </option>
+            <option value="generic">{{ $t("mediaGenericHttpBaseUrl") }}</option>
+          </select>
+        </div>
+
+        <template v-if="providerIcons === 'filebrowser'">
+          <div class="space-y-2">
+            <label
+              :for="`${tableName}-share-icons`"
+              class="block text-sm font-medium text-gray-700"
+            >
+              {{ $t("mediaPasteFilebrowserShareUrlOrHash") }}
+            </label>
+            <input
+              :id="`${tableName}-share-icons`"
+              class="w-full px-4 py-2 border rounded-lg transition-colors"
+              :class="{
+                'border-red-300 focus:ring-red-500 focus:border-red-500':
+                  !isIconsValid && shareInputIcons,
+                'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
+                  isIconsValid || !shareInputIcons,
+              }"
+              type="text"
+              :value="shareInputIcons"
+              placeholder="https://files.example.com/share/abc123 or abc123"
+              @input="
+                handleInput('icons', ($event.target as HTMLInputElement).value)
+              "
+            />
+            <p
+              v-if="!isIconsValid && shareInputIcons"
+              class="text-sm text-red-600"
+            >
+              {{ $t("mediaInvalidFormat") }}
+            </p>
+            <p class="text-xs text-gray-500">
+              <strong>{{ $t("mediaAccepts") }}</strong>
+              <code class="px-1 py-0.5 bg-gray-100 rounded"
+                >https://files.example.com/share/abc123</code
+              >,
+              <code class="px-1 py-0.5 bg-gray-100 rounded"
+                >https://files.example.com/api/public/dl/abc123</code
+              >,
+              {{ $t("or") }}
+              <code class="px-1 py-0.5 bg-gray-100 rounded">abc123</code>
+            </p>
+          </div>
+        </template>
+
+        <template v-else>
+          <div class="space-y-2">
+            <label
+              :for="`${tableName}-baseUrl-generic-icons`"
+              class="block text-sm font-medium text-gray-700"
+            >
+              {{ $t("mediaBaseUrl") }}
+            </label>
+            <input
+              :id="`${tableName}-baseUrl-generic-icons`"
+              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+              type="url"
+              :value="shareInputIcons"
+              placeholder="https://your-files-host.example/api/public/dl/"
+              @input="
+                handleInput('icons', ($event.target as HTMLInputElement).value)
+              "
+            />
+          </div>
+        </template>
       </div>
-
-      <template v-if="providerIcons === 'filebrowser'">
-        <div class="space-y-2">
-          <label
-            :for="`${tableName}-share-icons`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t("mediaPasteFilebrowserShareUrlOrHash") }}
-          </label>
-          <input
-            :id="`${tableName}-share-icons`"
-            class="w-full px-4 py-2 border rounded-lg transition-colors"
-            :class="{
-              'border-red-300 focus:ring-red-500 focus:border-red-500':
-                !isIconsValid && shareInputIcons,
-              'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
-                isIconsValid || !shareInputIcons,
-            }"
-            type="text"
-            :value="shareInputIcons"
-            placeholder="https://files.example.com/share/abc123 or abc123"
-            @input="
-              handleInput('icons', ($event.target as HTMLInputElement).value)
-            "
-          />
-          <p
-            v-if="!isIconsValid && shareInputIcons"
-            class="text-sm text-red-600"
-          >
-            {{ $t("mediaInvalidFormat") }}
-          </p>
-          <p class="text-xs text-gray-500">
-            <strong>{{ $t("mediaAccepts") }}</strong>
-            <code class="px-1 py-0.5 bg-gray-100 rounded"
-              >https://files.example.com/share/abc123</code
-            >,
-            <code class="px-1 py-0.5 bg-gray-100 rounded"
-              >https://files.example.com/api/public/dl/abc123</code
-            >,
-            {{ $t("or") }}
-            <code class="px-1 py-0.5 bg-gray-100 rounded">abc123</code>
-          </p>
-        </div>
-      </template>
-
-      <template v-else>
-        <div class="space-y-2">
-          <label
-            :for="`${tableName}-baseUrl-generic-icons`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t("mediaBaseUrl") }}
-          </label>
-          <input
-            :id="`${tableName}-baseUrl-generic-icons`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-            type="url"
-            :value="shareInputIcons"
-            placeholder="https://your-files-host.example/api/public/dl/"
-            @input="
-              handleInput('icons', ($event.target as HTMLInputElement).value)
-            "
-          />
-        </div>
-      </template>
     </div>
 
     <!-- MEDIA_COLUMN -->

--- a/components/config/ConfigViewInfo.vue
+++ b/components/config/ConfigViewInfo.vue
@@ -14,8 +14,16 @@ const emit = defineEmits(["updateConfig"]);
 </script>
 
 <template>
-  <div class="space-y-6">
-    <div v-for="key in keys" :key="key" class="space-y-2">
+  <div
+    class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6"
+    data-testid="config-field-grid"
+  >
+    <div
+      v-for="key in keys"
+      :key="key"
+      class="space-y-2"
+      :class="{ 'md:col-span-2': key === 'VIEW_DESCRIPTION' }"
+    >
       <template v-if="key === 'LOGO_URL'">
         <label
           :for="`${tableName}-${key}`"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -210,7 +210,7 @@
   "mediaBaseUrl": "Base URL",
   "mediaColumn": "Column to use for media files",
   "mediaColumnDescription": "Specify the column name containing media file references (e.g., photo, audio). Only values from this column will be rendered as media files. Leave empty to render media from all columns.",
-  "mediaFilebrowserDefault": "Filebrowser (Guardian Connector default)",
+  "mediaFilebrowserDefault": "Filebrowser (default)",
   "mediaGenericHttpBaseUrl": "Generic HTTP base URL",
   "mediaImageOpenModal": "View larger image",
   "mediaInvalidFormat": "Invalid format. Please use a Filebrowser share URL or hash.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -206,7 +206,7 @@
   "mediaBaseUrl": "URL base",
   "mediaColumn": "Columna a usar para archivos de medios",
   "mediaColumnDescription": "Especifique el nombre de la columna que contiene referencias de archivos de medios (por ejemplo, foto, audio). Solo los valores de esta columna se representarán como archivos de medios. Dejar vacío para renderizar medios de todas las columnas.",
-  "mediaFilebrowserDefault": "Filebrowser (predeterminado de Guardian Connector)",
+  "mediaFilebrowserDefault": "Filebrowser (predeterminado)",
   "mediaGenericHttpBaseUrl": "URL base HTTP genérica",
   "mediaImageOpenModal": "Ver imagen ampliada",
   "mediaInvalidFormat": "Formato inválido. Por favor, use una URL de compartir de Filebrowser o hash.",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -207,7 +207,7 @@
   "mediaBaseUrl": "Basis URL",
   "mediaColumn": "Kolom om te gebruiken voor mediabestanden",
   "mediaColumnDescription": "Specificeer de kolomnaam die verwijzingen naar mediabestanden bevat (bijv. foto, audio). Alleen waarden uit deze kolom worden weergegeven als mediabestanden. Laat leeg om media uit alle kolommen weer te geven.",
-  "mediaFilebrowserDefault": "Filebrowser (Guardian Connector standaard)",
+  "mediaFilebrowserDefault": "Filebrowser (standaard)",
   "mediaGenericHttpBaseUrl": "Generieke HTTP basis URL",
   "mediaImageOpenModal": "Grotere afbeelding tonen",
   "mediaInvalidFormat": "Ongeldig formaat. Gebruik alstublieft een Filebrowser deel-URL of hash.",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -206,7 +206,7 @@
   "mediaBaseUrl": "URL base",
   "mediaColumn": "Coluna a usar para arquivos de mídia",
   "mediaColumnDescription": "Especifique o nome da coluna que contém referências de arquivos de mídia (por exemplo, foto, áudio). Apenas valores desta coluna serão renderizados como arquivos de mídia. Deixe vazio para renderizar mídia de todas as colunas.",
-  "mediaFilebrowserDefault": "Filebrowser (padrão do Guardian Connector)",
+  "mediaFilebrowserDefault": "Filebrowser (padrão)",
   "mediaGenericHttpBaseUrl": "URL base HTTP genérica",
   "mediaImageOpenModal": "Ver imagem ampliada",
   "mediaInvalidFormat": "Formato inválido. Por favor, use uma URL de compartilhamento do Filebrowser ou hash.",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -210,7 +210,7 @@
   "mediaBaseUrl": "URL ya msingi",
   "mediaColumn": "Safu ya kutumia kwa faili za midia",
   "mediaColumnDescription": "Eleza jina la safu linalo marejeleo ya faili za midia (k.m., picha, sauti). Thamani kutoka safu hii pekee zitaonyeshwa kama faili za midia. Acha tupu ili kuonyesha midia kutoka safu zote.",
-  "mediaFilebrowserDefault": "Filebrowser (chaguo-msingi la Guardian Connector)",
+  "mediaFilebrowserDefault": "Filebrowser (chaguo-msingi)",
   "mediaGenericHttpBaseUrl": "URL ya msingi ya HTTP ya jumla",
   "mediaImageOpenModal": "Angalia picha kubwa",
   "mediaInvalidFormat": "Muundo si sahihi. Tafadhali tumia URL ya kushiriki ya Filebrowser au hash.",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -210,7 +210,7 @@
   "mediaBaseUrl": "Base URL",
   "mediaColumn": "คอลัมน์สำหรับไฟล์สื่อ",
   "mediaColumnDescription": "ระบุชื่อคอลัมน์ที่มีการอ้างอิงไฟล์สื่อ (เช่น รูป เสียง) เฉพาะค่าจากคอลัมน์นี้จะแสดงเป็นสื่อ เว้นว่างเพื่อแสดงสื่อจากทุกคอลัมน์",
-  "mediaFilebrowserDefault": "Filebrowser (ค่าเริ่มต้น Guardian Connector)",
+  "mediaFilebrowserDefault": "Filebrowser (ค่าเริ่มต้น)",
   "mediaGenericHttpBaseUrl": "HTTP base URL ทั่วไป",
   "mediaImageOpenModal": "ดูรูปขนาดใหญ่",
   "mediaInvalidFormat": "รูปแบบไม่ถูกต้อง โปรดใช้ URL แชร์ Filebrowser หรือแฮช",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,7 +92,7 @@ export default defineNuxtConfig({
     quality: 80,
   },
 
-  css: ["@/assets/overlay.css"],
+  css: ["@/assets/overlay.css", "@/assets/config-tags.css"],
 
   i18n: {
     locales: [

--- a/pages/config/new/[view_type].vue
+++ b/pages/config/new/[view_type].vue
@@ -193,7 +193,7 @@ definePageMeta({ layout: "explorer" });
       <div
         class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6"
       >
-        <div class="min-w-0 flex-1 space-y-6">
+        <div class="min-w-0 flex-1 grid grid-cols-1 md:grid-cols-2 gap-6">
           <SelectDatasetField
             id="create-form-primary"
             v-model="primaryDataset"

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -347,6 +347,37 @@ test("config page - view metadata displays current view type outside ConfigCard"
   await expect(viewsSection).toHaveCount(0);
 });
 
+test("config page - map number fields sit in two columns on desktop", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await openMapConfigEditPage(page);
+
+  const zoom = page.locator('input[id$="-MAPBOX_ZOOM"]');
+  const latitude = page.locator('input[id$="-MAPBOX_CENTER_LATITUDE"]');
+  await expect(zoom).toBeVisible({ timeout: 10000 });
+  await expect(latitude).toBeVisible();
+
+  const [zoomBox, latitudeBox] = await Promise.all([
+    zoom.boundingBox(),
+    latitude.boundingBox(),
+  ]);
+  expect(zoomBox).not.toBeNull();
+  expect(latitudeBox).not.toBeNull();
+  expect(latitudeBox!.x).toBeGreaterThan(zoomBox!.x + zoomBox!.width / 2);
+  expect(Math.abs(latitudeBox!.y - zoomBox!.y)).toBeLessThan(24);
+
+  await page.setViewportSize({ width: 375, height: 800 });
+  const [stackedZoomBox, stackedLatitudeBox] = await Promise.all([
+    zoom.boundingBox(),
+    latitude.boundingBox(),
+  ]);
+  expect(stackedZoomBox).not.toBeNull();
+  expect(stackedLatitudeBox).not.toBeNull();
+  expect(stackedLatitudeBox!.y).toBeGreaterThan(
+    stackedZoomBox!.y + stackedZoomBox!.height / 2,
+  );
+});
+
 test("config page - edit secondary dataset for Alert and Map views", async ({
   authenticatedPageAsAdmin: page,
 }) => {

--- a/tests/unit/components/ConfigFilters.test.ts
+++ b/tests/unit/components/ConfigFilters.test.ts
@@ -62,4 +62,13 @@ describe("ConfigFilters", () => {
       SECONDARY_FILTER_VALUES: "active",
     });
   });
+
+  it("keeps tag fields full width of the grid", () => {
+    const wrapper = mountConfigFilters();
+
+    expect(wrapper.get(".tag-field").classes()).toContain("w-full");
+    expect(
+      wrapper.get(".tag-field").element.parentElement?.className,
+    ).toContain("md:col-span-2");
+  });
 });

--- a/tests/unit/components/ConfigMap.test.ts
+++ b/tests/unit/components/ConfigMap.test.ts
@@ -806,4 +806,22 @@ describe("ConfigMap component", () => {
     const iconColumnInput = wrapper.find('input[id="test_table-ICON_COLUMN"]');
     expect(iconColumnInput.attributes("placeholder")).toBe("icon");
   });
+
+  it("uses a two-column grid and keeps the token field full width", () => {
+    const wrapper = mount(ConfigMap, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    expect(wrapper.get("[data-testid='config-field-grid']").classes()).toEqual(
+      expect.arrayContaining(["grid", "grid-cols-1", "md:grid-cols-2"]),
+    );
+    expect(
+      wrapper.get("#test_table-MAPBOX_ACCESS_TOKEN").element.parentElement
+        ?.className,
+    ).toContain("md:col-span-2");
+    expect(
+      wrapper.get("#test_table-MAPBOX_ZOOM").element.parentElement?.className,
+    ).not.toContain("md:col-span-2");
+  });
 });

--- a/tests/unit/components/ConfigMap.test.ts
+++ b/tests/unit/components/ConfigMap.test.ts
@@ -824,4 +824,46 @@ describe("ConfigMap component", () => {
       wrapper.get("#test_table-MAPBOX_ZOOM").element.parentElement?.className,
     ).not.toContain("md:col-span-2");
   });
+
+  it("places the 3D checkbox and slider side by side when 3D is on", async () => {
+    const wrapper = mount(ConfigMap, {
+      props: {
+        ...baseProps,
+        config: { ...baseProps.config, MAPBOX_3D: true },
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.get("[data-testid='config-3d-grid']").classes()).toEqual(
+      expect.arrayContaining(["grid", "grid-cols-1", "md:grid-cols-2"]),
+    );
+    expect(wrapper.get("#test_table-MAPBOX_3D").exists()).toBe(true);
+    expect(wrapper.findComponent({ name: "VueSlider" }).exists()).toBe(true);
+  });
+
+  it("hides the terrain slider until 3D is enabled", () => {
+    const wrapper = mount(ConfigMap, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    expect(wrapper.get("#test_table-MAPBOX_3D").exists()).toBe(true);
+    expect(wrapper.findComponent({ name: "VueSlider" }).exists()).toBe(false);
+  });
+
+  it("keeps the legend tag field full width of the grid", () => {
+    const wrapper = mount(ConfigMap, {
+      props: {
+        ...baseProps,
+        keys: [...baseProps.keys, "MAP_LEGEND_LAYER_IDS"],
+      },
+      global: globalConfig,
+    });
+
+    const tagField = wrapper.get(".tag-field");
+    expect(tagField.classes()).toContain("w-full");
+    expect(tagField.element.parentElement?.className).toContain(
+      "md:col-span-2",
+    );
+  });
 });

--- a/tests/unit/components/ConfigMedia.test.ts
+++ b/tests/unit/components/ConfigMedia.test.ts
@@ -89,7 +89,7 @@ const globalConfig = {
       const translations: Record<string, string> = {
         mediaAccepts: "Accepts:",
         mediaBaseUrl: "Base URL",
-        mediaFilebrowserDefault: "Filebrowser (Guardian Connector default)",
+        mediaFilebrowserDefault: "Filebrowser (default)",
         mediaGenericHttpBaseUrl: "Generic HTTP base URL",
         mediaInvalidFormat:
           "Invalid format. Please use a Filebrowser share URL or hash.",


### PR DESCRIPTION
## Goal

Closes #439. Put Config create and edit fields in a two-column grid on desktop. Stack the same fields on a small screen.


## Screenshots

<img width="1095" height="480" alt="Screenshot 2026-08-17 at 13 50 19" src="https://github.com/user-attachments/assets/8f298e8d-6ad1-4bf4-88f1-ca8f841ff067" />
<img width="715" height="716" alt="Screenshot 2026-08-17 at 13 52 08" src="https://github.com/user-attachments/assets/6c15a360-0530-477e-9502-1fbcb84f9642" />




## What I changed and why

- Config sections now use a `grid-cols-1 md:grid-cols-2` field grid so short fields share a row on wider screens
- Basemap manager, access token, 3D toggle, tag inputs, Planet API key, view description, and each media path group span both columns
- Within a media path group, provider and URL remain paired

## How I convinced myself this is right

Checking manually and the e2e test checks that they sit side by side at desktop width and stack at 375px. Token, 3D, tags, and the basemap manager need the full row, so they use `md:col-span-2`.


## What I'm not doing here

Nothing extrenous


## LLM use disclosure

Cursor Grok helped with tests only. 