### PR TITLE
Config: return dataset column metadata

### DIFF
--- a/server/api/config/columns/[table].get.ts
+++ b/server/api/config/columns/[table].get.ts
@@ -1,0 +1,17 @@
+import { fetchTableColumnEntries } from "@/server/database/dbOperations";
+import { getTableParam } from "@/server/utils/dbHelpers";
+import { validatePermissions } from "@/utils/accessControls";
+
+import type { H3Event } from "h3";
+
+export default defineEventHandler(async (event: H3Event) => {
+  await validatePermissions(event, "admin");
+
+  const table = getTableParam(event);
+  const columns = await fetchTableColumnEntries(table);
+
+  return {
+    columns,
+    table,
+  };
+});

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -264,6 +264,46 @@ export const fetchTableSqlColumns = async (
 };
 
 /**
+ * Resolves original and SQL column names for a warehouse table.
+ *
+ * @param {string} table - Base table name.
+ * @returns {Promise<ColumnEntry[]>} Ordered column names for Config controls.
+ */
+export const fetchTableColumnEntries = async (
+  table: string,
+): Promise<ColumnEntry[]> => {
+  const cleanTableName = normalizeTableName(table);
+  const columnsTable = `"${cleanTableName}__columns"`;
+
+  if (await checkTableExists(columnsTable)) {
+    const columns = (await fetchDataFromTable(
+      columnsTable,
+      DEFAULT_COLUMNS_TABLE_PROJECTION,
+    )) as Array<Partial<ColumnEntry>>;
+    const entries = columns.filter(
+      (column): column is ColumnEntry =>
+        typeof column.original_column === "string" &&
+        typeof column.sql_column === "string",
+    );
+
+    if (entries.length > 0) {
+      return entries.filter(
+        (column, index) =>
+          entries.findIndex(
+            (candidate) => candidate.sql_column === column.sql_column,
+          ) === index,
+      );
+    }
+  }
+
+  const sqlColumns = await fetchTableSqlColumns(cleanTableName);
+  return sqlColumns.map((column) => ({
+    original_column: column,
+    sql_column: column,
+  }));
+};
+
+/**
  * Fetches projected dataset rows and optional side tables for API routes.
  * Main-table projection is mandatory, while `__columns` and `__metadata`
  * reads are opt-in and require explicit projections.

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -296,6 +296,8 @@ export const fetchTableColumnEntries = async (
     }
   }
 
+  // This helper derives names from information_schema.columns when no usable
+  // `<table>__columns` metadata is available.
   const sqlColumns = await fetchTableSqlColumns(cleanTableName);
   return sqlColumns.map((column) => ({
     original_column: column,

--- a/tests/unit/server/configColumnsEndpoint.test.ts
+++ b/tests/unit/server/configColumnsEndpoint.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import configColumnsHandler from "@/server/api/config/columns/[table].get";
+
+const hoisted = vi.hoisted(() => {
+  Object.assign(globalThis, {
+    defineEventHandler: (handler: unknown) => handler,
+  });
+
+  return {
+    fetchTableColumnEntries: vi.fn(),
+    getTableParam: vi.fn(),
+    validatePermissions: vi.fn(),
+  };
+});
+
+vi.mock("@/server/database/dbOperations", () => ({
+  fetchTableColumnEntries: hoisted.fetchTableColumnEntries,
+}));
+
+vi.mock("@/server/utils/dbHelpers", () => ({
+  getTableParam: hoisted.getTableParam,
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: hoisted.validatePermissions,
+}));
+
+type ConfigColumnsHandler = (
+  event: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+const handleConfigColumnsRequest =
+  configColumnsHandler as unknown as ConfigColumnsHandler;
+
+describe("config columns endpoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getTableParam.mockReturnValue("survey_data");
+    hoisted.fetchTableColumnEntries.mockResolvedValue([
+      {
+        original_column: "Status",
+        sql_column: "status",
+      },
+    ]);
+  });
+
+  it("returns mapped columns without fetching dataset rows", async () => {
+    const event = {};
+
+    const response = await handleConfigColumnsRequest(event);
+
+    expect(hoisted.validatePermissions).toHaveBeenCalledWith(event, "admin");
+    expect(hoisted.fetchTableColumnEntries).toHaveBeenCalledWith("survey_data");
+    expect(response).toEqual({
+      table: "survey_data",
+      columns: [
+        {
+          original_column: "Status",
+          sql_column: "status",
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Return original and SQL column names for Config controls.

Part of #438.

> Stack: 1 of 4. This PR targets `feat/438-config-column-selectors-integration`.


## Screenshots

Not applicable


## What I changed and why

I added an admin-only endpoint that returns column metadata for one warehouse table. The database helper uses the columns metadata table when it is available. It uses `information_schema.columns` as a fallback and does not fetch dataset rows.


## How I convinced myself this is right

The endpoint uses the existing table-name normalization and Config permission checks. and the fallback preserves the SQL column name as the original name when no mapping table exists.


## What I'm not doing here

I am not adding save validation or changing Config controls in this PR.


## LLM use disclosure

Cursor GPT-5.6 Sol, with me driving.