### PR TITLE
Config: implement stylistic parameters from mockups like purple backgrounds for fields

### DIFF
--- a/assets/config-form.css
+++ b/assets/config-form.css
@@ -1,0 +1,82 @@
+/* Styles for VueTagsInput internals that Tailwind cannot target. */
+.tag-field.vue-tags-input {
+  width: 100%;
+  max-width: none;
+  position: relative;
+  background-color: #ede9fe;
+  border: 1px solid #ddd6fe;
+  border-radius: 0.5rem;
+}
+
+.tag-field.vue-tags-input:focus-within {
+  border-color: #8b5cf6;
+  box-shadow: 0 0 0 2px #8b5cf6;
+}
+
+.tag-field .ti-input {
+  display: flex;
+  padding: 0.5rem 1rem;
+  flex-wrap: wrap;
+  border: none;
+  background-color: transparent;
+}
+
+.tag-field .ti-tags {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  line-height: 1em;
+}
+
+.tag-field .ti-tag {
+  display: flex;
+  align-items: center;
+  margin: 0.125rem;
+  padding: 0.25rem 0.625rem;
+  background-color: #ddd6fe;
+  color: #6d28d9;
+  border-radius: 9999px;
+  font-size: 0.85em;
+}
+
+.tag-field .ti-tag .ti-content {
+  display: flex;
+  align-items: center;
+}
+
+.tag-field .ti-tag .ti-actions {
+  display: flex;
+  align-items: center;
+  margin-left: 0.25rem;
+}
+
+.tag-field .ti-tag .ti-actions i {
+  cursor: pointer;
+}
+
+.tag-field .ti-icon-close:before {
+  content: "\00d7";
+  font-family: inherit;
+  font-style: normal;
+}
+
+.tag-field .ti-new-tag-input-wrapper {
+  display: flex;
+  flex: 1 0 auto;
+  padding: 0.25rem 0.5rem;
+  margin: 0.125rem;
+}
+
+.tag-field .ti-new-tag-input-wrapper input,
+.tag-field .ti-new-tag-input {
+  flex: 1 0 auto;
+  min-width: 100px;
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+}
+
+.tag-field .ti-new-tag-input:focus {
+  outline: none;
+}

