### PR TITLE
Config: add dataset-backed column controls

### DIFF
--- a/components/config/ConfigColumnSelect.vue
+++ b/components/config/ConfigColumnSelect.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { getSelectableColumnOptions } from "@/utils/viewConfigColumns";
+
+import type { ColumnEntry } from "@/types";
+
+const props = withDefaults(
+  defineProps<{
+    columns: ColumnEntry[];
+    id: string;
+    label: string;
+    loading?: boolean;
+    modelValue?: string;
+    placeholder: string;
+  }>(),
+  {
+    loading: false,
+    modelValue: "",
+  },
+);
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+
+const selectableColumns = computed(() =>
+  getSelectableColumnOptions(props.columns),
+);
+
+const hasUnavailableValue = computed(
+  () =>
+    !props.loading &&
+    Boolean(props.modelValue) &&
+    !selectableColumns.value.some(
+      (column) => column.sql_column === props.modelValue?.trim(),
+    ),
+);
+
+const optionLabel = (column: ColumnEntry): string => {
+  return column.original_column === column.sql_column
+    ? column.sql_column
+    : `${column.original_column} (${column.sql_column})`;
+};
+</script>
+
+<template>
+  <div class="space-y-2 min-w-0">
+    <label :for="id" class="block text-sm font-medium text-gray-700">
+      {{ label }}
+    </label>
+    <select
+      :id="id"
+      :value="modelValue"
+      :disabled="loading"
+      :aria-invalid="hasUnavailableValue"
+      :aria-describedby="hasUnavailableValue ? `${id}-error` : undefined"
+      class="w-full px-4 py-2 text-base bg-violet-100 border rounded-lg focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:border-violet-500 transition-colors disabled:cursor-wait disabled:opacity-60"
+      :class="hasUnavailableValue ? 'border-red-400' : 'border-violet-200'"
+      @change="
+        emit('update:modelValue', ($event.target as HTMLSelectElement).value)
+      "
+    >
+      <option value="">
+        {{ loading ? $t("loading") : placeholder }}
+      </option>
+      <option v-if="hasUnavailableValue" :value="modelValue" disabled>
+        {{ modelValue }}
+      </option>
+      <option
+        v-for="column in selectableColumns"
+        :key="column.sql_column"
+        :value="column.sql_column"
+      >
+        {{ optionLabel(column) }}
+      </option>
+    </select>
+    <p
+      v-if="hasUnavailableValue"
+      :id="`${id}-error`"
+      class="text-sm text-red-600"
+      role="alert"
+    >
+      {{ $t("columnNotAvailable") }}
+    </p>
+  </div>
+</template>

--- a/composables/useDatasetColumns.ts
+++ b/composables/useDatasetColumns.ts
@@ -1,0 +1,58 @@
+import { encodeDatasetNameForUrl } from "@/utils/identifierUtils";
+
+import type { ColumnEntry } from "@/types";
+import type { Ref } from "vue";
+
+type DatasetColumnsResponse = {
+  columns: ColumnEntry[];
+  table: string;
+};
+
+/**
+ * Loads column metadata when the selected dataset changes.
+ *
+ * @param {Ref<string | null | undefined>} dataset - Selected warehouse table.
+ * @returns Column metadata and loading state.
+ */
+export const useDatasetColumns = (dataset: Ref<string | null | undefined>) => {
+  const columns = ref<ColumnEntry[]>([]);
+  const isLoading = ref(false);
+  let requestId = 0;
+
+  const loadColumns = async (): Promise<void> => {
+    const currentRequest = ++requestId;
+    const table = dataset.value?.trim() ?? "";
+
+    if (!table) {
+      columns.value = [];
+      isLoading.value = false;
+      return;
+    }
+
+    isLoading.value = true;
+
+    try {
+      const response = await $fetch<DatasetColumnsResponse>(
+        `/api/config/columns/${encodeDatasetNameForUrl(table)}`,
+      );
+      if (currentRequest === requestId) {
+        columns.value = response.columns;
+      }
+    } catch {
+      if (currentRequest === requestId) {
+        columns.value = [];
+      }
+    } finally {
+      if (currentRequest === requestId) {
+        isLoading.value = false;
+      }
+    }
+  };
+
+  watch(dataset, loadColumns, { immediate: true });
+
+  return {
+    columns,
+    isLoading,
+  };
+};

--- a/composables/useDatasetColumns.ts
+++ b/composables/useDatasetColumns.ts
@@ -1,12 +1,7 @@
 import { encodeDatasetNameForUrl } from "@/utils/identifierUtils";
 
