### PR TITLE
Config: API returns columns for config views, UI uses them for single-select dropdowns

### DIFF
--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -2,10 +2,12 @@
 import { useAppConfig } from "#imports";
 import {
   supportsSecondaryDataset,
+  type ColumnEntry,
   type ViewConfig,
   type ViewType,
 } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
+import { validateViewConfigColumns } from "@/utils/viewConfigColumns";
 import ConfigPermissions from "./ConfigPermissions.vue";
 import ConfigCollapsibleSection from "./ConfigCollapsibleSection.vue";
 import { Check, Trash2 } from "lucide-vue-next";
@@ -25,6 +27,10 @@ const props = withDefaults(
     /** False when the parent blocks Save (e.g. missing primary or duplicate view). */
     saveEnabled?: boolean;
     secondaryEditable?: boolean;
+    primaryColumns?: ColumnEntry[];
+    secondaryColumns?: ColumnEntry[];
+    primaryColumnsLoading?: boolean;
+    secondaryColumnsLoading?: boolean;
   }>(),
   {
     configToCopy: null,
@@ -32,6 +38,10 @@ const props = withDefaults(
     showRemove: true,
     saveEnabled: true,
     secondaryEditable: false,
+    primaryColumns: () => [],
+    secondaryColumns: () => [],
+    primaryColumnsLoading: false,
+    secondaryColumnsLoading: false,
   },
 );
 
