### PR TITLE
Config: Move ViewCard to the top, and improve field organization and media rendering

### DIFF
--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -66,10 +66,10 @@ const filterKeys = computed(() =>
     : ["FRONT_END_FILTER_COLUMN", "TIMESTAMP_COLUMN", "UNWANTED_COLUMNS"],
 );
 const viewInfoKeys = computed(() => [
-  "LOGO_URL",
   "DATASET_TABLE",
-  "VIEW_HEADER_IMAGE",
   "VIEW_DESCRIPTION",
+  "VIEW_HEADER_IMAGE",
+  "LOGO_URL",
 ]);
 
 // The child config components expect a `views` array; wrap the single view type
@@ -241,6 +241,16 @@ const handleSubmit = () => {
     </div>
     <div class="p-6">
       <form @submit.prevent="handleSubmit">
+        <ConfigCollapsibleSection :title="$t('view')" :default-open="true">
+          <ConfigViewInfo
+            :table-name="tableName"
+            :views="viewTypeList"
+            :config="localConfig"
+            :keys="viewInfoKeys"
+            @update-config="handleConfigUpdate"
+          />
+        </ConfigCollapsibleSection>
+
         <ConfigCollapsibleSection
           v-if="shouldShowConfigMap"
           :title="$t('map')"
@@ -279,16 +289,6 @@ const handleSubmit = () => {
             :views="viewTypeList"
             :config="localConfig"
             :keys="filterKeys"
-            @update-config="handleConfigUpdate"
-          />
-        </ConfigCollapsibleSection>
-
-        <ConfigCollapsibleSection :title="$t('view')" :default-open="true">
-          <ConfigViewInfo
-            :table-name="tableName"
-            :views="viewTypeList"
-            :config="localConfig"
-            :keys="viewInfoKeys"
             @update-config="handleConfigUpdate"
           />
         </ConfigCollapsibleSection>

--- a/components/config/ConfigImagePreview.vue
+++ b/components/config/ConfigImagePreview.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    src: string;
+    alt: string;
+    fit?: "contain" | "cover";
+  }>(),
+  {
+    fit: "contain",
+  },
+);
+
+const imageLoaded = ref(false);
+const imageFailed = ref(false);
+const trimmedSrc = computed(() => props.src.trim());
+
+watch(trimmedSrc, () => {
+  imageLoaded.value = false;
+  imageFailed.value = false;
+});
+
+const handleLoad = () => {
+  imageLoaded.value = true;
+  imageFailed.value = false;
+};
+
+const handleError = () => {
+  imageLoaded.value = false;
+  imageFailed.value = true;
+};
+</script>
+
+<template>
+  <div
+    v-if="trimmedSrc"
+    class="relative"
+    :class="{
+      'rounded-2xl border border-slate-200 bg-white p-2': imageLoaded,
+    }"
+    :data-testid="imageLoaded ? 'config-image-preview' : undefined"
+  >
+    <p
+      v-if="imageLoaded"
+      class="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-slate-500"
+    >
+      {{ $t("imagePreview") }}
+    </p>
+    <img
+      :key="trimmedSrc"
+      :src="trimmedSrc"
+      :alt="imageLoaded ? alt : ''"
+      class="rounded-lg outline outline-1 -outline-offset-1 outline-black/10"
+      :class="
+        imageLoaded
+          ? fit === 'cover'
+            ? 'h-28 w-full object-cover'
+            : 'max-h-28 w-auto max-w-full object-contain'
+          : 'pointer-events-none absolute h-px w-px opacity-0'
+      "
+      :aria-hidden="!imageLoaded"
+      @load="handleLoad"
+      @error="handleError"
+    />
+    <p
+      v-if="imageFailed"
+      class="text-pretty text-sm text-red-600"
+      role="alert"
+      data-testid="config-image-preview-error"
+    >
+      {{ $t("imagePreviewLoadError") }}
+    </p>
+  </div>
+</template>