--- a/assets/config-form.css
+++ b/assets/config-form.css
@@ -1,5 +1,6 @@
-/* Styles for VueTagsInput internals that Tailwind cannot target. */
-.tag-field.vue-tags-input {
+/* VueTagsInput ships scoped CSS (.ti-tag[data-v-…] is 0,2,0 and loads after
+   this file). Selectors here stay at 0,3,0 so the mockup chrome wins. */
+.tag-field.vue-tags-input.vue-tags-input {
   width: 100%;
   max-width: none;
   position: relative;
@@ -8,12 +9,12 @@
   border-radius: 0.5rem;
 }
 
-.tag-field.vue-tags-input:focus-within {
+.tag-field.vue-tags-input.vue-tags-input:focus-within {
   border-color: #8b5cf6;
   box-shadow: 0 0 0 2px #8b5cf6;
 }
 
-.tag-field .ti-input {
+.tag-field.vue-tags-input .ti-input {
   display: flex;
   padding: 0.5rem 1rem;
   flex-wrap: wrap;
@@ -21,14 +22,14 @@
   background-color: transparent;
 }
 
-.tag-field .ti-tags {
+.tag-field.vue-tags-input .ti-tags {
   display: flex;
   flex-wrap: wrap;
   width: 100%;
   line-height: 1em;
 }
 
-.tag-field .ti-tag {
+.tag-field.vue-tags-input .ti-tag {
   display: flex;
   align-items: center;
   margin: 0.125rem;
@@ -39,36 +40,36 @@
   font-size: 0.85em;
 }
 
-.tag-field .ti-tag .ti-content {
+.tag-field.vue-tags-input .ti-tag .ti-content {
   display: flex;
   align-items: center;
 }
 
-.tag-field .ti-tag .ti-actions {
+.tag-field.vue-tags-input .ti-tag .ti-actions {
   display: flex;
   align-items: center;
   margin-left: 0.25rem;
 }
 
-.tag-field .ti-tag .ti-actions i {
+.tag-field.vue-tags-input .ti-tag .ti-actions i {
   cursor: pointer;
 }
 
-.tag-field .ti-icon-close:before {
+.tag-field.vue-tags-input .ti-icon-close:before {
   content: "\00d7";
   font-family: inherit;
   font-style: normal;
 }
 
-.tag-field .ti-new-tag-input-wrapper {
+.tag-field.vue-tags-input .ti-new-tag-input-wrapper {
   display: flex;
   flex: 1 0 auto;
   padding: 0.25rem 0.5rem;
   margin: 0.125rem;
 }
 
-.tag-field .ti-new-tag-input-wrapper input,
-.tag-field .ti-new-tag-input {
+.tag-field.vue-tags-input .ti-new-tag-input-wrapper input,
+.tag-field.vue-tags-input .ti-new-tag-input {
   flex: 1 0 auto;
   min-width: 100px;
   border: none;
@@ -77,6 +78,6 @@
   margin: 0;
 }
 
-.tag-field .ti-new-tag-input:focus {
+.tag-field.vue-tags-input .ti-new-tag-input:focus {
   outline: none;
 }

--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -234,10 +234,8 @@ const handleSubmit = () => {
   <div
     class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden"
   >
-    <div
-      class="bg-gray-50 border-b border-gray-200 px-6 py-4"
-    >
-      <h2 class="text-xl font-bold text-gray-800">
+    <div class="border-b border-slate-200 bg-slate-50 px-6 py-4">
+      <h2 class="text-balance text-xl font-bold text-slate-800">
         {{ $t("configurationOptions") }}
       </h2>
     </div>

--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -235,7 +235,7 @@ const handleSubmit = () => {
     class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden"
   >
     <div
-      class="bg-gradient-to-r from-violet-100 to-violet-50 border-b border-violet-200 px-6 py-4"
+      class="bg-gray-50 border-b border-gray-200 px-6 py-4"
     >
       <h2 class="text-xl font-bold text-gray-800">
         {{ $t("configurationOptions") }}

--- a/components/config/ConfigCollapsibleSection.vue
+++ b/components/config/ConfigCollapsibleSection.vue
@@ -20,22 +20,31 @@ const toggle = () => {
 <template>
   <div
     data-testid="config-section-collapsible"
-    class="bg-gray-50 rounded-lg border border-gray-200 mb-4 overflow-hidden"
+    class="mb-4 last:mb-0 overflow-hidden rounded-3xl bg-slate-50 shadow-[0px_0px_0px_1px_rgba(0,0,0,0.06),0px_1px_2px_-1px_rgba(0,0,0,0.06),0px_2px_4px_0px_rgba(0,0,0,0.04)]"
   >
     <button
       type="button"
       :data-testid="`config-section-${title.toLowerCase()}-toggle`"
-      class="w-full flex items-center justify-between p-4 bg-gray-100 hover:bg-gray-200 transition-colors text-left border-b border-gray-200"
+      class="flex min-h-10 w-full items-center justify-between bg-slate-100 py-4 pl-4 pr-3.5 text-left transition-[background-color] duration-150 ease-out hover:bg-slate-200/80"
       @click="toggle"
     >
-      <h3 class="text-lg font-semibold text-gray-800">{{ title }}</h3>
+      <h3 class="text-balance text-lg font-semibold text-slate-800">
+        {{ title }}
+      </h3>
       <ChevronDown
-        class="w-5 h-5 text-violet-700 transition-transform"
+        class="h-5 w-5 shrink-0 text-violet-600 transition-transform duration-200 ease-out"
         :class="{ 'rotate-180': isOpen }"
       />
     </button>
-    <div v-show="isOpen" class="p-4">
-      <slot></slot>
+    <div
+      class="grid transition-[grid-template-rows] duration-200 ease-out"
+      :class="isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'"
+    >
+      <div class="min-h-0 overflow-hidden">
+        <div class="p-4">
+          <slot></slot>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/components/config/ConfigCollapsibleSection.vue
+++ b/components/config/ConfigCollapsibleSection.vue
@@ -36,15 +36,8 @@ const toggle = () => {
         :class="{ 'rotate-180': isOpen }"
       />
     </button>
-    <div
-      class="grid transition-[grid-template-rows] duration-200 ease-out"
-      :class="isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'"
-    >
-      <div class="min-h-0 overflow-hidden">
-        <div class="p-4">
-          <slot></slot>
-        </div>
-      </div>
+    <div v-show="isOpen" class="p-4">
+      <slot></slot>
     </div>
   </div>
 </template>

--- a/components/config/ConfigCollapsibleSection.vue
+++ b/components/config/ConfigCollapsibleSection.vue
@@ -20,12 +20,12 @@ const toggle = () => {
 <template>
   <div
     data-testid="config-section-collapsible"
-    class="bg-violet-50 rounded-lg border border-violet-200 mb-4 overflow-hidden"
+    class="bg-gray-50 rounded-lg border border-gray-200 mb-4 overflow-hidden"
   >
     <button
       type="button"
       :data-testid="`config-section-${title.toLowerCase()}-toggle`"
-      class="w-full flex items-center justify-between p-4 bg-violet-100 hover:bg-violet-200 transition-colors text-left"
+      class="w-full flex items-center justify-between p-4 bg-gray-100 hover:bg-gray-200 transition-colors text-left border-b border-gray-200"
       @click="toggle"
     >
       <h3 class="text-lg font-semibold text-gray-800">{{ title }}</h3>

--- a/components/config/ConfigFilters.vue
+++ b/components/config/ConfigFilters.vue
@@ -72,7 +72,7 @@ const handleInput = (key: string, value: string): void => {
         <input
           :id="`${tableName}-${key}`"
           :value="config[key]"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
           type="text"
           @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
         />
@@ -87,7 +87,7 @@ const handleInput = (key: string, value: string): void => {
         <input
           :id="`${tableName}-${key}`"
           :value="config[key]"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
           type="text"
           placeholder="e.g. End or created_at"
           @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
@@ -105,6 +105,7 @@ const handleInput = (key: string, value: string): void => {
           {{ $t(toCamelCase(key)) }}
         </label>
         <VueTagsInput
+          :id="`${tableName}-${key}`"
           class="tag-field w-full"
           :tags="tags[key]"
           @tags-changed="(newTags: Tag[]) => handleTagsChanged(key, newTags)"

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -354,7 +354,7 @@ const fullWidthKeys = [
             <button
               type="button"
               data-testid="basemap-add-button"
-              class="w-full px-4 py-2 text-sm font-medium text-violet-700 bg-white border border-violet-200 rounded-lg hover:bg-violet-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="w-full px-4 py-2 text-sm font-medium text-violet-700 bg-white border border-violet-200 rounded-lg hover:bg-violet-50 active:scale-[0.96] transition-[transform,background-color,border-color,color] duration-150 ease-out disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
               :disabled="!canAddBasemap"
               @click="addBasemap"
             >
@@ -404,7 +404,7 @@ const fullWidthKeys = [
           </label>
           <input
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors tabular-nums"
             type="number"
             step="any"
             :min="

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -279,13 +279,19 @@ const fullWidthKeys = [
                 </div>
                 <div class="flex-1 space-y-3">
                   <div>
+                    <label
+                      :for="`${tableName}-basemap-name-${index}`"
+                      class="block text-sm font-medium text-gray-700 mb-1"
+                    >
+                      {{ $t("basemapName") }}
+                    </label>
                     <input
                       :id="`${tableName}-basemap-name-${index}`"
-                      class="w-full px-4 py-2 border rounded-lg transition-colors"
+                      class="w-full px-4 py-2 bg-violet-100 border rounded-lg transition-colors"
                       :class="{
                         'border-red-300 focus:ring-red-500 focus:border-red-500':
                           !isNameValid(index, basemap.name),
-                        'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
+                        'border-violet-200 focus:ring-violet-500 focus:border-violet-500':
                           isNameValid(index, basemap.name) || !basemap.name,
                       }"
                       :placeholder="$t('basemapName')"
@@ -306,25 +312,33 @@ const fullWidthKeys = [
                       {{ getValidationError(index, basemap.name) }}
                     </span>
                   </div>
-                  <input
-                    :id="`${tableName}-basemap-style-${index}`"
-                    class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-                    pattern="^mapbox:\/\/styles\/[^\/]+\/[^\/]+$"
-                    placeholder="mapbox://styles/user/styleId"
-                    :title="
-                      $t('pleaseMatchFormat') +
-                      ': mapbox://styles/username/styleid'
-                    "
-                    :value="basemap.style"
-                    required
-                    @input="
-                      updateBasemap(
-                        index,
-                        'style',
-                        ($event.target as HTMLInputElement).value,
-                      )
-                    "
-                  />
+                  <div>
+                    <label
+                      :for="`${tableName}-basemap-style-${index}`"
+                      class="block text-sm font-medium text-gray-700 mb-1"
+                    >
+                      {{ $t("mapboxStyle") }}
+                    </label>
+                    <input
+                      :id="`${tableName}-basemap-style-${index}`"
+                      class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+                      pattern="^mapbox:\/\/styles\/[^\/]+\/[^\/]+$"
+                      placeholder="mapbox://styles/user/styleId"
+                      :title="
+                        $t('pleaseMatchFormat') +
+                        ': mapbox://styles/username/styleid'
+                      "
+                      :value="basemap.style"
+                      required
+                      @input="
+                        updateBasemap(
+                          index,
+                          'style',
+                          ($event.target as HTMLInputElement).value,
+                        )
+                      "
+                    />
+                  </div>
                 </div>
                 <button
                   v-if="index !== 0"
@@ -359,7 +373,7 @@ const fullWidthKeys = [
           </label>
           <input
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             pattern="^pk\.ey.*"
             placeholder="pk.ey…"
             :title="$t('pleaseMatchFormat') + ': pk.ey… '"
@@ -390,7 +404,7 @@ const fullWidthKeys = [
           </label>
           <input
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             type="number"
             step="any"
             :min="
@@ -438,7 +452,7 @@ const fullWidthKeys = [
           </label>
           <select
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             :value="config[key]"
             @change="
               (e) => handleInput(key, (e.target as HTMLSelectElement).value)
@@ -476,7 +490,7 @@ const fullWidthKeys = [
                 <input
                   :id="`${tableName}-${key}`"
                   type="checkbox"
-                  class="w-5 h-5 text-violet-600 border-gray-300 rounded focus:ring-violet-500 focus:ring-2"
+                  class="w-5 h-5 text-violet-600 accent-violet-600 bg-violet-100 border-violet-200 rounded focus:ring-violet-500 focus:ring-2"
                   :checked="Boolean(config[key])"
                   @change="
                     (e) =>
@@ -523,6 +537,7 @@ const fullWidthKeys = [
             {{ $t(toCamelCase(key)) }}
           </label>
           <VueTagsInput
+            :id="`${tableName}-${key}`"
             class="tag-field w-full"
             :tags="tags[key]"
             @tags-changed="(newTags: Tag[]) => handleTagsChanged(key, newTags)"
@@ -539,7 +554,7 @@ const fullWidthKeys = [
           </label>
           <input
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             type="text"
             :value="config[key]"
             @input="
@@ -558,7 +573,7 @@ const fullWidthKeys = [
           </label>
           <input
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             type="text"
             placeholder="color"
             :value="config[key]"
@@ -579,7 +594,7 @@ const fullWidthKeys = [
           </label>
           <input
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             type="text"
             placeholder="icon"
             :value="config[key]"

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -354,7 +354,7 @@ const fullWidthKeys = [
             <button
               type="button"
               data-testid="basemap-add-button"
-              class="w-full px-4 py-2 text-sm font-medium text-violet-700 bg-violet-50 border border-violet-200 rounded-lg hover:bg-violet-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="w-full px-4 py-2 text-sm font-medium text-violet-700 bg-white border border-violet-200 rounded-lg hover:bg-violet-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               :disabled="!canAddBasemap"
               @click="addBasemap"
             >

--- a/components/config/ConfigMedia.vue
+++ b/components/config/ConfigMedia.vue
@@ -246,7 +246,7 @@ watch(
           </label>
           <select
             :id="`${tableName}-provider-basePath`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             :value="providerBasePath"
             @change="
               handleProviderChange(
@@ -272,11 +272,11 @@ watch(
             </label>
             <input
               :id="`${tableName}-share-basePath`"
-              class="w-full px-4 py-2 border rounded-lg transition-colors"
+              class="w-full px-4 py-2 bg-violet-100 border rounded-lg transition-colors"
               :class="{
                 'border-red-300 focus:ring-red-500 focus:border-red-500':
                   !isBasePathValid && shareInputBasePath,
-                'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
+                'bg-violet-100 border-violet-200 focus:ring-violet-500 focus:border-violet-500':
                   isBasePathValid || !shareInputBasePath,
               }"
               type="text"
@@ -319,7 +319,7 @@ watch(
             </label>
             <input
               :id="`${tableName}-baseUrl-generic-basePath`"
-              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+              class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
               type="url"
               :value="shareInputBasePath"
               placeholder="https://your-files-host.example/api/public/dl/"
@@ -354,7 +354,7 @@ watch(
           </label>
           <select
             :id="`${tableName}-provider-alerts`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             :value="providerAlerts"
             @change="
               handleProviderChange(
@@ -380,11 +380,11 @@ watch(
             </label>
             <input
               :id="`${tableName}-share-alerts`"
-              class="w-full px-4 py-2 border rounded-lg transition-colors"
+              class="w-full px-4 py-2 bg-violet-100 border rounded-lg transition-colors"
               :class="{
                 'border-red-300 focus:ring-red-500 focus:border-red-500':
                   !isAlertsValid && shareInputAlerts,
-                'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
+                'bg-violet-100 border-violet-200 focus:ring-violet-500 focus:border-violet-500':
                   isAlertsValid || !shareInputAlerts,
               }"
               type="text"
@@ -424,7 +424,7 @@ watch(
             </label>
             <input
               :id="`${tableName}-baseUrl-generic-alerts`"
-              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+              class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
               type="url"
               :value="shareInputAlerts"
               placeholder="https://your-files-host.example/api/public/dl/"
@@ -456,7 +456,7 @@ watch(
           </label>
           <select
             :id="`${tableName}-provider-icons`"
-            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors bg-white"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
             :value="providerIcons"
             @change="
               handleProviderChange(
@@ -482,11 +482,11 @@ watch(
             </label>
             <input
               :id="`${tableName}-share-icons`"
-              class="w-full px-4 py-2 border rounded-lg transition-colors"
+              class="w-full px-4 py-2 bg-violet-100 border rounded-lg transition-colors"
               :class="{
                 'border-red-300 focus:ring-red-500 focus:border-red-500':
                   !isIconsValid && shareInputIcons,
-                'border-gray-300 focus:ring-violet-500 focus:border-violet-500':
+                'bg-violet-100 border-violet-200 focus:ring-violet-500 focus:border-violet-500':
                   isIconsValid || !shareInputIcons,
               }"
               type="text"
@@ -526,7 +526,7 @@ watch(
             </label>
             <input
               :id="`${tableName}-baseUrl-generic-icons`"
-              class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+              class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
               type="url"
               :value="shareInputIcons"
               placeholder="https://your-files-host.example/api/public/dl/"
@@ -541,7 +541,10 @@ watch(
 
     <!-- MEDIA_COLUMN -->
     <div v-if="keys.includes('MEDIA_COLUMN')" class="space-y-2">
-      <label class="block text-sm font-medium text-gray-700">
+      <label
+        :for="`${tableName}-media-column`"
+        class="block text-sm font-medium text-gray-700"
+      >
         {{ $t(toCamelCase("MEDIA_COLUMN")) }}
       </label>
       <p class="text-xs text-gray-500 mb-2">
@@ -549,7 +552,7 @@ watch(
       </p>
       <input
         :id="`${tableName}-media-column`"
-        class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+        class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
         type="text"
         :value="mediaColumn"
         placeholder="photo"

--- a/components/config/ConfigPermissions.vue
+++ b/components/config/ConfigPermissions.vue
@@ -82,7 +82,7 @@ watch(
 
     <div class="flex flex-col gap-3">
       <label
-        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 bg-violet-100 transition-all duration-200"
+        class="flex items-start gap-3 cursor-pointer p-3 rounded-xl border-2 bg-violet-100 transition-[border-color,background-color] duration-150 ease-out"
         :class="
           routeLevelPermission === 'anyone'
             ? 'border-violet-500'
@@ -99,14 +99,14 @@ watch(
           <span class="font-semibold text-gray-700">{{
             $t("visibilityPublic")
           }}</span>
-          <span class="text-sm text-gray-500 leading-relaxed">{{
+          <span class="text-pretty text-sm text-gray-500 leading-relaxed">{{
             $t("visibilityPublicDescription")
           }}</span>
         </div>
       </label>
 
       <label
-        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 bg-violet-100 transition-all duration-200"
+        class="flex items-start gap-3 cursor-pointer p-3 rounded-xl border-2 bg-violet-100 transition-[border-color,background-color] duration-150 ease-out"
         :class="
           routeLevelPermission === 'guest'
             ? 'border-violet-500'
@@ -123,14 +123,14 @@ watch(
           <span class="font-semibold text-gray-700">{{
             $t("visibilityGuest")
           }}</span>
-          <span class="text-sm text-gray-500 leading-relaxed">{{
+          <span class="text-pretty text-sm text-gray-500 leading-relaxed">{{
             $t("visibilityGuestDescription")
           }}</span>
         </div>
       </label>
 
       <label
-        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 bg-violet-100 transition-all duration-200"
+        class="flex items-start gap-3 cursor-pointer p-3 rounded-xl border-2 bg-violet-100 transition-[border-color,background-color] duration-150 ease-out"
         :class="
           routeLevelPermission === 'member'
             ? 'border-violet-500'
@@ -147,14 +147,14 @@ watch(
           <span class="font-semibold text-gray-700">{{
             $t("visibilityMembers")
           }}</span>
-          <span class="text-sm text-gray-500 leading-relaxed">{{
+          <span class="text-pretty text-sm text-gray-500 leading-relaxed">{{
             $t("visibilityMembersDescription")
           }}</span>
         </div>
       </label>
 
       <label
-        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 bg-violet-100 transition-all duration-200"
+        class="flex items-start gap-3 cursor-pointer p-3 rounded-xl border-2 bg-violet-100 transition-[border-color,background-color] duration-150 ease-out"
         :class="
           routeLevelPermission === 'admin'
             ? 'border-violet-500'
@@ -171,7 +171,7 @@ watch(
           <span class="font-semibold text-gray-700">{{
             $t("visibilityAdmins")
           }}</span>
-          <span class="text-sm text-gray-500 leading-relaxed">{{
+          <span class="text-pretty text-sm text-gray-500 leading-relaxed">{{
             $t("visibilityAdminsDescription")
           }}</span>
         </div>

--- a/components/config/ConfigPermissions.vue
+++ b/components/config/ConfigPermissions.vue
@@ -82,18 +82,18 @@ watch(
 
     <div class="flex flex-col gap-3">
       <label
-        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 transition-all duration-200"
+        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 bg-violet-100 transition-all duration-200"
         :class="
           routeLevelPermission === 'anyone'
-            ? 'border-violet-500 bg-violet-50'
-            : 'border-gray-200 hover:border-violet-300 hover:bg-violet-50/50'
+            ? 'border-violet-500'
+            : 'border-violet-200 hover:border-violet-300'
         "
       >
         <input
           v-model="routeLevelPermission"
           type="radio"
           value="anyone"
-          class="mt-0.5 flex-shrink-0 w-5 h-5 text-violet-600 border-gray-300 focus:ring-violet-500"
+          class="mt-0.5 flex-shrink-0 w-5 h-5 text-violet-600 accent-violet-600 bg-violet-100 border-violet-200 focus:ring-violet-500"
         />
         <div class="flex flex-col gap-1">
           <span class="font-semibold text-gray-700">{{
@@ -106,18 +106,18 @@ watch(
       </label>
 
       <label
-        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 transition-all duration-200"
+        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 bg-violet-100 transition-all duration-200"
         :class="
           routeLevelPermission === 'guest'
-            ? 'border-violet-500 bg-violet-50'
-            : 'border-gray-200 hover:border-violet-300 hover:bg-violet-50/50'
+            ? 'border-violet-500'
+            : 'border-violet-200 hover:border-violet-300'
         "
       >
         <input
           v-model="routeLevelPermission"
           type="radio"
           value="guest"
-          class="mt-0.5 flex-shrink-0 w-5 h-5 text-violet-600 border-gray-300 focus:ring-violet-500"
+          class="mt-0.5 flex-shrink-0 w-5 h-5 text-violet-600 accent-violet-600 bg-violet-100 border-violet-200 focus:ring-violet-500"
         />
         <div class="flex flex-col gap-1">
           <span class="font-semibold text-gray-700">{{
@@ -130,18 +130,18 @@ watch(
       </label>
 
       <label
-        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 transition-all duration-200"
+        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 bg-violet-100 transition-all duration-200"
         :class="
           routeLevelPermission === 'member'
-            ? 'border-violet-500 bg-violet-50'
-            : 'border-gray-200 hover:border-violet-300 hover:bg-violet-50/50'
+            ? 'border-violet-500'
+            : 'border-violet-200 hover:border-violet-300'
         "
       >
         <input
           v-model="routeLevelPermission"
           type="radio"
           value="member"
-          class="mt-0.5 flex-shrink-0 w-5 h-5 text-violet-600 border-gray-300 focus:ring-violet-500"
+          class="mt-0.5 flex-shrink-0 w-5 h-5 text-violet-600 accent-violet-600 bg-violet-100 border-violet-200 focus:ring-violet-500"
         />
         <div class="flex flex-col gap-1">
           <span class="font-semibold text-gray-700">{{
@@ -154,18 +154,18 @@ watch(
       </label>
 
       <label
-        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 transition-all duration-200"
+        class="flex items-start gap-3 cursor-pointer p-3 rounded-lg border-2 bg-violet-100 transition-all duration-200"
         :class="
           routeLevelPermission === 'admin'
-            ? 'border-violet-500 bg-violet-50'
-            : 'border-gray-200 hover:border-violet-300 hover:bg-violet-50/50'
+            ? 'border-violet-500'
+            : 'border-violet-200 hover:border-violet-300'
         "
       >
         <input
           v-model="routeLevelPermission"
           type="radio"
           value="admin"
-          class="mt-0.5 flex-shrink-0 w-5 h-5 text-violet-600 border-gray-300 focus:ring-violet-500"
+          class="mt-0.5 flex-shrink-0 w-5 h-5 text-violet-600 accent-violet-600 bg-violet-100 border-violet-200 focus:ring-violet-500"
         />
         <div class="flex flex-col gap-1">
           <span class="font-semibold text-gray-700">{{

--- a/components/config/ConfigViewInfo.vue
+++ b/components/config/ConfigViewInfo.vue
@@ -33,7 +33,7 @@ const emit = defineEmits(["updateConfig"]);
         </label>
         <input
           :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
           placeholder="https://…"
           type="url"
           :value="config[key]"
@@ -54,7 +54,7 @@ const emit = defineEmits(["updateConfig"]);
         </label>
         <input
           :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
           :placeholder="$t('viewDisplayNamePlaceholder')"
           type="text"
           :maxlength="CONFIG_LIMITS.DATASET_TABLE"
@@ -103,7 +103,7 @@ const emit = defineEmits(["updateConfig"]);
         </label>
         <input
           :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
           placeholder="https://…"
           type="url"
           :value="config[key]"
@@ -130,7 +130,7 @@ const emit = defineEmits(["updateConfig"]);
         </label>
         <textarea
           :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors resize-y"
+          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors resize-y"
           rows="3"
           :maxlength="CONFIG_LIMITS.VIEW_DESCRIPTION"
           :placeholder="$t('viewDescriptionPlaceholder')"

--- a/components/config/CopyConfigControl.vue
+++ b/components/config/CopyConfigControl.vue
@@ -49,10 +49,17 @@ const emit = defineEmits<{
         <p class="text-sm text-gray-600 mb-4">
           {{ $t("copyConfigDescription") }}
         </p>
+        <label
+          for="copy-config-select"
+          class="block text-sm font-medium text-gray-700 mb-2"
+        >
+          {{ $t("view") }}
+        </label>
         <select
+          id="copy-config-select"
           :value="selectedSource"
           data-testid="copy-config-select"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors mb-4"
+          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors mb-4"
           @change="
             emit(
               'update:selectedSource',

--- a/components/config/SelectDatasetField.vue
+++ b/components/config/SelectDatasetField.vue
@@ -45,7 +45,7 @@ const selectOptions = computed(() => {
       :value="modelValue ?? ''"
       :data-testid="testId"
       :required="required"
-      class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+      class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
       @change="
         emit('update:modelValue', ($event.target as HTMLSelectElement).value)
       "

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,7 +92,11 @@ export default defineNuxtConfig({
     quality: 80,
   },
 
-  css: ["@/assets/overlay.css", "@/assets/config-tags.css"],
+  css: [
+    "@/assets/overlay.css",
+    "@/assets/config-tags.css",
+    "@/assets/config-form.css",
+  ],
 
   i18n: {
     locales: [

--- a/pages/config/new/index.vue
+++ b/pages/config/new/index.vue
@@ -124,7 +124,7 @@ definePageMeta({ layout: "explorer" });
           id="create-primary-dataset"
           v-model="selectedPrimary"
           data-testid="create-primary-select"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
         >
           <option value="">{{ $t("selectPrimaryDatasetOptional") }}</option>
           <option v-for="table in availableTables" :key="table" :value="table">

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -689,6 +689,9 @@ test("config page - basemap configuration - update name and style", async ({
   const hasBasemapConfig = (await basemapLabel.count()) > 0;
 
   if (hasBasemapConfig) {
+    await expect(page.getByLabel("Basemap name").first()).toBeVisible();
+    await expect(page.getByLabel("Mapbox Style").first()).toBeVisible();
+
     const nameInput = page.locator('input[id*="basemap-name-0"]').first();
     const styleInput = page.locator('input[id*="basemap-style-0"]').first();
 

--- a/tests/unit/components/ConfigFilters.test.ts
+++ b/tests/unit/components/ConfigFilters.test.ts
@@ -71,4 +71,15 @@ describe("ConfigFilters", () => {
       wrapper.get(".tag-field").element.parentElement?.className,
     ).toContain("md:col-span-2");
   });
+
+  it("associates tag field labels with the tag input", () => {
+    const wrapper = mountConfigFilters();
+
+    expect(
+      wrapper.get('label[for="alerts_table-SECONDARY_FILTER_VALUES"]').text(),
+    ).toBe("secondaryFilterValues");
+    expect(
+      wrapper.get("#alerts_table-SECONDARY_FILTER_VALUES").attributes("id"),
+    ).toBe("alerts_table-SECONDARY_FILTER_VALUES");
+  });
 });

--- a/tests/unit/components/ConfigMap.test.ts
+++ b/tests/unit/components/ConfigMap.test.ts
@@ -807,6 +807,31 @@ describe("ConfigMap component", () => {
     expect(iconColumnInput.attributes("placeholder")).toBe("icon");
   });
 
+  it("labels basemap fields and uses purple field chrome", () => {
+    const wrapper = mount(ConfigMap, {
+      props: baseProps,
+      global: globalConfig,
+    });
+
+    const nameInput = wrapper.get("#test_table-basemap-name-0");
+    const styleInput = wrapper.get("#test_table-basemap-style-0");
+    const zoomInput = wrapper.get("#test_table-MAPBOX_ZOOM");
+
+    expect(wrapper.get('label[for="test_table-basemap-name-0"]').text()).toBe(
+      "basemapName",
+    );
+    expect(wrapper.get('label[for="test_table-basemap-style-0"]').text()).toBe(
+      "mapboxStyle",
+    );
+    expect(nameInput.classes()).toContain("bg-violet-100");
+    expect(styleInput.classes()).toEqual(
+      expect.arrayContaining(["bg-violet-100", "border-violet-200"]),
+    );
+    expect(zoomInput.classes()).toEqual(
+      expect.arrayContaining(["bg-violet-100", "border-violet-200"]),
+    );
+  });
+
   it("uses a two-column grid and keeps the token field full width", () => {
     const wrapper = mount(ConfigMap, {
       props: baseProps,

--- a/tests/unit/components/ConfigMedia.test.ts
+++ b/tests/unit/components/ConfigMedia.test.ts
@@ -751,4 +751,21 @@ describe("ConfigMedia component", () => {
     );
     expect(input.element.value).toBe("keep-me");
   });
+
+  it("associates the media column label with its input", () => {
+    const wrapper = mount(ConfigMedia, {
+      props: {
+        ...baseProps,
+        keys: ["MEDIA_COLUMN"],
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.get('label[for="test_table-media-column"]').text()).toBe(
+      "mediaColumn",
+    );
+    expect(wrapper.get("#test_table-media-column").classes()).toEqual(
+      expect.arrayContaining(["bg-violet-100", "border-violet-200"]),
+    );
+  });
 });


### PR DESCRIPTION
## Goal

Closes #581. Match Config field chrome to the mockup: violet surfaces, violet borders, visible labels, and pill tags.


## Screenshots
<img width="1095" height="480" alt="Screenshot 2026-08-17 at 13 47 59" src="https://github.com/user-attachments/assets/3ff2fd77-ccf3-4fb0-9bb4-ea94b50a4705" />
<img width="1091" height="557" alt="Screenshot 2026-08-17 at 13 47 10" src="https://github.com/user-attachments/assets/ba88a638-adac-492f-914f-1324d7b63f9e" />
<img width="818" height="100" alt="Screenshot 2026-08-17 at 14 12 51" src="https://github.com/user-attachments/assets/0db7b9d4-d9cf-4272-bea7-3fdc184e6f92" />
<img width="818" height="100" alt="Screenshot 2026-08-17 at 14 13 13" src="https://github.com/user-attachments/assets/f2193db6-024f-4d66-8f4d-ab7642f44b82" />



## What I changed and why

- Config inputs and selects now use `bg-violet-100` and `border-violet-200`
- Added a small CSS file for `VueTagsInput` rendering tags as violet pills with a `×` close control, without importing the library stylesheet since it sets a `max-width: 450px` constraint
- Added visible labels for basemap name, basemap style URL, and media column
- Added `id` attributes to tag fields so existing `label for` attributes work
- Filebrowser and Generic remain selects, Visibility remains radios, and `MAPBOX_3D` remains a checkbox

## How I convinced myself this is right

Manual testing

## What I'm not doing here

Nothing extrenous

## LLM use disclosure

Cursor 4.6 for tests only.