@@ -173,13 +183,42 @@ const isChanged = computed(() => {
 // Track permission validation state
 const isPermissionValid = ref(true);
 
+const hasSecondaryDataset = computed(
+  () =>
+    shouldUseSecondaryDataset.value &&
+    localSecondaryDataset.value.trim() !== "",
+);
+
+const columnValidation = computed(() =>
+  validateViewConfigColumns(
+    localConfig.value,
+    props.primaryColumns,
+    props.secondaryColumns,
+    props.viewType,
+    hasSecondaryDataset.value,
+  ),
+);
+
+const areColumnsLoading = computed(
+  () =>
+    props.primaryColumnsLoading ||
+    (props.viewType === "alerts" &&
+      hasSecondaryDataset.value &&
+      props.secondaryColumnsLoading),
+);
+
 const isFormValid = computed(() => {
   const isMapConfigValid = shouldShowConfigMap.value
     ? localConfig.value.MAPBOX_ACCESS_TOKEN?.trim() !== "" &&
       localConfig.value.MAPBOX_ACCESS_TOKEN != null
     : true;
 
-  return isMapConfigValid && isPermissionValid.value;
+  return (
+    isMapConfigValid &&
+    isPermissionValid.value &&
+    columnValidation.value.isValid &&
+    !areColumnsLoading.value
+  );
 });
 
 const canSubmit = computed(
@@ -261,6 +300,8 @@ const handleSubmit = () => {
             :views="viewTypeList"
             :config="localConfig"
             :keys="mapConfigKeys"
+            :columns="primaryColumns"
+            :columns-loading="primaryColumnsLoading"
             @update-config="handleConfigUpdate"
           />
         </ConfigCollapsibleSection>
@@ -275,6 +316,8 @@ const handleSubmit = () => {
             :views="viewTypeList"
             :config="localConfig"
             :keys="mediaKeys"
+            :columns="primaryColumns"
+            :columns-loading="primaryColumnsLoading"
             @update-config="handleConfigUpdate"
           />
         </ConfigCollapsibleSection>
@@ -289,6 +332,12 @@ const handleSubmit = () => {
             :views="viewTypeList"
             :config="localConfig"
             :keys="filterKeys"
+            :view-type="viewType"
+            :has-secondary-dataset="hasSecondaryDataset"
+            :primary-columns="primaryColumns"
+            :secondary-columns="secondaryColumns"
+            :primary-columns-loading="primaryColumnsLoading"
+            :secondary-columns-loading="secondaryColumnsLoading"
             @update-config="handleConfigUpdate"
           />
         </ConfigCollapsibleSection>

--- a/components/config/ConfigColumnSelect.vue
+++ b/components/config/ConfigColumnSelect.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import type { ColumnEntry } from "@/types";
+
+const props = withDefaults(
+  defineProps<{
+    columns: ColumnEntry[];
+    id: string;
+    label: string;
+    loading?: boolean;
+    modelValue?: string;
+    placeholder: string;
+  }>(),
+  {
+    loading: false,
+    modelValue: "",
+  },
+);
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+
+const hasUnavailableValue = computed(
+  () =>
+    !props.loading &&
+    Boolean(props.modelValue) &&
+    !props.columns.some(
+      (column) => column.sql_column === props.modelValue?.trim(),
+    ),
+);
+
+const optionLabel = (column: ColumnEntry): string => {
+  return column.original_column === column.sql_column
+    ? column.sql_column
+    : `${column.original_column} (${column.sql_column})`;
+};
+</script>
+
+<template>
+  <div class="space-y-2 min-w-0">
+    <label :for="id" class="block text-sm font-medium text-gray-700">
+      {{ label }}
+    </label>
+    <select
+      :id="id"
+      :value="modelValue"
+      :disabled="loading"
+      :aria-invalid="hasUnavailableValue"
+      :aria-describedby="hasUnavailableValue ? `${id}-error` : undefined"
+      class="w-full px-4 py-2 text-base bg-violet-100 border rounded-lg focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:border-violet-500 transition-colors disabled:cursor-wait disabled:opacity-60"
+      :class="hasUnavailableValue ? 'border-red-400' : 'border-violet-200'"
+      @change="
+        emit('update:modelValue', ($event.target as HTMLSelectElement).value)
+      "
+    >
+      <option value="">
+        {{ loading ? $t("loading") : placeholder }}
+      </option>
+      <option v-if="hasUnavailableValue" :value="modelValue" disabled>
+        {{ modelValue }}
+      </option>
+      <option
+        v-for="column in columns"
+        :key="column.sql_column"
+        :value="column.sql_column"
+      >
+        {{ optionLabel(column) }}
+      </option>
+    </select>
+    <p
+      v-if="hasUnavailableValue"
+      :id="`${id}-error`"
+      class="text-sm text-red-600"
+      role="alert"
+    >
+      {{ $t("columnNotAvailable") }}
+    </p>
+  </div>
+</template>

--- a/components/config/ConfigFilters.vue
+++ b/components/config/ConfigFilters.vue
@@ -1,18 +1,31 @@
 <script setup lang="ts">
+import { computed } from "vue";
+
+import ConfigColumnSelect from "@/components/config/ConfigColumnSelect.vue";
 import { toCamelCase } from "@/utils/identifierUtils";
 
 // @ts-expect-error - vue-tags-input does not have types
 import { VueTagsInput } from "@vojtechlanka/vue-tags-input";
 
 import { updateTags } from "@/composables/useTags";
+import {
+  getUnwantedColumnOptions,
+  validateViewConfigColumns,
+} from "@/utils/viewConfigColumns";
 
-import type { ViewConfig } from "@/types";
+import type { ColumnEntry, ViewConfig, ViewType } from "@/types";
 
 const props = defineProps<{
   tableName: string;
   config: ViewConfig;
   views: string[];
   keys: string[];
+  viewType: ViewType;
+  hasSecondaryDataset?: boolean;
+  primaryColumns?: ColumnEntry[];
+  secondaryColumns?: ColumnEntry[];
+  primaryColumnsLoading?: boolean;
+  secondaryColumnsLoading?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -38,14 +51,75 @@ const { tags, handleTagsChanged: rawHandleTagsChanged } = updateTags(
 );
 
 const handleTagsChanged = (key: string, newTags: Tag[]): void => {
-  rawHandleTagsChanged(key, newTags);
-  const values = newTags.map((tag) => tag.text).join(",");
+  const existingTags = new Set((tags.value[key] ?? []).map((tag) => tag.text));
+  const acceptedTags =
+    key === "UNWANTED_COLUMNS"
+      ? newTags.filter((tag) =>
+          [
+            ...unwantedColumnOptions.value.map(
+              (column) => column.original_column,
+            ),
+            ...existingTags,
+          ].includes(tag.text),
+        )
+      : newTags;
+  rawHandleTagsChanged(key, acceptedTags);
+  const values = acceptedTags.map((tag) => tag.text).join(",");
   emit("updateConfig", { [key]: values });
 };
 
 const handleInput = (key: string, value: string): void => {
   emit("updateConfig", { [key]: value });
 };
+
+const getStringConfigValue = (key: string): string => {
+  const value = props.config[key];
+  return typeof value === "string" ? value : "";
+};
+
+const filterColumns = computed(() =>
+  props.viewType === "alerts" && props.hasSecondaryDataset
+    ? (props.secondaryColumns ?? [])
+    : (props.primaryColumns ?? []),
+);
+
+const filterColumnsLoading = computed(() =>
+  props.viewType === "alerts" && props.hasSecondaryDataset
+    ? props.secondaryColumnsLoading
+    : props.primaryColumnsLoading,
+);
+
+const unwantedColumnOptions = computed(() =>
+  getUnwantedColumnOptions(
+    props.primaryColumns ?? [],
+    props.config,
+    props.viewType,
+    Boolean(props.hasSecondaryDataset),
+  ),
+);
+
+const unwantedAutocompleteItems = computed(() =>
+  unwantedColumnOptions.value.map((column) => ({
+    text: column.original_column,
+  })),
+);
+
+const columnValidation = computed(() =>
+  validateViewConfigColumns(
+    props.config,
+    props.primaryColumns ?? [],
+    props.secondaryColumns ?? [],
+    props.viewType,
+    Boolean(props.hasSecondaryDataset),
+  ),
+);
+
+const hasUnwantedColumnError = computed(
+  () =>
+    columnValidation.value.invalidUnwantedColumns.length > 0 ||
+    columnValidation.value.protectedUnwantedColumns.length > 0 ||
+    columnValidation.value.conflictingUnwantedColumns.length > 0,
+);
 </script>
 
 <template>
@@ -63,34 +137,25 @@ const handleInput = (key: string, value: string): void => {
       }"
     >
       <template v-if="key === 'FRONT_END_FILTER_COLUMN'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t("filterDataByColumn") }}
-        </label>
-        <input
+        <ConfigColumnSelect
           :id="`${tableName}-${key}`"
-          :value="config[key]"
-          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="text"
-          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
+          :model-value="getStringConfigValue(key)"
+          :label="$t('filterDataByColumn')"
+          :placeholder="$t('selectColumn')"
+          :columns="filterColumns"
+          :loading="filterColumnsLoading"
+          @update:model-value="(value) => handleInput(key, value)"
         />
       </template>
       <template v-else-if="key === 'TIMESTAMP_COLUMN'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <input
+        <ConfigColumnSelect
           :id="`${tableName}-${key}`"
-          :value="config[key]"
-          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="text"
-          placeholder="e.g. End or created_at"
-          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
+          :model-value="getStringConfigValue(key)"
+          :label="$t(toCamelCase(key))"
+          :placeholder="$t('selectColumn')"
+          :columns="primaryColumns ?? []"
+          :loading="primaryColumnsLoading"
+          @update:model-value="(value) => handleInput(key, value)"
         />
       </template>
       <template
@@ -108,8 +173,20 @@ const handleInput = (key: string, value: string): void => {
           :id="`${tableName}-${key}`"
           class="tag-field w-full"
           :tags="tags[key]"
+          :autocomplete-items="
+            key === 'UNWANTED_COLUMNS' ? unwantedAutocompleteItems : []
+          "
+          :autocomplete-min-length="0"
+          :autocomplete-filter-duplicates="true"
           @tags-changed="(newTags: Tag[]) => handleTagsChanged(key, newTags)"
         />
+        <p
+          v-if="key === 'UNWANTED_COLUMNS' && hasUnwantedColumnError"
+          class="text-sm text-red-600"
+          role="alert"
+        >
+          {{ $t("unwantedColumnsInvalid") }}
+        </p>
       </template>
     </div>
   </div>

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -3,16 +3,19 @@
 import { VueTagsInput } from "@vojtechlanka/vue-tags-input";
 import VueSlider from "vue-3-slider-component";
 
+import ConfigColumnSelect from "@/components/config/ConfigColumnSelect.vue";
 import { toCamelCase } from "@/utils/identifierUtils";
 import { updateTags } from "@/composables/useTags";
 
-import type { ViewConfig, BasemapConfig } from "@/types";
+import type { ViewConfig, BasemapConfig, ColumnEntry } from "@/types";
 
 const props = defineProps<{
   tableName: string;
   config: ViewConfig;
   views: string[];
   keys: string[];
+  columns?: ColumnEntry[];
+  columnsLoading?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -49,6 +52,11 @@ const handleTagsChanged = (key: string, newTags: Tag[]): void => {
 const handleInput = (key: string, value: string | number | boolean): void => {
   if (typeof value === "number" && isNaN(value)) return;
   emit("updateConfig", { [key]: value });
+};
+
+const getStringConfigValue = (key: string): string => {
+  const value = props.config[key];
+  return typeof value === "string" ? value : "";
 };
 
 const terrainExaggeration = ref<number>(
@@ -565,42 +573,28 @@ const fullWidthKeys = [
 
         <!-- Color Column -->
         <template v-else-if="key === 'COLOR_COLUMN'">
-          <label
-            :for="`${tableName}-${key}`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t(toCamelCase(key)) }}
-          </label>
-          <input
+          <ConfigColumnSelect
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-            type="text"
-            placeholder="color"
-            :value="config[key]"
-            @input="
-              (e) => handleInput(key, (e.target as HTMLInputElement).value)
-            "
+            :model-value="getStringConfigValue(key)"
+            :label="$t(toCamelCase(key))"
+            :placeholder="$t('selectColumn')"
+            :columns="columns ?? []"
+            :loading="columnsLoading"
+            @update:model-value="(value) => handleInput(key, value)"
           />
           <p class="field-description">{{ $t("colorColumnDescription") }}</p>
         </template>
 
         <!-- Icon Column -->
         <template v-else-if="key === 'ICON_COLUMN'">
-          <label
-            :for="`${tableName}-${key}`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t(toCamelCase(key)) }}
-          </label>
-          <input
+          <ConfigColumnSelect
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-            type="text"
-            placeholder="icon"
-            :value="config[key]"
-            @input="
-              (e) => handleInput(key, (e.target as HTMLInputElement).value)
-            "
+            :model-value="getStringConfigValue(key)"
+            :label="$t(toCamelCase(key))"
+            :placeholder="$t('selectColumn')"
+            :columns="columns ?? []"
+            :loading="columnsLoading"
+            @update:model-value="(value) => handleInput(key, value)"
           />
           <p class="text-xs text-gray-500 mt-1">
             {{ $t("iconColumnDescription") }}

--- a/components/config/ConfigMedia.vue
+++ b/components/config/ConfigMedia.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ConfigColumnSelect from "@/components/config/ConfigColumnSelect.vue";
 import { toCamelCase } from "@/utils/identifierUtils";
 import {
   extractShareId,
@@ -7,13 +8,15 @@ import {
   getBaseUrlFromInput,
   isValidFilebrowserInput,
 } from "@/utils/mediaHelpers";
-import type { ViewConfig } from "@/types";
+import type { ColumnEntry, ViewConfig } from "@/types";
 
 const props = defineProps<{
   tableName: string;
   config: ViewConfig;
   views: string[];
   keys: string[];
+  columns?: ColumnEntry[];
+  columnsLoading?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -29,7 +32,6 @@ const providerAlerts = ref<MediaProvider>("filebrowser");
 const shareInputAlerts = ref("");
 const providerIcons = ref<MediaProvider>("filebrowser");
 const shareInputIcons = ref("");
-const mediaColumn = ref("");
 const isInitializing = ref(true);
 
 /**
@@ -143,12 +145,6 @@ watch(resolvedIconsPath, (newValue) => {
   }
 });
 
-watch(mediaColumn, (newValue) => {
-  if (!isInitializing.value) {
-    emit("updateConfig", { MEDIA_COLUMN: newValue });
-  }
-});
-
 // Keep local media fields in sync with the config prop (including the initial value).
 watch(
   () => props.config,
@@ -211,8 +207,6 @@ watch(
     } else {
       shareInputIcons.value = "";
     }
-
-    mediaColumn.value = config.MEDIA_COLUMN || "";
 
     nextTick(() => {
       isInitializing.value = false;
@@ -541,22 +535,19 @@ watch(
 
     <!-- MEDIA_COLUMN -->
     <div v-if="keys.includes('MEDIA_COLUMN')" class="space-y-2">
-      <label
-        :for="`${tableName}-media-column`"
-        class="block text-sm font-medium text-gray-700"
-      >
-        {{ $t(toCamelCase("MEDIA_COLUMN")) }}
-      </label>
       <p class="text-xs text-gray-500 mb-2">
         {{ $t("mediaColumnDescription") }}
       </p>
-      <input
+      <ConfigColumnSelect
         :id="`${tableName}-media-column`"
-        class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-        type="text"
-        :value="mediaColumn"
-        placeholder="photo"
-        @input="mediaColumn = ($event.target as HTMLInputElement).value"
+        :model-value="config.MEDIA_COLUMN"
+        :label="$t(toCamelCase('MEDIA_COLUMN'))"
+        :placeholder="$t('selectColumn')"
+        :columns="columns ?? []"
+        :loading="columnsLoading"
+        @update:model-value="
+          (value) => emit('updateConfig', { MEDIA_COLUMN: value })
+        "
       />
     </div>
   </div>

--- a/composables/useDatasetColumns.ts
+++ b/composables/useDatasetColumns.ts
@@ -1,0 +1,58 @@
+import { encodeDatasetNameForUrl } from "@/utils/identifierUtils";
+
+import type { ColumnEntry } from "@/types";
+import type { Ref } from "vue";
+
+type DatasetColumnsResponse = {
+  columns: ColumnEntry[];
+  table: string;
+};
+
+/**
+ * Loads column metadata when the selected dataset changes.
+ *
+ * @param {Ref<string | null | undefined>} dataset - Selected warehouse table.
+ * @returns Column metadata and loading state.
+ */
+export const useDatasetColumns = (dataset: Ref<string | null | undefined>) => {
+  const columns = ref<ColumnEntry[]>([]);
+  const isLoading = ref(false);
+  let requestId = 0;
+
+  const loadColumns = async (): Promise<void> => {
+    const currentRequest = ++requestId;
+    const table = dataset.value?.trim() ?? "";
+
+    if (!table) {
+      columns.value = [];
+      isLoading.value = false;
+      return;
+    }
+
+    isLoading.value = true;
+
+    try {
+      const response = await $fetch<DatasetColumnsResponse>(
+        `/api/config/columns/${encodeDatasetNameForUrl(table)}`,
+      );
+      if (currentRequest === requestId) {
+        columns.value = response.columns;
+      }
+    } catch {
+      if (currentRequest === requestId) {
+        columns.value = [];
+      }
+    } finally {
+      if (currentRequest === requestId) {
+        isLoading.value = false;
+      }
+    }
+  };
+
+  watch(dataset, loadColumns, { immediate: true });
+
+  return {
+    columns,
+    isLoading,
+  };
+};

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -34,6 +34,7 @@
   "close": "Close",
   "colorColumn": "Color Column",
   "colorColumnDescription": "Optional: Specify a column name (e.g., 'color') that contains color values (e.g., hex codes like #FF0000). When set, map features and filter dots will use these colors instead of the randomly generated colors.",
+  "columnNotAvailable": "This column is not available in the selected dataset.",
   "community": {
     "community": "community"
   },
@@ -274,6 +275,7 @@
   "secondaryFilterValues": "Values to include from the secondary dataset on the alerts map",
   "selectAlertDateRange": "Select an alert date range",
   "selectBasemap": "Select basemap",
+  "selectColumn": "Select a column…",
   "selectMoreOptions": "Select more options",
   "selectPrimaryDataset": "Select a primary dataset…",
   "selectPrimaryDatasetOptional": "Select later…",
@@ -293,6 +295,7 @@
   "type": "Type",
   "typeOfAlerts": "Type of alerts",
   "unwantedColumns": "Unwanted columns",
+  "unwantedColumnsInvalid": "Remove protected, unavailable, or active columns before saving.",
   "version": "Version",
   "view": "View",
   "viewDescription": "View Description",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -34,6 +34,7 @@
   "close": "Cerrar",
   "colorColumn": "Columna de Color",
   "colorColumnDescription": "Opcional: Especifique un nombre de columna (por ejemplo, 'color') que contenga valores de color (por ejemplo, códigos hexadecimales como #FF0000). Cuando se establece, las características del mapa y los puntos del filtro utilizarán estos colores en lugar de los colores generados aleatoriamente.",
+  "columnNotAvailable": "Esta columna no está disponible en el conjunto de datos seleccionado.",
   "community": {
     "community": "comunidad"
   },
@@ -270,6 +271,7 @@
   "secondaryFilterValues": "Valores del conjunto de datos secundario que se incluirán en el mapa de alertas",
   "selectAlertDateRange": "Seleccione un rango de fechas de alerta",
   "selectBasemap": "Seleccione el mapa base",
+  "selectColumn": "Seleccione una columna…",
   "selectMoreOptions": "Seleccionar más opciones",
   "selectPrimaryDataset": "Seleccione un conjunto de datos principal…",
   "selectPrimaryDatasetOptional": "Seleccionar después…",
@@ -289,6 +291,7 @@
   "type": "Tipo",
   "typeOfAlerts": "Tipo de alertas",
   "unwantedColumns": "Columnas no deseadas",
+  "unwantedColumnsInvalid": "Elimine las columnas protegidas, no disponibles o activas antes de guardar.",
   "version": "Versión",
   "view": "Vista",
   "viewDescription": "Descripción de la vista",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -34,6 +34,7 @@
   "close": "Sluiten",
   "colorColumn": "Kleurkolom",
   "colorColumnDescription": "Optioneel: Specificeer een kolomnaam (bijv. 'color') die kleurwaarden bevat (bijv. hex-codes zoals #FF0000). Indien ingesteld, zullen kaartkenmerken en filterpunten deze kleuren gebruiken in plaats van willekeurig gegenereerde kleuren.",
+  "columnNotAvailable": "Deze kolom is niet beschikbaar in de geselecteerde dataset.",
   "community": {
     "community": "gemeenschap"
   },
@@ -271,6 +272,7 @@
   "secondaryFilterValues": "Waarden uit de secundaire dataset om op de alertkaart te laten zien",
   "selectAlertDateRange": "Selecteer een alert datum periode",
   "selectBasemap": "Selecteer basiskaart",
+  "selectColumn": "Selecteer een kolom…",
   "selectMoreOptions": "Meer opties selecteren",
   "selectPrimaryDataset": "Selecteer een primaire dataset…",
   "selectPrimaryDatasetOptional": "Later selecteren…",
@@ -290,6 +292,7 @@
   "type": "Type",
   "typeOfAlerts": "Type alerts",
   "unwantedColumns": "Ongewenste kolommen",
+  "unwantedColumnsInvalid": "Verwijder beschermde, niet-beschikbare of actieve kolommen voordat u opslaat.",
   "version": "Versie",
   "view": "Weergave",
   "viewDescription": "Weergavebeschrijving",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -34,6 +34,7 @@
   "close": "Fechar",
   "colorColumn": "Coluna de Cor",
   "colorColumnDescription": "Opcional: Especifique um nome de coluna (por exemplo, 'color') que contenha valores de cor (por exemplo, códigos hexadecimais como #FF0000). Quando definido, os recursos do mapa e os pontos do filtro usarão essas cores em vez das cores geradas aleatoriamente.",
+  "columnNotAvailable": "Esta coluna não está disponível no conjunto de dados selecionado.",
   "community": {
     "community": "comunidade"
   },
@@ -270,6 +271,7 @@
   "secondaryFilterValues": "Valores do conjunto de dados secundário para incluir no mapa de alertas",
   "selectAlertDateRange": "Selecione um intervalo de datas de alerta",
   "selectBasemap": "Selecione o mapa base",
+  "selectColumn": "Selecione uma coluna…",
   "selectMoreOptions": "Selecionar mais opções",
   "selectPrimaryDataset": "Selecione um conjunto de dados principal…",
   "selectPrimaryDatasetOptional": "Selecionar depois…",
@@ -289,6 +291,7 @@
   "type": "Tipo",
   "typeOfAlerts": "Tipo de alertas",
   "unwantedColumns": "Colunas indesejadas",
+  "unwantedColumnsInvalid": "Remova as colunas protegidas, indisponíveis ou ativas antes de salvar.",
   "version": "Versão",
   "view": "Visualização",
   "viewDescription": "Descrição da visualização",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -34,6 +34,7 @@
   "close": "Funga",
   "colorColumn": "Safu ya Rangi",
   "colorColumnDescription": "Hiari: Eleza jina la safu (k.m., 'color') linalo na thamani za rangi (k.m., misimbo ya hex kama #FF0000). Inapowekwa, vipengele vya ramani na nukta za kichujio zitatumia rangi hizi badala ya zile zilizotengenezwa kwa nasibu.",
+  "columnNotAvailable": "Safu hii haipatikani katika seti ya data iliyochaguliwa.",
   "community": {
     "community": "jamii"
   },
@@ -274,6 +275,7 @@
   "secondaryFilterValues": "Thamani za kujumuisha kutoka kwa seti ya data ya pili kwenye ramani ya arifa",
   "selectAlertDateRange": "Chagua masafa ya tarehe ya tahadhari",
   "selectBasemap": "Chagua ramani ya msingi",
+  "selectColumn": "Chagua safu…",
   "selectMoreOptions": "Chagua chaguo zaidi",
   "selectPrimaryDataset": "Chagua seti kuu ya data…",
   "selectPrimaryDatasetOptional": "Chagua baadaye…",
@@ -293,6 +295,7 @@
   "type": "Aina",
   "typeOfAlerts": "Aina ya tahadhari",
   "unwantedColumns": "Safu zisizotakiwa",
+  "unwantedColumnsInvalid": "Ondoa safu zilizolindwa, zisizopatikana au zinazotumika kabla ya kuhifadhi.",
   "version": "Toleo",
   "view": "Mtazamo",
   "viewDescription": "Maelezo ya Mtazamo",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -34,6 +34,7 @@
   "close": "ปิด",
   "colorColumn": "คอลัมน์สี",
   "colorColumnDescription": "ไม่บังคับ: ระบุชื่อคอลัมน์ (เช่น 'color') ที่มีค่าสี (เช่น รหัสสีแบบ #FF0000) เมื่อตั้งค่าแล้ว ฟีเจอร์บนแผนที่และจุดตัวกรองจะใช้สีเหล่านี้แทนสีที่สุ่ม",
+  "columnNotAvailable": "คอลัมน์นี้ไม่มีอยู่ในชุดข้อมูลที่เลือก",
   "community": {
     "community": "ชุมชน"
   },
@@ -274,6 +275,7 @@
   "secondaryFilterValues": "ค่าจากชุดข้อมูลรองที่จะรวมลงในแผนที่แจ้งเตือน",
   "selectAlertDateRange": "เลือกช่วงวันที่การแจ้งเตือน",
   "selectBasemap": "เลือกแผนที่ฐาน",
+  "selectColumn": "เลือกคอลัมน์…",
   "selectMoreOptions": "เลือกตัวเลือกเพิ่มเติม",
   "selectPrimaryDataset": "เลือกชุดข้อมูลหลัก…",
   "selectPrimaryDatasetOptional": "เลือกภายหลัง…",
@@ -293,6 +295,7 @@
   "type": "ประเภท",
   "typeOfAlerts": "ประเภทของการแจ้งเตือน",
   "unwantedColumns": "คอลัมน์ที่ไม่ต้องการ",
+  "unwantedColumnsInvalid": "นำคอลัมน์ที่ได้รับการป้องกัน ไม่มีอยู่ หรือกำลังใช้งานออกก่อนบันทึก",
   "version": "เวอร์ชัน",
   "view": "มุมมอง",
   "viewDescription": "คำอธิบายมุมมอง",

--- a/pages/config/[dataset].vue
+++ b/pages/config/[dataset].vue
@@ -6,6 +6,7 @@ import SelectDatasetField from "@/components/config/SelectDatasetField.vue";
 import DataLoadError from "@/components/shared/DataLoadError.vue";
 import ViewTypePill from "@/components/shared/ViewTypePill.vue";
 import { useCopyConfig } from "@/composables/useCopyConfig";
+import { useDatasetColumns } from "@/composables/useDatasetColumns";
 import {
   supportsSecondaryDataset,
   type ViewConfig,
@@ -32,6 +33,12 @@ const datasetConfig = ref<ViewConfig | null>(null);
 const secondaryDataset = ref<string | null>(null);
 const viewName = ref("");
 const errorMessage = ref<string | null>(null);
+const primaryDatasetForColumns = computed(() => dataset);
+const secondaryDatasetForColumns = computed(() => secondaryDataset.value);
+const { columns: primaryColumns, isLoading: primaryColumnsLoading } =
+  useDatasetColumns(primaryDatasetForColumns);
+const { columns: secondaryColumns, isLoading: secondaryColumnsLoading } =
+  useDatasetColumns(secondaryDatasetForColumns);
 
 const editedViewType = ref<ViewType | undefined>(undefined);
 
@@ -309,6 +316,10 @@ definePageMeta({ layout: "explorer" });
           :secondary-dataset="secondaryDataset"
           :config-to-copy="configToCopy"
           :secondary-editable="true"
+          :primary-columns="primaryColumns"
+          :secondary-columns="secondaryColumns"
+          :primary-columns-loading="primaryColumnsLoading"
+          :secondary-columns-loading="secondaryColumnsLoading"
           @submit-config="submitConfig"
           @remove-table-from-config="handleRemoveTableFromConfig"
         />

--- a/pages/config/new/[view_type].vue
+++ b/pages/config/new/[view_type].vue
@@ -6,6 +6,7 @@ import SelectDatasetField from "@/components/config/SelectDatasetField.vue";
 import DataLoadError from "@/components/shared/DataLoadError.vue";
 import ViewTypePill from "@/components/shared/ViewTypePill.vue";
 import { useCopyConfig } from "@/composables/useCopyConfig";
+import { useDatasetColumns } from "@/composables/useDatasetColumns";
 import { useDuplicateViewCheck } from "@/composables/useDuplicateViewCheck";
 import { useAppConfig } from "#imports";
 import {
@@ -57,6 +58,12 @@ const secondaryDataset = ref<string | null>(null);
 const errorMessage = ref<string | null>(null);
 const isSaving = ref(false);
 const showSavedModal = ref(false);
+const primaryDatasetForColumns = computed(() => primaryDataset.value);
+const secondaryDatasetForColumns = computed(() => secondaryDataset.value);
+const { columns: primaryColumns, isLoading: primaryColumnsLoading } =
+  useDatasetColumns(primaryDatasetForColumns);
+const { columns: secondaryColumns, isLoading: secondaryColumnsLoading } =
+  useDatasetColumns(secondaryDatasetForColumns);
 
 const { isDuplicate, existingView, isChecking, checkDuplicate } =
   useDuplicateViewCheck(viewType, primaryDataset);
@@ -264,6 +271,10 @@ definePageMeta({ layout: "explorer" });
         :show-remove="false"
         :save-enabled="saveEnabled"
         :secondary-editable="true"
+        :primary-columns="primaryColumns"
+        :secondary-columns="secondaryColumns"
+        :primary-columns-loading="primaryColumnsLoading"
+        :secondary-columns-loading="secondaryColumnsLoading"
         @submit-config="submitConfig"
       />
     </template>

--- a/server/api/config/columns/[table].get.ts
+++ b/server/api/config/columns/[table].get.ts
@@ -1,0 +1,17 @@
+import { fetchTableColumnEntries } from "@/server/database/dbOperations";
+import { getTableParam } from "@/server/utils/dbHelpers";
+import { validatePermissions } from "@/utils/accessControls";
+
+import type { H3Event } from "h3";
+
+export default defineEventHandler(async (event: H3Event) => {
+  await validatePermissions(event, "admin");
+
+  const table = getTableParam(event);
+  const columns = await fetchTableColumnEntries(table);
+
+  return {
+    columns,
+    table,
+  };
+});

--- a/server/api/config/update_config/[table].post.ts
+++ b/server/api/config/update_config/[table].post.ts
@@ -23,7 +23,11 @@ export default defineEventHandler(async (event: H3Event) => {
   } catch (error) {
     if (error instanceof Error) {
       console.error("Error updating config on API side:", error.message);
-      return sendError(event, new Error(error.message));
+      const statusCode = (error as { statusCode?: number }).statusCode ?? 500;
+      return sendError(
+        event,
+        createError({ statusCode, statusMessage: error.message }),
+      );
     } else {
       console.error("Unknown error updating config on API side:", error);
       return sendError(event, new Error("An unknown error occurred"));

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -14,6 +14,7 @@ import {
 } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
 import { normalizeTableName } from "@/utils/identifierUtils";
+import { validateViewConfigColumns } from "@/utils/viewConfigColumns";
 
 import { viewConfig, publicViews } from "./schema";
 import { configDb, warehouseDb } from "./dbConnection";
@@ -32,6 +33,16 @@ const createMissingViewConfigError = (table: string) => {
   };
   error.statusCode = 404;
   error.statusMessage = statusMessage;
+  return error;
+};
+
+const createInvalidConfigColumnsError = (message: string) => {
+  const error = new Error(message) as Error & {
+    statusCode: number;
+    statusMessage: string;
+  };
+  error.statusCode = 400;
+  error.statusMessage = message;
   return error;
 };
 
@@ -261,6 +272,46 @@ export const fetchTableSqlColumns = async (
         .filter((column): column is string => Boolean(column)),
     ),
   );
+};
+
+/**
+ * Resolves original and SQL column names for a warehouse table.
+ *
+ * @param {string} table - Base table name.
+ * @returns {Promise<ColumnEntry[]>} Ordered column names for Config controls.
+ */
+export const fetchTableColumnEntries = async (
+  table: string,
+): Promise<ColumnEntry[]> => {
+  const cleanTableName = normalizeTableName(table);
+  const columnsTable = `"${cleanTableName}__columns"`;
+
+  if (await checkTableExists(columnsTable)) {
+    const columns = (await fetchDataFromTable(
+      columnsTable,
+      DEFAULT_COLUMNS_TABLE_PROJECTION,
+    )) as Array<Partial<ColumnEntry>>;
+    const entries = columns.filter(
+      (column): column is ColumnEntry =>
+        typeof column.original_column === "string" &&
+        typeof column.sql_column === "string",
+    );
+
+    if (entries.length > 0) {
+      return entries.filter(
+        (column, index) =>
+          entries.findIndex(
+            (candidate) => candidate.sql_column === column.sql_column,
+          ) === index,
+      );
+    }
+  }
+
+  const sqlColumns = await fetchTableSqlColumns(cleanTableName);
+  return sqlColumns.map((column) => ({
+    original_column: column,
+    sql_column: column,
+  }));
 };
 
 /**
@@ -703,6 +754,57 @@ export const fetchPublicViewTableNames = async (): Promise<string[]> => {
   return rows.map((row) => normalizeTableName(row.tableName));
 };
 
+/**
+ * Rejects missing, protected, or conflicting column references in a view config.
+ *
+ * @param {string} primaryDataset - Primary warehouse table.
+ * @param {ViewConfig} config - View configuration to validate.
+ * @param {ViewType} viewType - View type being saved.
+ * @param {string | null | undefined} secondaryDataset - Optional secondary table.
+ * @returns {Promise<void>}
+ */
+const assertValidViewConfigColumns = async (
+  primaryDataset: string,
+  config: ViewConfig,
+  viewType: ViewType,
+  secondaryDataset?: string | null,
+): Promise<void> => {
+  const hasSecondaryDataset = Boolean(secondaryDataset);
+  const [primaryColumns, secondaryColumns] = await Promise.all([
+    fetchTableColumnEntries(primaryDataset),
+    viewType === "alerts" && secondaryDataset
+      ? fetchTableColumnEntries(secondaryDataset)
+      : Promise.resolve([]),
+  ]);
+  const validation = validateViewConfigColumns(
+    config,
+    primaryColumns,
+    secondaryColumns,
+    viewType,
+    hasSecondaryDataset,
+  );
+
+  if (validation.isValid) return;
+
+  const details = [
+    ...Object.entries(validation.invalidSelections).map(
+      ([key, column]) => `${key} references unavailable column "${column}"`,
+    ),
+    ...validation.invalidUnwantedColumns.map(
+      (column) => `UNWANTED_COLUMNS references unavailable column "${column}"`,
+    ),
+    ...validation.protectedUnwantedColumns.map(
+      (column) =>
+        `UNWANTED_COLUMNS cannot include protected column "${column}"`,
+    ),
+    ...validation.conflictingUnwantedColumns.map(
+      (column) => `UNWANTED_COLUMNS conflicts with active column "${column}"`,
+    ),
+  ];
+
+  throw createInvalidConfigColumnsError(details.join("; "));
+};
+
 export const updateConfig = async (
   tableName: string,
   config: unknown,
@@ -744,6 +846,12 @@ export const updateConfig = async (
         `updateConfig requires a view type for "${normalizedTable}"; refusing to update without identifying a single view.`,
       );
     }
+    await assertValidViewConfigColumns(
+      normalizedTable,
+      typedConfig,
+      viewType,
+      normalizedSecondary,
+    );
     const viewColumns = buildViewConfigColumns(
       normalizedTable,
       typedConfig,
@@ -789,6 +897,12 @@ export const addNewTableToConfig = async (
       ? normalizeTableName(secondaryDataset)
       : secondaryDataset;
   try {
+    await assertValidViewConfigColumns(
+      normalizedTable,
+      config ?? {},
+      viewType,
+      normalizedSecondary,
+    );
     await configDb.insert(viewConfig).values({
       ...buildViewConfigColumns(
         normalizedTable,

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -503,7 +503,6 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
 
   for (const view of views) {
     await page.goto(view.path);
-    await page.waitForLoadState("networkidle");
     await page.waitForSelector("form", { timeout: 15000 });
 
     const selector = page.locator(
@@ -511,6 +510,15 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
     );
     const submitButton = page.locator("[data-testid='config-submit-button']");
     const originalValue = await selector.inputValue();
+    let originalFilterValue: string | null = null;
+    if (view.primaryDataset === "fake_alerts") {
+      await page
+        .locator('[data-testid="config-section-filtering-toggle"]')
+        .click();
+      originalFilterValue = await page
+        .locator('select[id*="FRONT_END_FILTER_COLUMN"]')
+        .inputValue();
+    }
     const optionValues = await selector
       .locator("option")
       .evaluateAll((options) =>
@@ -525,6 +533,18 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
 
     expect(replacement).toBeTruthy();
     await selector.selectOption(replacement!);
+    if (view.primaryDataset === "fake_alerts") {
+      const filterColumn = page.locator(
+        'select[id*="FRONT_END_FILTER_COLUMN"]',
+      );
+      await expect(filterColumn).toBeEnabled();
+      const replacementFilter = await filterColumn
+        .locator('option:not([value=""]):not([disabled])')
+        .first()
+        .getAttribute("value");
+      expect(replacementFilter).toBeTruthy();
+      await filterColumn.selectOption(replacementFilter!);
+    }
     await expect(submitButton).toBeEnabled();
     await submitButton.evaluate((button) => {
       (button as HTMLButtonElement).formNoValidate = true;
@@ -538,6 +558,16 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
     await expect(selector).toHaveValue(replacement!);
 
     await selector.selectOption(originalValue);
+    if (view.primaryDataset === "fake_alerts") {
+      await page
+        .locator('[data-testid="config-section-filtering-toggle"]')
+        .click();
+      const filterColumn = page.locator(
+        'select[id*="FRONT_END_FILTER_COLUMN"]',
+      );
+      await expect(filterColumn).toBeEnabled();
+      await filterColumn.selectOption(originalFilterValue!);
+    }
     await expect(submitButton).toBeEnabled();
     await submitButton.evaluate((button) => {
       (button as HTMLButtonElement).formNoValidate = true;
@@ -653,7 +683,6 @@ test("config page - visibility permissions configuration", async ({
   // Use a seeded view that already has ROUTE_LEVEL_PERMISSION set. Newly added
   // views start with an empty config and intentionally have no radio selected.
   await page.goto("/config/fake_alerts?view_type=alerts");
-  await page.waitForLoadState("networkidle");
   await page.waitForSelector("form", { timeout: 15000 });
 
   const visibilitySection = page.locator(
@@ -830,21 +859,65 @@ test("config page - color column configuration", async ({
 }) => {
   await openMapConfigEditPage(page);
 
-  const colorColumnInput = page.locator('input[id*="COLOR_COLUMN"]');
-  const hasColorColumn = (await colorColumnInput.count()) > 0;
+  const colorColumnSelect = page.locator('select[id*="COLOR_COLUMN"]');
+  const hasColorColumn = (await colorColumnSelect.count()) > 0;
 
   if (hasColorColumn) {
-    await expect(colorColumnInput.first()).toBeVisible();
+    await expect(colorColumnSelect.first()).toBeVisible();
 
-    await colorColumnInput.first().clear();
-    await colorColumnInput.first().fill("color");
+    await colorColumnSelect.first().selectOption("community");
     await page.waitForTimeout(300);
 
-    await expect(colorColumnInput.first()).toHaveValue("color");
+    await expect(colorColumnSelect.first()).toHaveValue("community");
 
     const submitButton = page.locator("[data-testid='config-submit-button']");
     await expect(submitButton).toBeEnabled();
   }
+});
+
+test("config page - column controls use dataset metadata and reject conflicts", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await openMapConfigEditPage(page);
+
+  const response = await page.request.get(
+    "/api/config/columns/bcmform_responses",
+  );
+  expect(response.ok()).toBe(true);
+  const body = (await response.json()) as {
+    columns: Array<{ original_column: string; sql_column: string }>;
+  };
+  expect(body.columns).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        original_column: "community",
+        sql_column: "community",
+      }),
+    ]),
+  );
+
+  const colorColumnSelect = page.locator('select[id*="COLOR_COLUMN"]');
+  const iconColumnSelect = page.locator('select[id*="ICON_COLUMN"]');
+  await expect(
+    colorColumnSelect.locator('option[value="community"]'),
+  ).toHaveText("community");
+  await expect(iconColumnSelect.locator('option[value="photo"]')).toHaveText(
+    "photo",
+  );
+
+  const invalidSave = await page.request.post(
+    "/api/config/update_config/bcmform_responses?view_type=map",
+    {
+      data: {
+        config: {
+          COLOR_COLUMN: "community",
+          UNWANTED_COLUMNS: "community",
+        },
+        secondaryDataset: null,
+      },
+    },
+  );
+  expect(invalidSave.status()).toBe(400);
 });
 
 test("config page - copy config from another same-type view", async ({

--- a/tests/unit/components/ConfigColumnSelect.test.ts
+++ b/tests/unit/components/ConfigColumnSelect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import ConfigColumnSelect from "@/components/config/ConfigColumnSelect.vue";
+
+const columns = [
+  {
+    original_column: "formhub/uuid",
+    sql_column: "uuid__formhub",
+  },
+  {
+    original_column: "status",
+    sql_column: "status",
+  },
+];
+
+const mountSelect = (modelValue = "") =>
+  mount(ConfigColumnSelect, {
+    props: {
+      columns,
+      id: "column-select",
+      label: "Column",
+      modelValue,
+      placeholder: "Select a column",
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+
+describe("ConfigColumnSelect", () => {
+  it("uses SQL names as values and shows original names", () => {
+    const wrapper = mountSelect();
+    const options = wrapper.findAll("option");
+
+    expect(options.map((option) => option.attributes("value"))).toEqual([
+      "",
+      "uuid__formhub",
+      "status",
+    ]);
+    expect(options[1].text()).toBe("formhub/uuid (uuid__formhub)");
+  });
+
+  it("emits the selected SQL column", async () => {
+    const wrapper = mountSelect();
+
+    await wrapper.get("select").setValue("status");
+
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual(["status"]);
+  });
+
+  it("keeps an unavailable configured value visible with an error", () => {
+    const wrapper = mountSelect("missing_column");
+
+    expect(wrapper.get("select").attributes("aria-invalid")).toBe("true");
+    expect(wrapper.get('[role="alert"]').text()).toBe("columnNotAvailable");
+    expect(wrapper.get('option[value="missing_column"]').exists()).toBe(true);
+  });
+});

--- a/tests/unit/components/ConfigFilters.test.ts
+++ b/tests/unit/components/ConfigFilters.test.ts
@@ -22,13 +22,20 @@ const mountConfigFilters = () =>
         SECONDARY_FILTER_VALUES: "active,pending",
       },
       views: ["alerts"],
+      viewType: "alerts",
+      hasSecondaryDataset: true,
+      primaryColumns: [{ original_column: "_id", sql_column: "_id" }],
+      secondaryColumns: [
+        { original_column: "status", sql_column: "status" },
+        { original_column: "status_type", sql_column: "status_type" },
+      ],
       keys: ["FRONT_END_FILTER_COLUMN", "SECONDARY_FILTER_VALUES"],
     },
     global: {
       stubs: {
         VueTagsInput: {
           name: "VueTagsInput",
-          props: ["tags"],
+          props: ["tags", "autocompleteItems"],
           emits: ["tags-changed"],
           template:
             "<button data-testid=\"filter-values\" @click=\"$emit('tags-changed', [{ text: 'active' }])\" />",
@@ -45,7 +52,7 @@ describe("ConfigFilters", () => {
     const wrapper = mountConfigFilters();
 
     await wrapper
-      .get<HTMLInputElement>("#alerts_table-FRONT_END_FILTER_COLUMN")
+      .get<HTMLSelectElement>("#alerts_table-FRONT_END_FILTER_COLUMN")
       .setValue("status_type");
 
     expect(wrapper.emitted("updateConfig")?.[0]?.[0]).toEqual({
@@ -81,5 +88,76 @@ describe("ConfigFilters", () => {
     expect(
       wrapper.get("#alerts_table-SECONDARY_FILTER_VALUES").attributes("id"),
     ).toBe("alerts_table-SECONDARY_FILTER_VALUES");
+  });
+
+  it("excludes protected and active columns from unwanted suggestions", () => {
+    const wrapper = mount(ConfigFilters, {
+      props: {
+        tableName: "survey_table",
+        config: {
+          COLOR_COLUMN: "status",
+        },
+        views: ["map"],
+        viewType: "map",
+        primaryColumns: [
+          { original_column: "_id", sql_column: "_id" },
+          { original_column: "Geometry", sql_column: "g__coordinates" },
+          { original_column: "Status", sql_column: "status" },
+          { original_column: "Photo", sql_column: "photo" },
+        ],
+        keys: ["UNWANTED_COLUMNS"],
+      },
+      global: {
+        stubs: {
+          VueTagsInput: {
+            name: "VueTagsInput",
+            props: ["tags", "autocompleteItems"],
+            template: "<div />",
+          },
+        },
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+
+    expect(
+      wrapper.getComponent({ name: "VueTagsInput" }).props(),
+    ).toMatchObject({
+      autocompleteItems: [{ text: "Photo" }],
+    });
+  });
+
+  it("shows an error when unwanted columns conflict with active fields", () => {
+    const wrapper = mount(ConfigFilters, {
+      props: {
+        tableName: "survey_table",
+        config: {
+          COLOR_COLUMN: "status",
+          UNWANTED_COLUMNS: "Status",
+        },
+        views: ["map"],
+        viewType: "map",
+        primaryColumns: [
+          { original_column: "_id", sql_column: "_id" },
+          { original_column: "Status", sql_column: "status" },
+        ],
+        keys: ["UNWANTED_COLUMNS"],
+      },
+      global: {
+        stubs: {
+          VueTagsInput: {
+            name: "VueTagsInput",
+            props: ["tags", "autocompleteItems"],
+            template: "<div />",
+          },
+        },
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+
+    expect(wrapper.get('[role="alert"]').text()).toBe("unwantedColumnsInvalid");
   });
 });

--- a/tests/unit/components/ConfigMap.test.ts
+++ b/tests/unit/components/ConfigMap.test.ts
@@ -714,16 +714,17 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const colorColumnInput = wrapper.find(
-      'input[id="test_table-COLOR_COLUMN"]',
+    const colorColumnSelect = wrapper.find(
+      'select[id="test_table-COLOR_COLUMN"]',
     );
-    expect(colorColumnInput.exists()).toBe(true);
+    expect(colorColumnSelect.exists()).toBe(true);
   });
 
   it("updates COLOR_COLUMN value when input changes", async () => {
     const propsWithColorColumn = {
       ...baseProps,
       keys: [...baseProps.keys, "COLOR_COLUMN"],
+      columns: [{ original_column: "color", sql_column: "color" }],
     };
 
     const wrapper = mount(ConfigMap, {
@@ -731,17 +732,17 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const colorColumnInput = wrapper.find(
-      'input[id="test_table-COLOR_COLUMN"]',
+    const colorColumnSelect = wrapper.find(
+      'select[id="test_table-COLOR_COLUMN"]',
     );
-    await colorColumnInput.setValue("color");
+    await colorColumnSelect.setValue("color");
 
     expect(wrapper.emitted("updateConfig")).toBeTruthy();
     const emitted = wrapper.emitted("updateConfig");
     expect(emitted?.[0]?.[0]).toEqual({ COLOR_COLUMN: "color" });
   });
 
-  it("displays placeholder for COLOR_COLUMN field", () => {
+  it("displays an empty option for COLOR_COLUMN", () => {
     const propsWithColorColumn = {
       ...baseProps,
       keys: [...baseProps.keys, "COLOR_COLUMN"],
@@ -752,10 +753,10 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const colorColumnInput = wrapper.find(
-      'input[id="test_table-COLOR_COLUMN"]',
+    const colorColumnSelect = wrapper.find(
+      'select[id="test_table-COLOR_COLUMN"]',
     );
-    expect(colorColumnInput.attributes("placeholder")).toBe("color");
+    expect(colorColumnSelect.find('option[value=""]').exists()).toBe(true);
   });
 
   it("renders ICON_COLUMN field when included in keys", () => {
@@ -769,14 +770,17 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const iconColumnInput = wrapper.find('input[id="test_table-ICON_COLUMN"]');
-    expect(iconColumnInput.exists()).toBe(true);
+    const iconColumnSelect = wrapper.find(
+      'select[id="test_table-ICON_COLUMN"]',
+    );
+    expect(iconColumnSelect.exists()).toBe(true);
   });
 
   it("updates ICON_COLUMN value when input changes", async () => {
     const propsWithIconColumn = {
       ...baseProps,
       keys: [...baseProps.keys, "ICON_COLUMN"],
+      columns: [{ original_column: "icon", sql_column: "icon" }],
     };
 
     const wrapper = mount(ConfigMap, {
@@ -784,15 +788,17 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const iconColumnInput = wrapper.find('input[id="test_table-ICON_COLUMN"]');
-    await iconColumnInput.setValue("icon");
+    const iconColumnSelect = wrapper.find(
+      'select[id="test_table-ICON_COLUMN"]',
+    );
+    await iconColumnSelect.setValue("icon");
 
     expect(wrapper.emitted("updateConfig")).toBeTruthy();
     const emitted = wrapper.emitted("updateConfig");
     expect(emitted?.[0]?.[0]).toEqual({ ICON_COLUMN: "icon" });
   });
 
-  it("displays placeholder for ICON_COLUMN field", () => {
+  it("displays an empty option for ICON_COLUMN", () => {
     const propsWithIconColumn = {
       ...baseProps,
       keys: [...baseProps.keys, "ICON_COLUMN"],
@@ -803,8 +809,10 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const iconColumnInput = wrapper.find('input[id="test_table-ICON_COLUMN"]');
-    expect(iconColumnInput.attributes("placeholder")).toBe("icon");
+    const iconColumnSelect = wrapper.find(
+      'select[id="test_table-ICON_COLUMN"]',
+    );
+    expect(iconColumnSelect.find('option[value=""]').exists()).toBe(true);
   });
 
   it("labels basemap fields and uses purple field chrome", () => {

--- a/tests/unit/server/configColumnsEndpoint.test.ts
+++ b/tests/unit/server/configColumnsEndpoint.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import configColumnsHandler from "@/server/api/config/columns/[table].get";
+
+const hoisted = vi.hoisted(() => {
+  Object.assign(globalThis, {
+    defineEventHandler: (handler: unknown) => handler,
+  });
+
+  return {
+    fetchTableColumnEntries: vi.fn(),
+    getTableParam: vi.fn(),
+    validatePermissions: vi.fn(),
+  };
+});
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchTableColumnEntries: hoisted.fetchTableColumnEntries,
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  getTableParam: hoisted.getTableParam,
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: hoisted.validatePermissions,
+}));
+
+type ConfigColumnsHandler = (
+  event: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+const handleConfigColumnsRequest =
+  configColumnsHandler as unknown as ConfigColumnsHandler;
+
+describe("config columns endpoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getTableParam.mockReturnValue("survey_data");
+    hoisted.fetchTableColumnEntries.mockResolvedValue([
+      {
+        original_column: "Status",
+        sql_column: "status",
+      },
+    ]);
+  });
+
+  it("returns mapped columns without fetching dataset rows", async () => {
+    const event = {};
+
+    const response = await handleConfigColumnsRequest(event);
+
+    expect(hoisted.validatePermissions).toHaveBeenCalledWith(event, "admin");
+    expect(hoisted.fetchTableColumnEntries).toHaveBeenCalledWith("survey_data");
+    expect(response).toEqual({
+      table: "survey_data",
+      columns: [
+        {
+          original_column: "Status",
+          sql_column: "status",
+        },
+      ],
+    });
+  });
+});

--- a/tests/unit/utils/viewConfigColumns.test.ts
+++ b/tests/unit/utils/viewConfigColumns.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getUnwantedColumnOptions,
+  validateViewConfigColumns,
+} from "@/utils/viewConfigColumns";
+
+import type { ColumnEntry, ViewConfig } from "@/types";
+
+const primaryColumns: ColumnEntry[] = [
+  { original_column: "_id", sql_column: "_id" },
+  { original_column: "geometry type", sql_column: "g__type" },
+  { original_column: "geometry", sql_column: "g__coordinates" },
+  { original_column: "Status", sql_column: "status" },
+  { original_column: "Photo", sql_column: "photo" },
+  { original_column: "Recorded at", sql_column: "recorded_at" },
+];
+
+const secondaryColumns: ColumnEntry[] = [
+  { original_column: "_id", sql_column: "_id" },
+  { original_column: "Category", sql_column: "p__categoryid" },
+];
+
+describe("viewConfigColumns", () => {
+  it("removes protected and active columns from unwanted choices", () => {
+    const config: ViewConfig = {
+      COLOR_COLUMN: "status",
+      MEDIA_COLUMN: "photo",
+    };
+
+    expect(
+      getUnwantedColumnOptions(primaryColumns, config, "gallery", false).map(
+        (column) => column.sql_column,
+      ),
+    ).toEqual(["recorded_at"]);
+  });
+
+  it("matches unwanted original names to active SQL column names", () => {
+    const validation = validateViewConfigColumns(
+      {
+        COLOR_COLUMN: "status",
+        UNWANTED_COLUMNS: "Status",
+      },
+      primaryColumns,
+      [],
+      "map",
+      false,
+    );
+
+    expect(validation.conflictingUnwantedColumns).toEqual(["Status"]);
+    expect(validation.isValid).toBe(false);
+  });
+
+  it("rejects protected, missing, and unavailable columns", () => {
+    const validation = validateViewConfigColumns(
+      {
+        ICON_COLUMN: "not_a_column",
+        UNWANTED_COLUMNS: "_id,Unknown",
+      },
+      primaryColumns,
+      [],
+      "gallery",
+      false,
+    );
+
+    expect(validation.invalidSelections).toEqual({
+      ICON_COLUMN: "not_a_column",
+    });
+    expect(validation.protectedUnwantedColumns).toEqual(["_id"]);
+    expect(validation.invalidUnwantedColumns).toEqual(["Unknown"]);
+    expect(validation.isValid).toBe(false);
+  });
+
+  it("uses secondary columns for the Alerts filter column", () => {
+    const validation = validateViewConfigColumns(
+      {
+        FRONT_END_FILTER_COLUMN: "p__categoryid",
+      },
+      primaryColumns,
+      secondaryColumns,
+      "alerts",
+      true,
+    );
+
+    expect(validation.isValid).toBe(true);
+  });
+});

--- a/utils/viewConfigColumns.ts
+++ b/utils/viewConfigColumns.ts
@@ -1,0 +1,172 @@
+import type { ColumnEntry, ViewConfig, ViewType } from "@/types";
+
+export const PROTECTED_COLUMN_NAMES = [
+  "_id",
+  "g__type",
+  "g__coordinates",
+] as const;
+
+export const FUNCTIONAL_COLUMN_KEYS = [
+  "COLOR_COLUMN",
+  "FRONT_END_FILTER_COLUMN",
+  "TIMESTAMP_COLUMN",
+  "MEDIA_COLUMN",
+  "ICON_COLUMN",
+] as const;
+
+export type FunctionalColumnKey = (typeof FUNCTIONAL_COLUMN_KEYS)[number];
+
+export type ViewConfigColumnValidation = {
+  conflictingUnwantedColumns: string[];
+  invalidSelections: Partial<Record<FunctionalColumnKey, string>>;
+  invalidUnwantedColumns: string[];
+  isValid: boolean;
+  protectedUnwantedColumns: string[];
+};
+
+const getColumnEntry = (
+  columns: ColumnEntry[],
+  name: string,
+): ColumnEntry | undefined => {
+  return columns.find(
+    (column) => column.original_column === name || column.sql_column === name,
+  );
+};
+
+const getColumnSource = (
+  key: FunctionalColumnKey,
+  viewType: ViewType,
+  hasSecondaryDataset: boolean,
+): "primary" | "secondary" => {
+  if (
+    key === "FRONT_END_FILTER_COLUMN" &&
+    viewType === "alerts" &&
+    hasSecondaryDataset
+  ) {
+    return "secondary";
+  }
+
+  return "primary";
+};
+
+const getSelectedSqlColumns = (
+  config: ViewConfig,
+  viewType: ViewType,
+  hasSecondaryDataset: boolean,
+  source: "primary" | "secondary",
+): Set<string> => {
+  return new Set(
+    FUNCTIONAL_COLUMN_KEYS.flatMap((key) => {
+      const value = config[key]?.trim();
+      return value &&
+        getColumnSource(key, viewType, hasSecondaryDataset) === source
+        ? [value]
+        : [];
+    }),
+  );
+};
+
+/**
+ * Gets the primary dataset columns that can be selected as unwanted columns.
+ *
+ * @param {ColumnEntry[]} columns - Available primary dataset columns.
+ * @param {ViewConfig} config - Current view configuration.
+ * @param {ViewType} viewType - Current view type.
+ * @param {boolean} hasSecondaryDataset - Whether the view uses a secondary dataset.
+ * @returns {ColumnEntry[]} Columns that are not protected or used by another field.
+ */
+export const getUnwantedColumnOptions = (
+  columns: ColumnEntry[],
+  config: ViewConfig,
+  viewType: ViewType,
+  hasSecondaryDataset: boolean,
+): ColumnEntry[] => {
+  const selectedColumns = getSelectedSqlColumns(
+    config,
+    viewType,
+    hasSecondaryDataset,
+    "primary",
+  );
+  const protectedColumns = new Set<string>(PROTECTED_COLUMN_NAMES);
+
+  return columns.filter(
+    (column) =>
+      !protectedColumns.has(column.sql_column) &&
+      !selectedColumns.has(column.sql_column),
+  );
+};
+
+/**
+ * Validates configured column names and unwanted-column conflicts.
+ *
+ * @param {ViewConfig} config - View configuration to validate.
+ * @param {ColumnEntry[]} primaryColumns - Available primary dataset columns.
+ * @param {ColumnEntry[]} secondaryColumns - Available secondary dataset columns.
+ * @param {ViewType} viewType - Current view type.
+ * @param {boolean} hasSecondaryDataset - Whether the view uses a secondary dataset.
+ * @returns {ViewConfigColumnValidation} Validation details for the UI and API.
+ */
+export const validateViewConfigColumns = (
+  config: ViewConfig,
+  primaryColumns: ColumnEntry[],
+  secondaryColumns: ColumnEntry[],
+  viewType: ViewType,
+  hasSecondaryDataset: boolean,
+): ViewConfigColumnValidation => {
+  const invalidSelections: Partial<Record<FunctionalColumnKey, string>> = {};
+
+  FUNCTIONAL_COLUMN_KEYS.forEach((key) => {
+    const value = config[key]?.trim();
+    if (!value) return;
+
+    const source = getColumnSource(key, viewType, hasSecondaryDataset);
+    const columns = source === "secondary" ? secondaryColumns : primaryColumns;
+    if (!columns.some((column) => column.sql_column === value)) {
+      invalidSelections[key] = value;
+    }
+  });
+
+  const unwantedSource =
+    viewType === "alerts" && hasSecondaryDataset ? "secondary" : "primary";
+  const unwantedColumns =
+    unwantedSource === "secondary" ? secondaryColumns : primaryColumns;
+  const selectedColumns = getSelectedSqlColumns(
+    config,
+    viewType,
+    hasSecondaryDataset,
+    unwantedSource,
+  );
+  const protectedColumns = new Set<string>(PROTECTED_COLUMN_NAMES);
+  const unwantedNames = (config.UNWANTED_COLUMNS ?? "")
+    .split(",")
+    .map((column) => column.trim())
+    .filter(Boolean);
+  const invalidUnwantedColumns: string[] = [];
+  const protectedUnwantedColumns: string[] = [];
+  const conflictingUnwantedColumns: string[] = [];
+
+  unwantedNames.forEach((name) => {
+    const column = getColumnEntry(unwantedColumns, name);
+    if (!column) {
+      invalidUnwantedColumns.push(name);
+    } else if (protectedColumns.has(column.sql_column)) {
+      protectedUnwantedColumns.push(name);
+    } else if (selectedColumns.has(column.sql_column)) {
+      conflictingUnwantedColumns.push(name);
+    }
+  });
+
+  const isValid =
+    Object.keys(invalidSelections).length === 0 &&
+    invalidUnwantedColumns.length === 0 &&
+    protectedUnwantedColumns.length === 0 &&
+    conflictingUnwantedColumns.length === 0;
+
+  return {
+    conflictingUnwantedColumns,
+    invalidSelections,
+    invalidUnwantedColumns,
+    isValid,
+    protectedUnwantedColumns,
+  };
+};


### PR DESCRIPTION
## Goal

Use dataset columns for Config dropdowns and typeaheads. Prevent unavailable, protected, or conflicting column settings.

Closes #438 

> **Reviewer note:** This PR has 1,075 added lines. Of these, 399 lines are test code. The remaining changes add the column metadata API, shared validation, reusable selectors, and Config form integration.

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-08-19 at 14 33 46" src="https://github.com/user-attachments/assets/679e58ff-6473-48c5-9fa5-2c09019c0fcc" />
<img width="1470" height="956" alt="Screenshot 2026-08-19 at 14 32 57" src="https://github.com/user-attachments/assets/68f0dc5e-8997-4f0a-a04a-c5f46d3f7661" />



## Commit guide

| Commit | Change |
| --- | --- |
| [06f0a18](https://github.com/ConservationMetrics/gc-explorer/commit/06f0a1810b63aa0f08aeea5a1107e66ff7bcd548) | Add the column metadata endpoint and server-side save validation. |
| [e14b798](https://github.com/ConservationMetrics/gc-explorer/commit/e14b798bfc8b67d1ff2be53144d1f2db9683f6bf) | Add the reusable column selector and reactive column loader. |
| [eb06995](https://github.com/ConservationMetrics/gc-explorer/commit/eb0699547866add2b97d83683bf2407c99a74e63) | Use dataset columns across the Config forms. |
| [7cca189](https://github.com/ConservationMetrics/gc-explorer/commit/7cca1899e39c535f8e6e8c41a394e2e18e4a5378) | Add coverage for column retrieval, selection, and validation. |


## What I changed and why

* Added an admin-only API route to fetch valid dataset columns.
* Config column fields now use selectors instead of free text.
* Alerts filters use secondary dataset columns when configured.
* Other fields use primary dataset columns.
* Unwanted columns exclude protected and active columns.
* The same validation is enforced on the server.


## How I convinced myself this is right

Manual verification and tests

## What I am not doing here

- I am not combining primary and secondary column lists.
- I am not redesigning the Config page.
- I am not adding a new interface dependency.
- I am not changing unrelated dataset APIs.


## LLM use disclosure

Cursor GPT-5.6 Sol, with me driving.