### PR TITLE
Config: use dataset columns in forms

### DIFF
--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -2,10 +2,12 @@
 import { useAppConfig } from "#imports";
 import {
   supportsSecondaryDataset,
+  type ColumnEntry,
   type ViewConfig,
   type ViewType,
 } from "@/types";
 import { CONFIG_LIMITS } from "@/utils";
+import { validateViewConfigColumns } from "@/utils/viewConfigColumns";
 import ConfigPermissions from "./ConfigPermissions.vue";
 import ConfigCollapsibleSection from "./ConfigCollapsibleSection.vue";
 import { Check, Trash2 } from "lucide-vue-next";
@@ -25,6 +27,10 @@ const props = withDefaults(
     /** False when the parent blocks Save (e.g. missing primary or duplicate view). */
     saveEnabled?: boolean;
     secondaryEditable?: boolean;
+    primaryColumns?: ColumnEntry[];
+    secondaryColumns?: ColumnEntry[];
+    primaryColumnsLoading?: boolean;
+    secondaryColumnsLoading?: boolean;
   }>(),
   {
     configToCopy: null,
@@ -32,6 +38,10 @@ const props = withDefaults(
     showRemove: true,
     saveEnabled: true,
     secondaryEditable: false,
+    primaryColumns: () => [],
+    secondaryColumns: () => [],
+    primaryColumnsLoading: false,
+    secondaryColumnsLoading: false,
   },
 );
 
