### PR TITLE
Config: validate configured column selections

### DIFF
--- a/server/api/config/update_config/[table].post.ts
+++ b/server/api/config/update_config/[table].post.ts
@@ -23,7 +23,11 @@ export default defineEventHandler(async (event: H3Event) => {
   } catch (error) {
     if (error instanceof Error) {
       console.error("Error updating config on API side:", error.message);
-      return sendError(event, new Error(error.message));
+      const statusCode = (error as { statusCode?: number }).statusCode ?? 500;
+      return sendError(
+        event,
+        createError({ statusCode, statusMessage: error.message }),
+      );
     } else {
       console.error("Unknown error updating config on API side:", error);
       return sendError(event, new Error("An unknown error occurred"));

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -14,6 +14,7 @@ import {
 } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
 import { normalizeTableName } from "@/utils/identifierUtils";
+import { validateViewConfigColumns } from "@/utils/viewConfigColumns";
 
 import { viewConfig, publicViews } from "./schema";
 import { configDb, warehouseDb } from "./dbConnection";
@@ -32,6 +33,16 @@ const createMissingViewConfigError = (table: string) => {
   };
   error.statusCode = 404;
   error.statusMessage = statusMessage;
+  return error;
+};
+
+const createInvalidConfigColumnsError = (message: string) => {
+  const error = new Error(message) as Error & {
+    statusCode: number;
+    statusMessage: string;
+  };
+  error.statusCode = 400;
+  error.statusMessage = message;
   return error;
 };
 
@@ -745,6 +756,57 @@ export const fetchPublicViewTableNames = async (): Promise<string[]> => {
   return rows.map((row) => normalizeTableName(row.tableName));
 };
 
+/**
+ * Rejects missing, protected, or conflicting column references in a view config.
+ *
+ * @param {string} primaryDataset - Primary warehouse table.
+ * @param {ViewConfig} config - View configuration to validate.
+ * @param {ViewType} viewType - View type being saved.
+ * @param {string | null | undefined} secondaryDataset - Optional secondary table.
+ * @returns {Promise<void>}
+ */
+const assertValidViewConfigColumns = async (
+  primaryDataset: string,
+  config: ViewConfig,
+  viewType: ViewType,
+  secondaryDataset?: string | null,
+): Promise<void> => {
+  const hasSecondaryDataset = Boolean(secondaryDataset);
+  const [primaryColumns, secondaryColumns] = await Promise.all([
+    fetchTableColumnEntries(primaryDataset),
+    viewType === "alerts" && secondaryDataset
+      ? fetchTableColumnEntries(secondaryDataset)
+      : Promise.resolve([]),
+  ]);
+  const validation = validateViewConfigColumns(
+    config,
+    primaryColumns,
+    secondaryColumns,
+    viewType,
+    hasSecondaryDataset,
+  );
+
+  if (validation.isValid) return;
+
+  const details = [
+    ...Object.entries(validation.invalidSelections).map(
+      ([key, column]) => `${key} references unavailable column "${column}"`,
+    ),
+    ...validation.invalidUnwantedColumns.map(
+      (column) => `UNWANTED_COLUMNS references unavailable column "${column}"`,
+    ),
+    ...validation.protectedUnwantedColumns.map(
+      (column) =>
+        `UNWANTED_COLUMNS cannot include protected column "${column}"`,
+    ),
+    ...validation.conflictingUnwantedColumns.map(
+      (column) => `UNWANTED_COLUMNS conflicts with active column "${column}"`,
+    ),
+  ];
+
+  throw createInvalidConfigColumnsError(details.join("; "));
+};
+
 export const updateConfig = async (
   tableName: string,
   config: unknown,
@@ -786,6 +848,12 @@ export const updateConfig = async (
         `updateConfig requires a view type for "${normalizedTable}"; refusing to update without identifying a single view.`,
       );
     }
+    await assertValidViewConfigColumns(
+      normalizedTable,
+      typedConfig,
+      viewType,
+      normalizedSecondary,
+    );
     const viewColumns = buildViewConfigColumns(
       normalizedTable,
       typedConfig,
@@ -831,6 +899,12 @@ export const addNewTableToConfig = async (
       ? normalizeTableName(secondaryDataset)
       : secondaryDataset;
   try {
+    await assertValidViewConfigColumns(
+      normalizedTable,
+      config ?? {},
+      viewType,
+      normalizedSecondary,
+    );
     await configDb.insert(viewConfig).values({
       ...buildViewConfigColumns(
         normalizedTable,

--- a/tests/unit/utils/viewConfigColumns.test.ts
+++ b/tests/unit/utils/viewConfigColumns.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getSelectableColumnOptions,
+  getUnwantedColumnOptions,
+  validateViewConfigColumns,
+} from "@/utils/viewConfigColumns";
+
+import type { ColumnEntry, ViewConfig } from "@/types";
+
+const primaryColumns: ColumnEntry[] = [
+  { original_column: "_id", sql_column: "_id" },
+  { original_column: "geometry type", sql_column: "g__type" },
+  { original_column: "geometry", sql_column: "g__coordinates" },
+  { original_column: "Status", sql_column: "status" },
+  { original_column: "Photo", sql_column: "photo" },
+  { original_column: "Recorded at", sql_column: "recorded_at" },
+];
+
+const secondaryColumns: ColumnEntry[] = [
+  { original_column: "_id", sql_column: "_id" },
+  { original_column: "Category", sql_column: "p__categoryid" },
+];
+
+describe("viewConfigColumns", () => {
+  it("removes _id from functional column choices", () => {
+    expect(
+      getSelectableColumnOptions(primaryColumns).map(
+        (column) => column.sql_column,
+      ),
+    ).toEqual(["g__type", "g__coordinates", "status", "photo", "recorded_at"]);
+  });
+
+  it("removes protected and active columns from unwanted choices", () => {
+    const config: ViewConfig = {
+      COLOR_COLUMN: "status",
+      MEDIA_COLUMN: "photo",
+    };
+
+    expect(
+      getUnwantedColumnOptions(primaryColumns, config, "gallery", false).map(
+        (column) => column.sql_column,
+      ),
+    ).toEqual(["recorded_at"]);
+  });
+
+  it("matches unwanted original names to active SQL column names", () => {
+    const validation = validateViewConfigColumns(
+      {
+        COLOR_COLUMN: "status",
+        UNWANTED_COLUMNS: "Status",
+      },
+      primaryColumns,
+      [],
+      "map",
+      false,
+    );
+
+    expect(validation.conflictingUnwantedColumns).toEqual(["Status"]);
+    expect(validation.isValid).toBe(false);
+  });
+
+  it("rejects protected, missing, and unavailable columns", () => {
+    const validation = validateViewConfigColumns(
+      {
+        COLOR_COLUMN: "not_a_column",
+        ICON_COLUMN: "_id",
+        UNWANTED_COLUMNS: "_id,Unknown",
+      },
+      primaryColumns,
+      [],
+      "gallery",
+      false,
+    );
+
+    expect(validation.invalidSelections).toEqual({
+      COLOR_COLUMN: "not_a_column",
+      ICON_COLUMN: "_id",
+    });
+    expect(validation.protectedUnwantedColumns).toEqual(["_id"]);
+    expect(validation.invalidUnwantedColumns).toEqual(["Unknown"]);
+    expect(validation.isValid).toBe(false);
+  });
+
+  it("uses secondary columns for the Alerts filter column", () => {
+    const validation = validateViewConfigColumns(
+      {
+        FRONT_END_FILTER_COLUMN: "p__categoryid",
+      },
+      primaryColumns,
+      secondaryColumns,
+      "alerts",
+      true,
+    );
+
+    expect(validation.isValid).toBe(true);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -120,6 +120,21 @@ export interface ViewConfig {
   VIEW_DESCRIPTION?: string; // Description of the dataset/table
 }
 
+export type FunctionalColumnKey =
+  | "COLOR_COLUMN"
+  | "FRONT_END_FILTER_COLUMN"
+  | "TIMESTAMP_COLUMN"
+  | "MEDIA_COLUMN"
+  | "ICON_COLUMN";
+
+export type ViewConfigColumnValidation = {
+  conflictingUnwantedColumns: string[];
+  invalidSelections: Partial<Record<FunctionalColumnKey, string>>;
+  invalidUnwantedColumns: string[];
+  isValid: boolean;
+  protectedUnwantedColumns: string[];
+};
+
 export interface Views {
   [key: string]: ViewConfig;
 }

--- a/utils/viewConfigColumns.ts
+++ b/utils/viewConfigColumns.ts
@@ -1,0 +1,188 @@
+import type {
+  ColumnEntry,
+  FunctionalColumnKey,
+  ViewConfig,
+  ViewConfigColumnValidation,
+  ViewType,
+} from "@/types";
+
+export const PROTECTED_COLUMN_NAMES = [
+  "_id",
+  "g__type",
+  "g__coordinates",
+] as const;
+
+export const FUNCTIONAL_COLUMN_KEYS: readonly FunctionalColumnKey[] = [
+  "COLOR_COLUMN",
+  "FRONT_END_FILTER_COLUMN",
+  "TIMESTAMP_COLUMN",
+  "MEDIA_COLUMN",
+  "ICON_COLUMN",
+] as const;
+
+const NON_SELECTABLE_FUNCTIONAL_COLUMN_NAMES = new Set(["_id"]);
+
+/**
+ * Gets columns that can be used by functional Config fields.
+ *
+ * @param {ColumnEntry[]} columns - Available dataset columns.
+ * @returns {ColumnEntry[]} Columns that can be selected.
+ */
+export const getSelectableColumnOptions = (
+  columns: ColumnEntry[],
+): ColumnEntry[] => {
+  return columns.filter(
+    (column) => !NON_SELECTABLE_FUNCTIONAL_COLUMN_NAMES.has(column.sql_column),
+  );
+};
+
+const getColumnEntry = (
+  columns: ColumnEntry[],
+  name: string,
+): ColumnEntry | undefined => {
+  return columns.find(
+    (column) => column.original_column === name || column.sql_column === name,
+  );
+};
+
+const getColumnSource = (
+  key: FunctionalColumnKey,
+  viewType: ViewType,
+  hasSecondaryDataset: boolean,
+): "primary" | "secondary" => {
+  if (
+    key === "FRONT_END_FILTER_COLUMN" &&
+    viewType === "alerts" &&
+    hasSecondaryDataset
+  ) {
+    return "secondary";
+  }
+
+  return "primary";
+};
+
+const getSelectedSqlColumns = (
+  config: ViewConfig,
+  viewType: ViewType,
+  hasSecondaryDataset: boolean,
+  source: "primary" | "secondary",
+): Set<string> => {
+  return new Set(
+    FUNCTIONAL_COLUMN_KEYS.flatMap((key) => {
+      const value = config[key]?.trim();
+      return value &&
+        getColumnSource(key, viewType, hasSecondaryDataset) === source
+        ? [value]
+        : [];
+    }),
+  );
+};
+
+/**
+ * Gets the primary dataset columns that can be selected as unwanted columns.
+ *
+ * @param {ColumnEntry[]} columns - Available primary dataset columns.
+ * @param {ViewConfig} config - Current view configuration.
+ * @param {ViewType} viewType - Current view type.
+ * @param {boolean} hasSecondaryDataset - Whether the view uses a secondary dataset.
+ * @returns {ColumnEntry[]} Columns that are not protected or used by another field.
+ */
+export const getUnwantedColumnOptions = (
+  columns: ColumnEntry[],
+  config: ViewConfig,
+  viewType: ViewType,
+  hasSecondaryDataset: boolean,
+): ColumnEntry[] => {
+  const selectedColumns = getSelectedSqlColumns(
+    config,
+    viewType,
+    hasSecondaryDataset,
+    "primary",
+  );
+  const protectedColumns = new Set<string>(PROTECTED_COLUMN_NAMES);
+
+  return columns.filter(
+    (column) =>
+      !protectedColumns.has(column.sql_column) &&
+      !selectedColumns.has(column.sql_column),
+  );
+};
+
+/**
+ * Validates configured column names and unwanted-column conflicts.
+ *
+ * @param {ViewConfig} config - View configuration to validate.
+ * @param {ColumnEntry[]} primaryColumns - Available primary dataset columns.
+ * @param {ColumnEntry[]} secondaryColumns - Available secondary dataset columns.
+ * @param {ViewType} viewType - Current view type.
+ * @param {boolean} hasSecondaryDataset - Whether the view uses a secondary dataset.
+ * @returns {ViewConfigColumnValidation} Validation details for the UI and API.
+ */
+export const validateViewConfigColumns = (
+  config: ViewConfig,
+  primaryColumns: ColumnEntry[],
+  secondaryColumns: ColumnEntry[],
+  viewType: ViewType,
+  hasSecondaryDataset: boolean,
+): ViewConfigColumnValidation => {
+  const invalidSelections: Partial<Record<FunctionalColumnKey, string>> = {};
+
+  FUNCTIONAL_COLUMN_KEYS.forEach((key) => {
+    const value = config[key]?.trim();
+    if (!value) return;
+
+    const source = getColumnSource(key, viewType, hasSecondaryDataset);
+    const columns = source === "secondary" ? secondaryColumns : primaryColumns;
+    if (
+      !getSelectableColumnOptions(columns).some(
+        (column) => column.sql_column === value,
+      )
+    ) {
+      invalidSelections[key] = value;
+    }
+  });
+
+  const unwantedSource =
+    viewType === "alerts" && hasSecondaryDataset ? "secondary" : "primary";
+  const unwantedColumns =
+    unwantedSource === "secondary" ? secondaryColumns : primaryColumns;
+  const selectedColumns = getSelectedSqlColumns(
+    config,
+    viewType,
+    hasSecondaryDataset,
+    unwantedSource,
+  );
+  const protectedColumns = new Set<string>(PROTECTED_COLUMN_NAMES);
+  const unwantedNames = (config.UNWANTED_COLUMNS ?? "")
+    .split(",")
+    .map((column) => column.trim())
+    .filter(Boolean);
+  const invalidUnwantedColumns: string[] = [];
+  const protectedUnwantedColumns: string[] = [];
+  const conflictingUnwantedColumns: string[] = [];
+
+  unwantedNames.forEach((name) => {
+    const column = getColumnEntry(unwantedColumns, name);
+    if (!column) {
+      invalidUnwantedColumns.push(name);
+    } else if (protectedColumns.has(column.sql_column)) {
+      protectedUnwantedColumns.push(name);
+    } else if (selectedColumns.has(column.sql_column)) {
+      conflictingUnwantedColumns.push(name);
+    }
+  });
+
+  const isValid =
+    Object.keys(invalidSelections).length === 0 &&
+    invalidUnwantedColumns.length === 0 &&
+    protectedUnwantedColumns.length === 0 &&
+    conflictingUnwantedColumns.length === 0;
+
+  return {
+    conflictingUnwantedColumns,
+    invalidSelections,
+    invalidUnwantedColumns,
+    isValid,
+    protectedUnwantedColumns,
+  };
+};


### PR DESCRIPTION
## Goal

Reject unavailable, protected, or conflicting Config column values.

Part of #438.

> Stack: 2 of 4. This PR is based on `feat/438-column-metadata-api`.


## Screenshots

Not applicable. This PR does not change the interface.


## What I changed and why

I added shared column validation to Config create and update requests. The validation uses the correct primary or secondary dataset, protects unwanted columns, rejects conflicts with active fields, and rejects `_id` as a functional column. 


## How I convinced myself this is right

The validator resolves original names to SQL names before it checks conflicts. Alerts filter values use the selected secondary dataset, while other functional fields use the primary dataset. 


## What I'm not doing here

I am not adding dropdown components or changing Config forms in this PR.


## LLM use disclosure

Cursor GPT-5.6 Sol, with me driving.