-import type { ColumnEntry } from "@/types";
+import type { ColumnEntry, DatasetColumnsResponse } from "@/types";
 import type { Ref } from "vue";
-
-type DatasetColumnsResponse = {
-  columns: ColumnEntry[];
-  table: string;
-};
 
 /**
  * Loads column metadata when the selected dataset changes.

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -34,6 +34,7 @@
   "close": "Close",
   "colorColumn": "Color Column",
   "colorColumnDescription": "Optional: Specify a column name (e.g., 'color') that contains color values (e.g., hex codes like #FF0000). When set, map features and filter dots will use these colors instead of the randomly generated colors.",
+  "columnNotAvailable": "This column is not available in the selected dataset.",
   "community": {
     "community": "community"
   },
@@ -274,6 +275,7 @@
   "secondaryFilterValues": "Values to include from the secondary dataset on the alerts map",
   "selectAlertDateRange": "Select an alert date range",
   "selectBasemap": "Select basemap",
+  "selectColumn": "Select a column…",
   "selectMoreOptions": "Select more options",
   "selectPrimaryDataset": "Select a primary dataset…",
   "selectPrimaryDatasetOptional": "Select later…",
@@ -293,6 +295,7 @@
   "type": "Type",
   "typeOfAlerts": "Type of alerts",
   "unwantedColumns": "Unwanted columns",
+  "unwantedColumnsInvalid": "Remove protected, unavailable, or active columns before saving.",
   "version": "Version",
   "view": "View",
   "viewDescription": "View Description",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -34,6 +34,7 @@
   "close": "Cerrar",
   "colorColumn": "Columna de Color",
   "colorColumnDescription": "Opcional: Especifique un nombre de columna (por ejemplo, 'color') que contenga valores de color (por ejemplo, códigos hexadecimales como #FF0000). Cuando se establece, las características del mapa y los puntos del filtro utilizarán estos colores en lugar de los colores generados aleatoriamente.",
+  "columnNotAvailable": "Esta columna no está disponible en el conjunto de datos seleccionado.",
   "community": {
     "community": "comunidad"
   },
@@ -270,6 +271,7 @@
   "secondaryFilterValues": "Valores del conjunto de datos secundario que se incluirán en el mapa de alertas",
   "selectAlertDateRange": "Seleccione un rango de fechas de alerta",
   "selectBasemap": "Seleccione el mapa base",
+  "selectColumn": "Seleccione una columna…",
   "selectMoreOptions": "Seleccionar más opciones",
   "selectPrimaryDataset": "Seleccione un conjunto de datos principal…",
   "selectPrimaryDatasetOptional": "Seleccionar después…",
@@ -289,6 +291,7 @@
   "type": "Tipo",
   "typeOfAlerts": "Tipo de alertas",
   "unwantedColumns": "Columnas no deseadas",
+  "unwantedColumnsInvalid": "Elimine las columnas protegidas, no disponibles o activas antes de guardar.",
   "version": "Versión",
   "view": "Vista",
   "viewDescription": "Descripción de la vista",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -34,6 +34,7 @@
   "close": "Sluiten",
   "colorColumn": "Kleurkolom",
   "colorColumnDescription": "Optioneel: Specificeer een kolomnaam (bijv. 'color') die kleurwaarden bevat (bijv. hex-codes zoals #FF0000). Indien ingesteld, zullen kaartkenmerken en filterpunten deze kleuren gebruiken in plaats van willekeurig gegenereerde kleuren.",
+  "columnNotAvailable": "Deze kolom is niet beschikbaar in de geselecteerde dataset.",
   "community": {
     "community": "gemeenschap"
   },
@@ -271,6 +272,7 @@
   "secondaryFilterValues": "Waarden uit de secundaire dataset om op de alertkaart te laten zien",
   "selectAlertDateRange": "Selecteer een alert datum periode",
   "selectBasemap": "Selecteer basiskaart",
+  "selectColumn": "Selecteer een kolom…",
   "selectMoreOptions": "Meer opties selecteren",
   "selectPrimaryDataset": "Selecteer een primaire dataset…",
   "selectPrimaryDatasetOptional": "Later selecteren…",
@@ -290,6 +292,7 @@
   "type": "Type",
   "typeOfAlerts": "Type alerts",
   "unwantedColumns": "Ongewenste kolommen",
+  "unwantedColumnsInvalid": "Verwijder beschermde, niet-beschikbare of actieve kolommen voordat u opslaat.",
   "version": "Versie",
   "view": "Weergave",
   "viewDescription": "Weergavebeschrijving",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -34,6 +34,7 @@
   "close": "Fechar",
   "colorColumn": "Coluna de Cor",
   "colorColumnDescription": "Opcional: Especifique um nome de coluna (por exemplo, 'color') que contenha valores de cor (por exemplo, códigos hexadecimais como #FF0000). Quando definido, os recursos do mapa e os pontos do filtro usarão essas cores em vez das cores geradas aleatoriamente.",
+  "columnNotAvailable": "Esta coluna não está disponível no conjunto de dados selecionado.",
   "community": {
     "community": "comunidade"
   },
@@ -270,6 +271,7 @@
   "secondaryFilterValues": "Valores do conjunto de dados secundário para incluir no mapa de alertas",
   "selectAlertDateRange": "Selecione um intervalo de datas de alerta",
   "selectBasemap": "Selecione o mapa base",
+  "selectColumn": "Selecione uma coluna…",
   "selectMoreOptions": "Selecionar mais opções",
   "selectPrimaryDataset": "Selecione um conjunto de dados principal…",
   "selectPrimaryDatasetOptional": "Selecionar depois…",
@@ -289,6 +291,7 @@
   "type": "Tipo",
   "typeOfAlerts": "Tipo de alertas",
   "unwantedColumns": "Colunas indesejadas",
+  "unwantedColumnsInvalid": "Remova as colunas protegidas, indisponíveis ou ativas antes de salvar.",
   "version": "Versão",
   "view": "Visualização",
   "viewDescription": "Descrição da visualização",

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -34,6 +34,7 @@
   "close": "Funga",
   "colorColumn": "Safu ya Rangi",
   "colorColumnDescription": "Hiari: Eleza jina la safu (k.m., 'color') linalo na thamani za rangi (k.m., misimbo ya hex kama #FF0000). Inapowekwa, vipengele vya ramani na nukta za kichujio zitatumia rangi hizi badala ya zile zilizotengenezwa kwa nasibu.",
+  "columnNotAvailable": "Safu hii haipatikani katika seti ya data iliyochaguliwa.",
   "community": {
     "community": "jamii"
   },
@@ -274,6 +275,7 @@
   "secondaryFilterValues": "Thamani za kujumuisha kutoka kwa seti ya data ya pili kwenye ramani ya arifa",
   "selectAlertDateRange": "Chagua masafa ya tarehe ya tahadhari",
   "selectBasemap": "Chagua ramani ya msingi",
+  "selectColumn": "Chagua safu…",
   "selectMoreOptions": "Chagua chaguo zaidi",
   "selectPrimaryDataset": "Chagua seti kuu ya data…",
   "selectPrimaryDatasetOptional": "Chagua baadaye…",
@@ -293,6 +295,7 @@
   "type": "Aina",
   "typeOfAlerts": "Aina ya tahadhari",
   "unwantedColumns": "Safu zisizotakiwa",
+  "unwantedColumnsInvalid": "Ondoa safu zilizolindwa, zisizopatikana au zinazotumika kabla ya kuhifadhi.",
   "version": "Toleo",
   "view": "Mtazamo",
   "viewDescription": "Maelezo ya Mtazamo",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -34,6 +34,7 @@
   "close": "ปิด",
   "colorColumn": "คอลัมน์สี",
   "colorColumnDescription": "ไม่บังคับ: ระบุชื่อคอลัมน์ (เช่น 'color') ที่มีค่าสี (เช่น รหัสสีแบบ #FF0000) เมื่อตั้งค่าแล้ว ฟีเจอร์บนแผนที่และจุดตัวกรองจะใช้สีเหล่านี้แทนสีที่สุ่ม",
+  "columnNotAvailable": "คอลัมน์นี้ไม่มีอยู่ในชุดข้อมูลที่เลือก",
   "community": {
     "community": "ชุมชน"
   },
@@ -274,6 +275,7 @@
   "secondaryFilterValues": "ค่าจากชุดข้อมูลรองที่จะรวมลงในแผนที่แจ้งเตือน",
   "selectAlertDateRange": "เลือกช่วงวันที่การแจ้งเตือน",
   "selectBasemap": "เลือกแผนที่ฐาน",
+  "selectColumn": "เลือกคอลัมน์…",
   "selectMoreOptions": "เลือกตัวเลือกเพิ่มเติม",
   "selectPrimaryDataset": "เลือกชุดข้อมูลหลัก…",
   "selectPrimaryDatasetOptional": "เลือกภายหลัง…",
@@ -293,6 +295,7 @@
   "type": "ประเภท",
   "typeOfAlerts": "ประเภทของการแจ้งเตือน",
   "unwantedColumns": "คอลัมน์ที่ไม่ต้องการ",
+  "unwantedColumnsInvalid": "นำคอลัมน์ที่ได้รับการป้องกัน ไม่มีอยู่ หรือกำลังใช้งานออกก่อนบันทึก",
   "version": "เวอร์ชัน",
   "view": "มุมมอง",
   "viewDescription": "คำอธิบายมุมมอง",

--- a/server/api/config/columns/[table].get.ts
+++ b/server/api/config/columns/[table].get.ts
@@ -2,16 +2,19 @@ import { fetchTableColumnEntries } from "@/server/database/dbOperations";
 import { getTableParam } from "@/server/utils/dbHelpers";
 import { validatePermissions } from "@/utils/accessControls";
 
+import type { DatasetColumnsResponse } from "@/types";
 import type { H3Event } from "h3";
 
-export default defineEventHandler(async (event: H3Event) => {
-  await validatePermissions(event, "admin");
+export default defineEventHandler(
+  async (event: H3Event): Promise<DatasetColumnsResponse> => {
+    await validatePermissions(event, "admin");
 
-  const table = getTableParam(event);
-  const columns = await fetchTableColumnEntries(table);
+    const table = getTableParam(event);
+    const columns = await fetchTableColumnEntries(table);
 
-  return {
-    columns,
-    table,
-  };
-});
+    return {
+      columns,
+      table,
+    };
+  },
+);

--- a/tests/unit/components/ConfigColumnSelect.test.ts
+++ b/tests/unit/components/ConfigColumnSelect.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import ConfigColumnSelect from "@/components/config/ConfigColumnSelect.vue";
+
+const columns = [
+  {
+    original_column: "_id",
+    sql_column: "_id",
+  },
+  {
+    original_column: "formhub/uuid",
+    sql_column: "uuid__formhub",
+  },
+  {
+    original_column: "status",
+    sql_column: "status",
+  },
+];
+
+const mountSelect = (modelValue = "") =>
+  mount(ConfigColumnSelect, {
+    props: {
+      columns,
+      id: "column-select",
+      label: "Column",
+      modelValue,
+      placeholder: "Select a column",
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+
+describe("ConfigColumnSelect", () => {
+  it("uses SQL names as values and shows original names", () => {
+    const wrapper = mountSelect();
+    const options = wrapper.findAll("option");
+
+    expect(options.map((option) => option.attributes("value"))).toEqual([
+      "",
+      "uuid__formhub",
+      "status",
+    ]);
+    expect(options[1].text()).toBe("formhub/uuid (uuid__formhub)");
+  });
+
+  it("does not offer _id as a selectable value", () => {
+    const wrapper = mountSelect();
+
+    expect(wrapper.find('option[value="_id"]').exists()).toBe(false);
+  });
+
+  it("emits the selected SQL column", async () => {
+    const wrapper = mountSelect();
+
+    await wrapper.get("select").setValue("status");
+
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual(["status"]);
+  });
+
+  it("keeps an unavailable configured value visible with an error", () => {
+    const wrapper = mountSelect("missing_column");
+
+    expect(wrapper.get("select").attributes("aria-invalid")).toBe("true");
+    expect(wrapper.get('[role="alert"]').text()).toBe("columnNotAvailable");
+    expect(wrapper.get('option[value="missing_column"]').exists()).toBe(true);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -194,6 +194,11 @@ export type ColumnEntry = {
   sql_column: string;
 };
 
+export type DatasetColumnsResponse = {
+  columns: ColumnEntry[];
+  table: string;
+};
+
 export type DataEntry = Record<string, string> & {
   normalizedId?: number;
 };


### PR DESCRIPTION
## Goal

Add reusable controls that load and display valid dataset columns.

Part of #438.

> Stack: 3 of 4. This PR is based on `feat/438-column-validation`.


## Screenshots

Not included. 

## What I changed and why

I added a reactive dataset-column loader and a shared column select component. The loader ignores stale responses when the selected dataset changes. The select shows original and SQL names, keeps unavailable saved values visible as errors, and does not offer `_id`.


## How I convinced myself this is right

Manual testing


## What I'm not doing here

I am not replacing existing Config fields in this PR.


## LLM use disclosure

Cursor GPT-5.6 Sol, with me driving.