@@ -173,13 +183,42 @@ const isChanged = computed(() => {
 // Track permission validation state
 const isPermissionValid = ref(true);
 
+const hasSecondaryDataset = computed(
+  () =>
+    shouldUseSecondaryDataset.value &&
+    localSecondaryDataset.value.trim() !== "",
+);
+
+const columnValidation = computed(() =>
+  validateViewConfigColumns(
+    localConfig.value,
+    props.primaryColumns,
+    props.secondaryColumns,
+    props.viewType,
+    hasSecondaryDataset.value,
+  ),
+);
+
+const areColumnsLoading = computed(
+  () =>
+    props.primaryColumnsLoading ||
+    (props.viewType === "alerts" &&
+      hasSecondaryDataset.value &&
+      props.secondaryColumnsLoading),
+);
+
 const isFormValid = computed(() => {
   const isMapConfigValid = shouldShowConfigMap.value
     ? localConfig.value.MAPBOX_ACCESS_TOKEN?.trim() !== "" &&
       localConfig.value.MAPBOX_ACCESS_TOKEN != null
     : true;
 
-  return isMapConfigValid && isPermissionValid.value;
+  return (
+    isMapConfigValid &&
+    isPermissionValid.value &&
+    columnValidation.value.isValid &&
+    !areColumnsLoading.value
+  );
 });
 
 const canSubmit = computed(
@@ -261,6 +300,8 @@ const handleSubmit = () => {
             :views="viewTypeList"
             :config="localConfig"
             :keys="mapConfigKeys"
+            :columns="primaryColumns"
+            :columns-loading="primaryColumnsLoading"
             @update-config="handleConfigUpdate"
           />
         </ConfigCollapsibleSection>
@@ -275,6 +316,8 @@ const handleSubmit = () => {
             :views="viewTypeList"
             :config="localConfig"
             :keys="mediaKeys"
+            :columns="primaryColumns"
+            :columns-loading="primaryColumnsLoading"
             @update-config="handleConfigUpdate"
           />
         </ConfigCollapsibleSection>
@@ -289,6 +332,12 @@ const handleSubmit = () => {
             :views="viewTypeList"
             :config="localConfig"
             :keys="filterKeys"
+            :view-type="viewType"
+            :has-secondary-dataset="hasSecondaryDataset"
+            :primary-columns="primaryColumns"
+            :secondary-columns="secondaryColumns"
+            :primary-columns-loading="primaryColumnsLoading"
+            :secondary-columns-loading="secondaryColumnsLoading"
             @update-config="handleConfigUpdate"
           />
         </ConfigCollapsibleSection>

--- a/components/config/ConfigFilters.vue
+++ b/components/config/ConfigFilters.vue
@@ -1,18 +1,31 @@
 <script setup lang="ts">
+import { computed } from "vue";
+
+import ConfigColumnSelect from "@/components/config/ConfigColumnSelect.vue";
 import { toCamelCase } from "@/utils/identifierUtils";
 
 // @ts-expect-error - vue-tags-input does not have types
 import { VueTagsInput } from "@vojtechlanka/vue-tags-input";
 
 import { updateTags } from "@/composables/useTags";
+import {
+  getUnwantedColumnOptions,
+  validateViewConfigColumns,
+} from "@/utils/viewConfigColumns";
 
-import type { ViewConfig } from "@/types";
+import type { ColumnEntry, ViewConfig, ViewType } from "@/types";
 
 const props = defineProps<{
   tableName: string;
   config: ViewConfig;
   views: string[];
   keys: string[];
+  viewType: ViewType;
+  hasSecondaryDataset?: boolean;
+  primaryColumns?: ColumnEntry[];
+  secondaryColumns?: ColumnEntry[];
+  primaryColumnsLoading?: boolean;
+  secondaryColumnsLoading?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -38,14 +51,75 @@ const { tags, handleTagsChanged: rawHandleTagsChanged } = updateTags(
 );
 
 const handleTagsChanged = (key: string, newTags: Tag[]): void => {
-  rawHandleTagsChanged(key, newTags);
-  const values = newTags.map((tag) => tag.text).join(",");
+  const existingTags = new Set((tags.value[key] ?? []).map((tag) => tag.text));
+  const acceptedTags =
+    key === "UNWANTED_COLUMNS"
+      ? newTags.filter((tag) =>
+          [
+            ...unwantedColumnOptions.value.map(
+              (column) => column.original_column,
+            ),
+            ...existingTags,
+          ].includes(tag.text),
+        )
+      : newTags;
+  rawHandleTagsChanged(key, acceptedTags);
+  const values = acceptedTags.map((tag) => tag.text).join(",");
   emit("updateConfig", { [key]: values });
 };
 
 const handleInput = (key: string, value: string): void => {
   emit("updateConfig", { [key]: value });
 };
+
+const getStringConfigValue = (key: string): string => {
+  const value = props.config[key];
+  return typeof value === "string" ? value : "";
+};
+
+const filterColumns = computed(() =>
+  props.viewType === "alerts" && props.hasSecondaryDataset
+    ? (props.secondaryColumns ?? [])
+    : (props.primaryColumns ?? []),
+);
+
+const filterColumnsLoading = computed(() =>
+  props.viewType === "alerts" && props.hasSecondaryDataset
+    ? props.secondaryColumnsLoading
+    : props.primaryColumnsLoading,
+);
+
+const unwantedColumnOptions = computed(() =>
+  getUnwantedColumnOptions(
+    props.primaryColumns ?? [],
+    props.config,
+    props.viewType,
+    Boolean(props.hasSecondaryDataset),
+  ),
+);
+
+const unwantedAutocompleteItems = computed(() =>
+  unwantedColumnOptions.value.map((column) => ({
+    text: column.original_column,
+  })),
+);
+
+const columnValidation = computed(() =>
+  validateViewConfigColumns(
+    props.config,
+    props.primaryColumns ?? [],
+    props.secondaryColumns ?? [],
+    props.viewType,
+    Boolean(props.hasSecondaryDataset),
+  ),
+);
+
+const hasUnwantedColumnError = computed(
+  () =>
+    columnValidation.value.invalidUnwantedColumns.length > 0 ||
+    columnValidation.value.protectedUnwantedColumns.length > 0 ||
+    columnValidation.value.conflictingUnwantedColumns.length > 0,
+);
 </script>
 
 <template>
@@ -63,34 +137,25 @@ const handleInput = (key: string, value: string): void => {
       }"
     >
       <template v-if="key === 'FRONT_END_FILTER_COLUMN'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t("filterDataByColumn") }}
-        </label>
-        <input
+        <ConfigColumnSelect
           :id="`${tableName}-${key}`"
-          :value="config[key]"
-          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="text"
-          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
+          :model-value="getStringConfigValue(key)"
+          :label="$t('filterDataByColumn')"
+          :placeholder="$t('selectColumn')"
+          :columns="filterColumns"
+          :loading="filterColumnsLoading"
+          @update:model-value="(value) => handleInput(key, value)"
         />
       </template>
       <template v-else-if="key === 'TIMESTAMP_COLUMN'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <input
+        <ConfigColumnSelect
           :id="`${tableName}-${key}`"
-          :value="config[key]"
-          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          type="text"
-          placeholder="e.g. End or created_at"
-          @input="(e) => handleInput(key, (e.target as HTMLInputElement).value)"
+          :model-value="getStringConfigValue(key)"
+          :label="$t(toCamelCase(key))"
+          :placeholder="$t('selectColumn')"
+          :columns="primaryColumns ?? []"
+          :loading="primaryColumnsLoading"
+          @update:model-value="(value) => handleInput(key, value)"
         />
       </template>
       <template
@@ -108,8 +173,20 @@ const handleInput = (key: string, value: string): void => {
           :id="`${tableName}-${key}`"
           class="tag-field w-full"
           :tags="tags[key]"
+          :autocomplete-items="
+            key === 'UNWANTED_COLUMNS' ? unwantedAutocompleteItems : []
+          "
+          :autocomplete-min-length="0"
+          :autocomplete-filter-duplicates="true"
           @tags-changed="(newTags: Tag[]) => handleTagsChanged(key, newTags)"
         />
+        <p
+          v-if="key === 'UNWANTED_COLUMNS' && hasUnwantedColumnError"
+          class="text-sm text-red-600"
+          role="alert"
+        >
+          {{ $t("unwantedColumnsInvalid") }}
+        </p>
       </template>
     </div>
   </div>

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -3,16 +3,19 @@
 import { VueTagsInput } from "@vojtechlanka/vue-tags-input";
 import VueSlider from "vue-3-slider-component";
 
+import ConfigColumnSelect from "@/components/config/ConfigColumnSelect.vue";
 import { toCamelCase } from "@/utils/identifierUtils";
 import { updateTags } from "@/composables/useTags";
 
-import type { ViewConfig, BasemapConfig } from "@/types";
+import type { ViewConfig, BasemapConfig, ColumnEntry } from "@/types";
 
 const props = defineProps<{
   tableName: string;
   config: ViewConfig;
   views: string[];
   keys: string[];
+  columns?: ColumnEntry[];
+  columnsLoading?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -49,6 +52,11 @@ const handleTagsChanged = (key: string, newTags: Tag[]): void => {
 const handleInput = (key: string, value: string | number | boolean): void => {
   if (typeof value === "number" && isNaN(value)) return;
   emit("updateConfig", { [key]: value });
+};
+
+const getStringConfigValue = (key: string): string => {
+  const value = props.config[key];
+  return typeof value === "string" ? value : "";
 };
 
 const terrainExaggeration = ref<number>(
@@ -565,42 +573,28 @@ const fullWidthKeys = [
 
         <!-- Color Column -->
         <template v-else-if="key === 'COLOR_COLUMN'">
-          <label
-            :for="`${tableName}-${key}`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t(toCamelCase(key)) }}
-          </label>
-          <input
+          <ConfigColumnSelect
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-            type="text"
-            placeholder="color"
-            :value="config[key]"
-            @input="
-              (e) => handleInput(key, (e.target as HTMLInputElement).value)
-            "
+            :model-value="getStringConfigValue(key)"
+            :label="$t(toCamelCase(key))"
+            :placeholder="$t('selectColumn')"
+            :columns="columns ?? []"
+            :loading="columnsLoading"
+            @update:model-value="(value) => handleInput(key, value)"
           />
           <p class="field-description">{{ $t("colorColumnDescription") }}</p>
         </template>
 
         <!-- Icon Column -->
         <template v-else-if="key === 'ICON_COLUMN'">
-          <label
-            :for="`${tableName}-${key}`"
-            class="block text-sm font-medium text-gray-700"
-          >
-            {{ $t(toCamelCase(key)) }}
-          </label>
-          <input
+          <ConfigColumnSelect
             :id="`${tableName}-${key}`"
-            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-            type="text"
-            placeholder="icon"
-            :value="config[key]"
-            @input="
-              (e) => handleInput(key, (e.target as HTMLInputElement).value)
-            "
+            :model-value="getStringConfigValue(key)"
+            :label="$t(toCamelCase(key))"
+            :placeholder="$t('selectColumn')"
+            :columns="columns ?? []"
+            :loading="columnsLoading"
+            @update:model-value="(value) => handleInput(key, value)"
           />
           <p class="text-xs text-gray-500 mt-1">
             {{ $t("iconColumnDescription") }}

--- a/components/config/ConfigMedia.vue
+++ b/components/config/ConfigMedia.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ConfigColumnSelect from "@/components/config/ConfigColumnSelect.vue";
 import { toCamelCase } from "@/utils/identifierUtils";
 import {
   extractShareId,
@@ -7,13 +8,15 @@ import {
   getBaseUrlFromInput,
   isValidFilebrowserInput,
 } from "@/utils/mediaHelpers";
-import type { ViewConfig } from "@/types";
+import type { ColumnEntry, ViewConfig } from "@/types";
 
 const props = defineProps<{
   tableName: string;
   config: ViewConfig;
   views: string[];
   keys: string[];
+  columns?: ColumnEntry[];
+  columnsLoading?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -29,7 +32,6 @@ const providerAlerts = ref<MediaProvider>("filebrowser");
 const shareInputAlerts = ref("");
 const providerIcons = ref<MediaProvider>("filebrowser");
 const shareInputIcons = ref("");
-const mediaColumn = ref("");
 const isInitializing = ref(true);
 
 /**
@@ -143,12 +145,6 @@ watch(resolvedIconsPath, (newValue) => {
   }
 });
 
-watch(mediaColumn, (newValue) => {
-  if (!isInitializing.value) {
-    emit("updateConfig", { MEDIA_COLUMN: newValue });
-  }
-});
-
 // Keep local media fields in sync with the config prop (including the initial value).
 watch(
   () => props.config,
@@ -211,8 +207,6 @@ watch(
     } else {
       shareInputIcons.value = "";
     }
-
-    mediaColumn.value = config.MEDIA_COLUMN || "";
 
     nextTick(() => {
       isInitializing.value = false;
@@ -541,22 +535,19 @@ watch(
 
     <!-- MEDIA_COLUMN -->
     <div v-if="keys.includes('MEDIA_COLUMN')" class="space-y-2">
-      <label
-        :for="`${tableName}-media-column`"
-        class="block text-sm font-medium text-gray-700"
-      >
-        {{ $t(toCamelCase("MEDIA_COLUMN")) }}
-      </label>
       <p class="text-xs text-gray-500 mb-2">
         {{ $t("mediaColumnDescription") }}
       </p>
-      <input
+      <ConfigColumnSelect
         :id="`${tableName}-media-column`"
-        class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-        type="text"
-        :value="mediaColumn"
-        placeholder="photo"
-        @input="mediaColumn = ($event.target as HTMLInputElement).value"
+        :model-value="config.MEDIA_COLUMN"
+        :label="$t(toCamelCase('MEDIA_COLUMN'))"
+        :placeholder="$t('selectColumn')"
+        :columns="columns ?? []"
+        :loading="columnsLoading"
+        @update:model-value="
+          (value) => emit('updateConfig', { MEDIA_COLUMN: value })
+        "
       />
     </div>
   </div>

--- a/pages/config/[dataset].vue
+++ b/pages/config/[dataset].vue
@@ -6,6 +6,7 @@ import SelectDatasetField from "@/components/config/SelectDatasetField.vue";
 import DataLoadError from "@/components/shared/DataLoadError.vue";
 import ViewTypePill from "@/components/shared/ViewTypePill.vue";
 import { useCopyConfig } from "@/composables/useCopyConfig";
+import { useDatasetColumns } from "@/composables/useDatasetColumns";
 import {
   supportsSecondaryDataset,
   type ViewConfig,
@@ -32,6 +33,12 @@ const datasetConfig = ref<ViewConfig | null>(null);
 const secondaryDataset = ref<string | null>(null);
 const viewName = ref("");
 const errorMessage = ref<string | null>(null);
+const primaryDatasetForColumns = computed(() => dataset);
+const secondaryDatasetForColumns = computed(() => secondaryDataset.value);
+const { columns: primaryColumns, isLoading: primaryColumnsLoading } =
+  useDatasetColumns(primaryDatasetForColumns);
+const { columns: secondaryColumns, isLoading: secondaryColumnsLoading } =
+  useDatasetColumns(secondaryDatasetForColumns);
 
 const editedViewType = ref<ViewType | undefined>(undefined);
 
@@ -309,6 +316,10 @@ definePageMeta({ layout: "explorer" });
           :secondary-dataset="secondaryDataset"
           :config-to-copy="configToCopy"
           :secondary-editable="true"
+          :primary-columns="primaryColumns"
+          :secondary-columns="secondaryColumns"
+          :primary-columns-loading="primaryColumnsLoading"
+          :secondary-columns-loading="secondaryColumnsLoading"
           @submit-config="submitConfig"
           @remove-table-from-config="handleRemoveTableFromConfig"
         />

--- a/pages/config/new/[view_type].vue
+++ b/pages/config/new/[view_type].vue
@@ -6,6 +6,7 @@ import SelectDatasetField from "@/components/config/SelectDatasetField.vue";
 import DataLoadError from "@/components/shared/DataLoadError.vue";
 import ViewTypePill from "@/components/shared/ViewTypePill.vue";
 import { useCopyConfig } from "@/composables/useCopyConfig";
+import { useDatasetColumns } from "@/composables/useDatasetColumns";
 import { useDuplicateViewCheck } from "@/composables/useDuplicateViewCheck";
 import { useAppConfig } from "#imports";
 import {
@@ -57,6 +58,12 @@ const secondaryDataset = ref<string | null>(null);
 const errorMessage = ref<string | null>(null);
 const isSaving = ref(false);
 const showSavedModal = ref(false);
+const primaryDatasetForColumns = computed(() => primaryDataset.value);
+const secondaryDatasetForColumns = computed(() => secondaryDataset.value);
+const { columns: primaryColumns, isLoading: primaryColumnsLoading } =
+  useDatasetColumns(primaryDatasetForColumns);
+const { columns: secondaryColumns, isLoading: secondaryColumnsLoading } =
+  useDatasetColumns(secondaryDatasetForColumns);
 
 const { isDuplicate, existingView, isChecking, checkDuplicate } =
   useDuplicateViewCheck(viewType, primaryDataset);
@@ -264,6 +271,10 @@ definePageMeta({ layout: "explorer" });
         :show-remove="false"
         :save-enabled="saveEnabled"
         :secondary-editable="true"
+        :primary-columns="primaryColumns"
+        :secondary-columns="secondaryColumns"
+        :primary-columns-loading="primaryColumnsLoading"
+        :secondary-columns-loading="secondaryColumnsLoading"
         @submit-config="submitConfig"
       />
     </template>

--- a/tests/e2e/04-config.spec.ts
+++ b/tests/e2e/04-config.spec.ts
@@ -503,7 +503,6 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
 
   for (const view of views) {
     await page.goto(view.path);
-    await page.waitForLoadState("networkidle");
     await page.waitForSelector("form", { timeout: 15000 });
 
     const selector = page.locator(
@@ -511,6 +510,15 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
     );
     const submitButton = page.locator("[data-testid='config-submit-button']");
     const originalValue = await selector.inputValue();
+    let originalFilterValue: string | null = null;
+    if (view.primaryDataset === "fake_alerts") {
+      await page
+        .locator('[data-testid="config-section-filtering-toggle"]')
+        .click();
+      originalFilterValue = await page
+        .locator('select[id*="FRONT_END_FILTER_COLUMN"]')
+        .inputValue();
+    }
     const optionValues = await selector
       .locator("option")
       .evaluateAll((options) =>
@@ -525,6 +533,18 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
 
     expect(replacement).toBeTruthy();
     await selector.selectOption(replacement!);
+    if (view.primaryDataset === "fake_alerts") {
+      const filterColumn = page.locator(
+        'select[id*="FRONT_END_FILTER_COLUMN"]',
+      );
+      await expect(filterColumn).toBeEnabled();
+      const replacementFilter = await filterColumn
+        .locator('option:not([value=""]):not([disabled])')
+        .first()
+        .getAttribute("value");
+      expect(replacementFilter).toBeTruthy();
+      await filterColumn.selectOption(replacementFilter!);
+    }
     await expect(submitButton).toBeEnabled();
     await submitButton.evaluate((button) => {
       (button as HTMLButtonElement).formNoValidate = true;
@@ -538,6 +558,16 @@ test("config page - edit secondary dataset for Alert and Map views", async ({
     await expect(selector).toHaveValue(replacement!);
 
     await selector.selectOption(originalValue);
+    if (view.primaryDataset === "fake_alerts") {
+      await page
+        .locator('[data-testid="config-section-filtering-toggle"]')
+        .click();
+      const filterColumn = page.locator(
+        'select[id*="FRONT_END_FILTER_COLUMN"]',
+      );
+      await expect(filterColumn).toBeEnabled();
+      await filterColumn.selectOption(originalFilterValue!);
+    }
     await expect(submitButton).toBeEnabled();
     await submitButton.evaluate((button) => {
       (button as HTMLButtonElement).formNoValidate = true;
@@ -653,7 +683,6 @@ test("config page - visibility permissions configuration", async ({
   // Use a seeded view that already has ROUTE_LEVEL_PERMISSION set. Newly added
   // views start with an empty config and intentionally have no radio selected.
   await page.goto("/config/fake_alerts?view_type=alerts");
-  await page.waitForLoadState("networkidle");
   await page.waitForSelector("form", { timeout: 15000 });
 
   const visibilitySection = page.locator(
@@ -830,21 +859,67 @@ test("config page - color column configuration", async ({
 }) => {
   await openMapConfigEditPage(page);
 
-  const colorColumnInput = page.locator('input[id*="COLOR_COLUMN"]');
-  const hasColorColumn = (await colorColumnInput.count()) > 0;
+  const colorColumnSelect = page.locator('select[id*="COLOR_COLUMN"]');
+  const hasColorColumn = (await colorColumnSelect.count()) > 0;
 
   if (hasColorColumn) {
-    await expect(colorColumnInput.first()).toBeVisible();
+    await expect(colorColumnSelect.first()).toBeVisible();
 
-    await colorColumnInput.first().clear();
-    await colorColumnInput.first().fill("color");
+    await colorColumnSelect.first().selectOption("community");
     await page.waitForTimeout(300);
 
-    await expect(colorColumnInput.first()).toHaveValue("color");
+    await expect(colorColumnSelect.first()).toHaveValue("community");
 
     const submitButton = page.locator("[data-testid='config-submit-button']");
     await expect(submitButton).toBeEnabled();
   }
+});
+
+test("config page - column controls use dataset metadata and reject conflicts", async ({
+  authenticatedPageAsAdmin: page,
+}) => {
+  await openMapConfigEditPage(page);
+
+  const response = await page.request.get(
+    "/api/config/columns/bcmform_responses",
+  );
+  expect(response.ok()).toBe(true);
+  const body = (await response.json()) as {
+    columns: Array<{ original_column: string; sql_column: string }>;
+  };
+  expect(body.columns).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        original_column: "community",
+        sql_column: "community",
+      }),
+    ]),
+  );
+
+  const colorColumnSelect = page.locator('select[id*="COLOR_COLUMN"]');
+  const iconColumnSelect = page.locator('select[id*="ICON_COLUMN"]');
+  await expect(
+    colorColumnSelect.locator('option[value="community"]'),
+  ).toHaveText("community");
+  await expect(iconColumnSelect.locator('option[value="photo"]')).toHaveText(
+    "photo",
+  );
+  await expect(colorColumnSelect.locator('option[value="_id"]')).toHaveCount(0);
+  await expect(iconColumnSelect.locator('option[value="_id"]')).toHaveCount(0);
+
+  const invalidSave = await page.request.post(
+    "/api/config/update_config/bcmform_responses?view_type=map",
+    {
+      data: {
+        config: {
+          COLOR_COLUMN: "community",
+          UNWANTED_COLUMNS: "community",
+        },
+        secondaryDataset: null,
+      },
+    },
+  );
+  expect(invalidSave.status()).toBe(400);
 });
 
 test("config page - copy config from another same-type view", async ({

--- a/tests/unit/components/ConfigFilters.test.ts
+++ b/tests/unit/components/ConfigFilters.test.ts
@@ -22,13 +22,20 @@ const mountConfigFilters = () =>
         SECONDARY_FILTER_VALUES: "active,pending",
       },
       views: ["alerts"],
+      viewType: "alerts",
+      hasSecondaryDataset: true,
+      primaryColumns: [{ original_column: "_id", sql_column: "_id" }],
+      secondaryColumns: [
+        { original_column: "status", sql_column: "status" },
+        { original_column: "status_type", sql_column: "status_type" },
+      ],
       keys: ["FRONT_END_FILTER_COLUMN", "SECONDARY_FILTER_VALUES"],
     },
     global: {
       stubs: {
         VueTagsInput: {
           name: "VueTagsInput",
-          props: ["tags"],
+          props: ["tags", "autocompleteItems"],
           emits: ["tags-changed"],
           template:
             "<button data-testid=\"filter-values\" @click=\"$emit('tags-changed', [{ text: 'active' }])\" />",
@@ -45,7 +52,7 @@ describe("ConfigFilters", () => {
     const wrapper = mountConfigFilters();
 
     await wrapper
-      .get<HTMLInputElement>("#alerts_table-FRONT_END_FILTER_COLUMN")
+      .get<HTMLSelectElement>("#alerts_table-FRONT_END_FILTER_COLUMN")
       .setValue("status_type");
 
     expect(wrapper.emitted("updateConfig")?.[0]?.[0]).toEqual({
@@ -81,5 +88,76 @@ describe("ConfigFilters", () => {
     expect(
       wrapper.get("#alerts_table-SECONDARY_FILTER_VALUES").attributes("id"),
     ).toBe("alerts_table-SECONDARY_FILTER_VALUES");
+  });
+
+  it("excludes protected and active columns from unwanted suggestions", () => {
+    const wrapper = mount(ConfigFilters, {
+      props: {
+        tableName: "survey_table",
+        config: {
+          COLOR_COLUMN: "status",
+        },
+        views: ["map"],
+        viewType: "map",
+        primaryColumns: [
+          { original_column: "_id", sql_column: "_id" },
+          { original_column: "Geometry", sql_column: "g__coordinates" },
+          { original_column: "Status", sql_column: "status" },
+          { original_column: "Photo", sql_column: "photo" },
+        ],
+        keys: ["UNWANTED_COLUMNS"],
+      },
+      global: {
+        stubs: {
+          VueTagsInput: {
+            name: "VueTagsInput",
+            props: ["tags", "autocompleteItems"],
+            template: "<div />",
+          },
+        },
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+
+    expect(
+      wrapper.getComponent({ name: "VueTagsInput" }).props(),
+    ).toMatchObject({
+      autocompleteItems: [{ text: "Photo" }],
+    });
+  });
+
+  it("shows an error when unwanted columns conflict with active fields", () => {
+    const wrapper = mount(ConfigFilters, {
+      props: {
+        tableName: "survey_table",
+        config: {
+          COLOR_COLUMN: "status",
+          UNWANTED_COLUMNS: "Status",
+        },
+        views: ["map"],
+        viewType: "map",
+        primaryColumns: [
+          { original_column: "_id", sql_column: "_id" },
+          { original_column: "Status", sql_column: "status" },
+        ],
+        keys: ["UNWANTED_COLUMNS"],
+      },
+      global: {
+        stubs: {
+          VueTagsInput: {
+            name: "VueTagsInput",
+            props: ["tags", "autocompleteItems"],
+            template: "<div />",
+          },
+        },
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    });
+
+    expect(wrapper.get('[role="alert"]').text()).toBe("unwantedColumnsInvalid");
   });
 });

--- a/tests/unit/components/ConfigMap.test.ts
+++ b/tests/unit/components/ConfigMap.test.ts
@@ -714,16 +714,17 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const colorColumnInput = wrapper.find(
-      'input[id="test_table-COLOR_COLUMN"]',
+    const colorColumnSelect = wrapper.find(
+      'select[id="test_table-COLOR_COLUMN"]',
     );
-    expect(colorColumnInput.exists()).toBe(true);
+    expect(colorColumnSelect.exists()).toBe(true);
   });
 
   it("updates COLOR_COLUMN value when input changes", async () => {
     const propsWithColorColumn = {
       ...baseProps,
       keys: [...baseProps.keys, "COLOR_COLUMN"],
+      columns: [{ original_column: "color", sql_column: "color" }],
     };
 
     const wrapper = mount(ConfigMap, {
@@ -731,17 +732,17 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const colorColumnInput = wrapper.find(
-      'input[id="test_table-COLOR_COLUMN"]',
+    const colorColumnSelect = wrapper.find(
+      'select[id="test_table-COLOR_COLUMN"]',
     );
-    await colorColumnInput.setValue("color");
+    await colorColumnSelect.setValue("color");
 
     expect(wrapper.emitted("updateConfig")).toBeTruthy();
     const emitted = wrapper.emitted("updateConfig");
     expect(emitted?.[0]?.[0]).toEqual({ COLOR_COLUMN: "color" });
   });
 
-  it("displays placeholder for COLOR_COLUMN field", () => {
+  it("displays an empty option for COLOR_COLUMN", () => {
     const propsWithColorColumn = {
       ...baseProps,
       keys: [...baseProps.keys, "COLOR_COLUMN"],
@@ -752,10 +753,10 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const colorColumnInput = wrapper.find(
-      'input[id="test_table-COLOR_COLUMN"]',
+    const colorColumnSelect = wrapper.find(
+      'select[id="test_table-COLOR_COLUMN"]',
     );
-    expect(colorColumnInput.attributes("placeholder")).toBe("color");
+    expect(colorColumnSelect.find('option[value=""]').exists()).toBe(true);
   });
 
   it("renders ICON_COLUMN field when included in keys", () => {
@@ -769,14 +770,17 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const iconColumnInput = wrapper.find('input[id="test_table-ICON_COLUMN"]');
-    expect(iconColumnInput.exists()).toBe(true);
+    const iconColumnSelect = wrapper.find(
+      'select[id="test_table-ICON_COLUMN"]',
+    );
+    expect(iconColumnSelect.exists()).toBe(true);
   });
 
   it("updates ICON_COLUMN value when input changes", async () => {
     const propsWithIconColumn = {
       ...baseProps,
       keys: [...baseProps.keys, "ICON_COLUMN"],
+      columns: [{ original_column: "icon", sql_column: "icon" }],
     };
 
     const wrapper = mount(ConfigMap, {
@@ -784,15 +788,17 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const iconColumnInput = wrapper.find('input[id="test_table-ICON_COLUMN"]');
-    await iconColumnInput.setValue("icon");
+    const iconColumnSelect = wrapper.find(
+      'select[id="test_table-ICON_COLUMN"]',
+    );
+    await iconColumnSelect.setValue("icon");
 
     expect(wrapper.emitted("updateConfig")).toBeTruthy();
     const emitted = wrapper.emitted("updateConfig");
     expect(emitted?.[0]?.[0]).toEqual({ ICON_COLUMN: "icon" });
   });
 
-  it("displays placeholder for ICON_COLUMN field", () => {
+  it("displays an empty option for ICON_COLUMN", () => {
     const propsWithIconColumn = {
       ...baseProps,
       keys: [...baseProps.keys, "ICON_COLUMN"],
@@ -803,8 +809,10 @@ describe("ConfigMap component", () => {
       global: globalConfig,
     });
 
-    const iconColumnInput = wrapper.find('input[id="test_table-ICON_COLUMN"]');
-    expect(iconColumnInput.attributes("placeholder")).toBe("icon");
+    const iconColumnSelect = wrapper.find(
+      'select[id="test_table-ICON_COLUMN"]',
+    );
+    expect(iconColumnSelect.find('option[value=""]').exists()).toBe(true);
   });
 
   it("labels basemap fields and uses purple field chrome", () => {


### PR DESCRIPTION
## Goal

Use dataset columns in Config dropdowns and the unwanted-column typeahead.

Part of #438.

> Stack: 4 of 4. This PR is based on `feat/438-column-controls`.


## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-08-19 at 14 33 46" src="https://github.com/user-attachments/assets/61ccd3ff-4d01-4571-9145-df5b3e1fc076" />
<img width="1470" height="956" alt="Screenshot 2026-08-19 at 14 32 57" src="https://github.com/user-attachments/assets/74d7a785-6478-4fd5-b359-b0be381dabd1" />

## What I changed and why

I replaced free-text column fields with dataset-backed selects and added valid suggestions to the unwanted-column field. Color, icon, timestamp, and media fields use primary columns. The Alerts filter uses the selected secondary dataset when it is available. Save remains disabled while metadata loads or while configured columns are invalid.


## How I convinced myself this is right

Checking out the UI myself


## What I'm not doing here

I am not combining primary and secondary options or redesigning unrelated Config sections.


## LLM use disclosure

Cursor GPT-5.6 Sol, with me driving.