--- a/components/config/ConfigViewInfo.vue
+++ b/components/config/ConfigViewInfo.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ConfigImagePreview from "@/components/config/ConfigImagePreview.vue";
 import { CONFIG_LIMITS } from "@/utils";
 import { toCamelCase } from "@/utils/identifierUtils";
 import type { ViewConfig } from "@/types";
@@ -22,7 +23,9 @@ const emit = defineEmits(["updateConfig"]);
       v-for="key in keys"
       :key="key"
       class="space-y-2"
-      :class="{ 'md:col-span-2': key === 'VIEW_DESCRIPTION' }"
+      :class="{
+        'md:col-span-2': key === 'DATASET_TABLE' || key === 'VIEW_DESCRIPTION',
+      }"
     >
       <template v-if="key === 'LOGO_URL'">
         <label
@@ -43,6 +46,11 @@ const emit = defineEmits(["updateConfig"]);
                 [key]: (e.target as HTMLInputElement).value,
               })
           "
+        />
+        <ConfigImagePreview
+          :src="config.LOGO_URL ?? ''"
+          :alt="$t(toCamelCase(key))"
+          fit="contain"
         />
       </template>
       <template v-else-if="key === 'DATASET_TABLE'">
@@ -120,6 +128,11 @@ const emit = defineEmits(["updateConfig"]);
             "Optional: URL for the header background image"
           }}
         </p>
+        <ConfigImagePreview
+          :src="config.VIEW_HEADER_IMAGE ?? ''"
+          :alt="$t('viewHeaderImage')"
+          fit="cover"
+        />
       </template>
       <template v-else-if="key === 'VIEW_DESCRIPTION'">
         <label

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -119,6 +119,8 @@
   "iconColumnDescription": "Optional: Specify a column name (e.g., 'icon') that contains icon filenames (e.g., 'camp.png'). When set and icons base path is configured, point features can be displayed as icons instead of circles.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "If you are zoomed out, alerts will be shown as a",
   "imageNotFound": "Image not found",
+  "imagePreview": "Image preview",
+  "imagePreviewLoadError": "The image preview could not be loaded.",
   "incidents": "Incidents",
   "incidents.backToIncidents": "Back to saved incidents",
   "incidents.by": "By",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -116,6 +116,8 @@
   "iconColumnDescription": "Opcional: Especifique un nombre de columna (por ejemplo, 'icon') que contenga nombres de archivos de iconos (por ejemplo, 'camp.png'). Cuando se establece y la ruta base de iconos está configurada, las características de puntos se pueden mostrar como iconos en lugar de círculos.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "Si está alejado, las alertas se mostrarán como un",
   "imageNotFound": "Imagen no encontrada",
+  "imagePreview": "Vista previa de la imagen",
+  "imagePreviewLoadError": "No se pudo cargar la vista previa de la imagen.",
   "incidents": "Incidentes",
   "incidents.backToIncidents": "Volver a incidentes guardados",
   "incidents.by": "Por",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -117,6 +117,8 @@
   "iconColumnDescription": "Optioneel: Specificeer een kolomnaam (bijv. 'icon') die bestandsnamen van iconen bevat (bijv. 'camp.png'). Indien ingesteld en het basispad voor iconen is geconfigureerd, kunnen puntkenmerken worden weergegeven als iconen in plaats van cirkels.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "Als u bent uitgezoomd, worden alerts weergegeven als een",
   "imageNotFound": "Afbeelding niet gevonden",
+  "imagePreview": "Afbeeldingsvoorbeeld",
+  "imagePreviewLoadError": "Het afbeeldingsvoorbeeld kon niet worden geladen.",
   "incidents": "Incidenten",
   "incidents.backToIncidents": "Terug naar opgeslagen incidenten",
   "incidents.by": "Door",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -116,6 +116,8 @@
   "iconColumnDescription": "Opcional: Especifique um nome de coluna (por exemplo, 'icon') que contenha nomes de arquivos de ícones (por exemplo, 'camp.png'). Quando definido e o caminho base dos ícones está configurado, os recursos de pontos podem ser exibidos como ícones em vez de círculos.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "Se você estiver afastado, os alertas serão mostrados como um",
   "imageNotFound": "Imagem não encontrada",
+  "imagePreview": "Pré-visualização da imagem",
+  "imagePreviewLoadError": "Não foi possível carregar a pré-visualização da imagem.",
   "incidents": "Incidentes",
   "incidents.backToIncidents": "Voltar para incidentes salvos",
   "incidents.by": "Por",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -119,6 +119,8 @@
   "iconColumnDescription": "Hiari: Eleza jina la safu (k.m., 'icon') linalo majina ya faili za ikoni (k.m., 'camp.png'). Inapowekwa na njia ya msingi ya ikoni imesanidiwa, vipengele vya nukta vinaweza kuonyeshwa kama ikoni badala ya duara.",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "Ukiwa umevuta nje, tahadhari zitaonyeshwa kama",
   "imageNotFound": "Picha haipatikani",
+  "imagePreview": "Hakiki ya picha",
+  "imagePreviewLoadError": "Hakiki ya picha haikuweza kupakiwa.",
   "incidents": "Matukio",
   "incidents.backToIncidents": "Rudi kwenye matukio yaliyohifadhiwa",
   "incidents.by": "Na",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -119,6 +119,8 @@
   "iconColumnDescription": "ไม่บังคับ: ระบุชื่อคอลัมน์ (เช่น 'icon') ที่มีชื่อไฟล์ไอคอน (เช่น 'camp.png') เมื่อตั้งค่าและมี base path สำหรับไอคอน ฟีเจอร์จุดสามารถแสดงเป็นไอคอนแทนวงกลม",
   "ifYouAreZoomedOutAlertsWillBeShownAsA": "หากซูมออก การแจ้งเตือนจะแสดงเป็น",
   "imageNotFound": "ไม่พบรูปภาพ",
+  "imagePreview": "ตัวอย่างรูปภาพ",
+  "imagePreviewLoadError": "ไม่สามารถโหลดตัวอย่างรูปภาพได้",
   "incidents": "เหตุการณ์",
   "incidents.backToIncidents": "กลับไปเหตุการณ์ที่บันทึกไว้",
   "incidents.by": "โดย",

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -208,6 +208,115 @@ test("config page - edit dataset view form structure", async ({
   }
 });
 
+test("config page - View is first with prioritized responsive fields", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await openMapConfigEditPage(page);
+
+  const sections = page.locator(
+    "form [data-testid='config-section-collapsible']",
+  );
+  await expect(sections.first().locator("button").first()).toHaveAttribute(
+    "data-testid",
+    "config-section-view-toggle",
+  );
+
+  const viewSection = page
+    .locator("[data-testid='config-section-view-toggle']")
+    .locator("..");
+  const fieldIds = await viewSection
+    .locator("input, textarea")
+    .evaluateAll((fields) =>
+      fields.map((field) => field.id.replace(/^.*?-/, "")),
+    );
+  expect(fieldIds).toEqual([
+    "DATASET_TABLE",
+    "VIEW_DESCRIPTION",
+    "VIEW_HEADER_IMAGE",
+    "LOGO_URL",
+  ]);
+
+  const displayName = viewSection.locator('input[id$="-DATASET_TABLE"]');
+  const description = viewSection.locator('textarea[id$="-VIEW_DESCRIPTION"]');
+  const headerImage = viewSection.locator('input[id$="-VIEW_HEADER_IMAGE"]');
+  const logo = viewSection.locator('input[id$="-LOGO_URL"]');
+  const [displayBox, descriptionBox, headerBox, logoBox] = await Promise.all([
+    displayName.boundingBox(),
+    description.boundingBox(),
+    headerImage.boundingBox(),
+    logo.boundingBox(),
+  ]);
+
+  expect(displayBox).not.toBeNull();
+  expect(descriptionBox).not.toBeNull();
+  expect(headerBox).not.toBeNull();
+  expect(logoBox).not.toBeNull();
+  expect(displayBox!.width).toBeCloseTo(descriptionBox!.width, 0);
+  expect(logoBox!.x).toBeGreaterThan(headerBox!.x + headerBox!.width / 2);
+  expect(Math.abs(logoBox!.y - headerBox!.y)).toBeLessThan(24);
+
+  await page.setViewportSize({ width: 375, height: 800 });
+  const [stackedHeaderBox, stackedLogoBox] = await Promise.all([
+    headerImage.boundingBox(),
+    logo.boundingBox(),
+  ]);
+  expect(stackedHeaderBox).not.toBeNull();
+  expect(stackedLogoBox).not.toBeNull();
+  expect(stackedLogoBox!.y).toBeGreaterThan(
+    stackedHeaderBox!.y + stackedHeaderBox!.height / 2,
+  );
+});
+
+test("config page - image URL fields render previews and load errors", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  const imageBody = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  );
+  await page.route("**/__config-preview/**", async (route) => {
+    if (route.request().url().endsWith("missing.png")) {
+      await route.abort();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "image/png",
+      body: imageBody,
+    });
+  });
+  await openMapConfigEditPage(page);
+  const previewBase = `${new URL(page.url()).origin}/__config-preview`;
+
+  const viewSection = page
+    .locator("[data-testid='config-section-view-toggle']")
+    .locator("..");
+  const headerImage = viewSection.locator('input[id$="-VIEW_HEADER_IMAGE"]');
+  const logo = viewSection.locator('input[id$="-LOGO_URL"]');
+
+  await headerImage.fill(`${previewBase}/header.png`);
+  await logo.fill(`${previewBase}/logo.png`);
+
+  await expect(
+    viewSection.locator("[data-testid='config-image-preview']"),
+  ).toHaveCount(2);
+  await expect(
+    viewSection.locator(
+      `[data-testid='config-image-preview'] img[src='${previewBase}/header.png']`,
+    ),
+  ).toBeVisible();
+  await expect(
+    viewSection.locator(
+      `[data-testid='config-image-preview'] img[src='${previewBase}/logo.png']`,
+    ),
+  ).toBeVisible();
+
+  await logo.fill(`${previewBase}/missing.png`);
+  await expect(
+    viewSection.locator("[data-testid='config-image-preview-error']"),
+  ).toHaveText("The image preview could not be loaded.");
+});
+
 test("config page - cancel create leaves database unchanged", async ({
   authenticatedPageAsAdmin: page,
 }) => {

--- a/tests/unit/components/ConfigCard.mapInit.test.ts
+++ b/tests/unit/components/ConfigCard.mapInit.test.ts
@@ -57,7 +57,11 @@ const mountConfigCard = () =>
       },
       stubs: {
         BasemapSelector: true,
-        ConfigViewInfo: true,
+        ConfigViewInfo: {
+          props: ["keys"],
+          template:
+            '<div data-testid="config-view-info" :data-keys="keys.join(\',\')" />',
+        },
         ConfigFilters: true,
         ConfigMedia: true,
         ConfigPermissions: {
@@ -66,7 +70,9 @@ const mountConfigCard = () =>
         },
         ConfigViews: true,
         ConfigCollapsibleSection: {
-          template: "<div><slot /></div>",
+          props: ["title"],
+          template:
+            '<section data-testid="config-section" :data-title="title"><slot /></section>',
         },
       },
       mocks: {
@@ -76,6 +82,24 @@ const mountConfigCard = () =>
   });
 
 describe("ConfigCard map initialization", () => {
+  it("puts View before the other configuration sections", () => {
+    const wrapper = mountConfigCard();
+
+    expect(
+      wrapper
+        .findAll("[data-testid='config-section']")
+        .map((section) => section.attributes("data-title")),
+    ).toEqual(["view", "map", "media", "filtering", "visibility"]);
+  });
+
+  it("orders View fields by display name, description, header, and logo", () => {
+    const wrapper = mountConfigCard();
+
+    expect(
+      wrapper.get("[data-testid='config-view-info']").attributes("data-keys"),
+    ).toBe("DATASET_TABLE,VIEW_DESCRIPTION,VIEW_HEADER_IMAGE,LOGO_URL");
+  });
+
   it("keeps saved numeric fields visible after changing projection", async () => {
     const wrapper = mountConfigCard();
 

--- a/tests/unit/components/ConfigImagePreview.test.ts
+++ b/tests/unit/components/ConfigImagePreview.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { computed, ref, watch } from "vue";
+
+import ConfigImagePreview from "@/components/config/ConfigImagePreview.vue";
+
+Object.assign(globalThis, { computed, ref, watch });
+
+const mountPreview = (props: {
+  src: string;
+  alt: string;
+  fit?: "contain" | "cover";
+}) =>
+  mount(ConfigImagePreview, {
+    props,
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+
+describe("ConfigImagePreview", () => {
+  it("does not render for an empty source", () => {
+    const wrapper = mountPreview({ src: "   ", alt: "Logo" });
+
+    expect(wrapper.find("img").exists()).toBe(false);
+    expect(wrapper.find("[data-testid='config-image-preview']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("shows a contain preview after the image loads", async () => {
+    const wrapper = mountPreview({
+      src: "  https://example.test/logo.png  ",
+      alt: "Logo",
+    });
+
+    await wrapper.get("img").trigger("load");
+
+    const preview = wrapper.get("[data-testid='config-image-preview']");
+    const image = preview.get("img");
+    expect(image.attributes("src")).toBe("https://example.test/logo.png");
+    expect(image.attributes("alt")).toBe("Logo");
+    expect(image.classes()).toEqual(
+      expect.arrayContaining(["max-h-28", "object-contain"]),
+    );
+  });
+
+  it("uses a wide cover crop for header images", async () => {
+    const wrapper = mountPreview({
+      src: "https://example.test/header.jpg",
+      alt: "Header",
+      fit: "cover",
+    });
+
+    await wrapper.get("img").trigger("load");
+
+    expect(
+      wrapper.get("[data-testid='config-image-preview'] img").classes(),
+    ).toEqual(expect.arrayContaining(["h-28", "w-full", "object-cover"]));
+  });
+
+  it("shows an error instead of a broken image", async () => {
+    const wrapper = mountPreview({
+      src: "https://example.test/missing.png",
+      alt: "Missing image",
+    });
+
+    await wrapper.get("img").trigger("error");
+
+    expect(
+      wrapper.get("[data-testid='config-image-preview-error']").text(),
+    ).toBe("imagePreviewLoadError");
+    expect(wrapper.find("[data-testid='config-image-preview']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("resets the preview when the source changes", async () => {
+    const wrapper = mountPreview({
+      src: "https://example.test/first.png",
+      alt: "Logo",
+    });
+
+    await wrapper.get("img").trigger("load");
+    expect(wrapper.find("[data-testid='config-image-preview']").exists()).toBe(
+      true,
+    );
+
+    await wrapper.setProps({ src: "https://example.test/second.png" });
+
+    expect(wrapper.find("[data-testid='config-image-preview']").exists()).toBe(
+      false,
+    );
+    expect(wrapper.get("img").attributes("src")).toBe(
+      "https://example.test/second.png",
+    );
+  });
+});

--- a/tests/unit/components/ConfigViewInfo.test.ts
+++ b/tests/unit/components/ConfigViewInfo.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import ConfigViewInfo from "@/components/config/ConfigViewInfo.vue";
+import type { ViewConfig } from "@/types";
+
+const viewKeys = [
+  "DATASET_TABLE",
+  "VIEW_DESCRIPTION",
+  "VIEW_HEADER_IMAGE",
+  "LOGO_URL",
+];
+
+const mountViewInfo = () =>
+  mount(ConfigViewInfo, {
+    props: {
+      tableName: "test_table",
+      config: {
+        DATASET_TABLE: "Test View",
+        VIEW_DESCRIPTION: "Test description",
+        VIEW_HEADER_IMAGE: "https://example.test/header.jpg",
+        LOGO_URL: "https://example.test/logo.png",
+      } as ViewConfig,
+      views: ["map"],
+      keys: viewKeys,
+    },
+    global: {
+      stubs: {
+        ConfigImagePreview: {
+          props: ["src", "alt", "fit"],
+          template:
+            '<div data-testid="image-preview" :data-src="src" :data-fit="fit" />',
+        },
+      },
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+
+describe("ConfigViewInfo", () => {
+  it("renders display name, description, header image, and logo in order", () => {
+    const wrapper = mountViewInfo();
+
+    expect(
+      wrapper.findAll("input, textarea").map((field) => field.attributes("id")),
+    ).toEqual([
+      "test_table-DATASET_TABLE",
+      "test_table-VIEW_DESCRIPTION",
+      "test_table-VIEW_HEADER_IMAGE",
+      "test_table-LOGO_URL",
+    ]);
+  });
+
+  it("gives display name and description the full grid width", () => {
+    const wrapper = mountViewInfo();
+
+    expect(
+      wrapper.get("#test_table-DATASET_TABLE").element.parentElement?.className,
+    ).toContain("md:col-span-2");
+    expect(
+      wrapper.get("#test_table-VIEW_DESCRIPTION").element.parentElement
+        ?.className,
+    ).toContain("md:col-span-2");
+    expect(
+      wrapper.get("#test_table-VIEW_HEADER_IMAGE").element.parentElement
+        ?.className,
+    ).not.toContain("md:col-span-2");
+    expect(
+      wrapper.get("#test_table-LOGO_URL").element.parentElement?.className,
+    ).not.toContain("md:col-span-2");
+  });
+
+  it("uses cover for the header and contain for the logo preview", () => {
+    const previews = mountViewInfo().findAll("[data-testid='image-preview']");
+
+    expect(previews.map((preview) => preview.attributes("data-src"))).toEqual([
+      "https://example.test/header.jpg",
+      "https://example.test/logo.png",
+    ]);
+    expect(previews.map((preview) => preview.attributes("data-fit"))).toEqual([
+      "cover",
+      "contain",
+    ]);
+  });
+
+  it("emits display name updates", async () => {
+    const wrapper = mountViewInfo();
+
+    await wrapper
+      .get<HTMLInputElement>("#test_table-DATASET_TABLE")
+      .setValue("Updated View");
+
+    expect(wrapper.emitted("updateConfig")?.[0]?.[0]).toEqual({
+      DATASET_TABLE: "Updated View",
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Make the View configuration easier to find and make image URL fields easier to verify. Closes #580 

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-08-18 at 18 57 42" src="https://github.com/user-attachments/assets/d615c4ab-798d-44fc-8c59-f584a6000ff1" />
<img width="1470" height="956" alt="Screenshot 2026-08-18 at 18 57 29" src="https://github.com/user-attachments/assets/590ed597-3e3f-4c7f-9294-7e1e940e6c76" />
<img width="719" height="572" alt="Screenshot 2026-08-18 at 19 02 16" src="https://github.com/user-attachments/assets/d5733d64-b5c5-4665-8598-71352fb15b78" />


## What I changed and why

- Moved the View section to the top of the configuration form with fields ordered as display name, description, header image, and logo URL
- Display name and description span the full form width
- Added a reusable image preview component for header image and logo URL fields, with appropriate image fit per field and a clear message when an image fails to load
- Added translated preview text and unit and e2e coverage for the preview behavior

## How I convinced myself this is right

I manually checked the field order, responsive layout, successful image rendering, and image load error state in the browser. 

## What I'm not doing here

This change does not upload, edit, cache, or validate image files. It only previews the URL that the user enters.

## LLM use disclosure
Cursor helped with tests per usual