### PR TITLE
Hide / show unused config fields by view type

### DIFF
--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -48,39 +48,51 @@ const props = withDefaults(
 const emit = defineEmits(["submitConfig", "removeTableFromConfig"]);
 
 // Set keys for the different sections of the config
-const mapConfigKeys = computed(() => [
-  "MAPBOX_STYLE",
-  "MAPBOX_ACCESS_TOKEN",
-  "MAPBOX_ZOOM",
-  "MAPBOX_CENTER_LATITUDE",
-  "MAPBOX_CENTER_LONGITUDE",
-  "MAPBOX_PROJECTION",
-  "MAPBOX_BEARING",
-  "MAPBOX_PITCH",
-  "MAPBOX_3D",
-  "MAPBOX_3D_TERRAIN_EXAGGERATION",
-  "MAP_LEGEND_LAYER_IDS",
-  "PLANET_API_KEY",
-  "COLOR_COLUMN",
-  "ICON_COLUMN",
-]);
-const mediaKeys = computed(() => [
-  "MEDIA_BASE_PATH",
-  "MEDIA_BASE_PATH_ALERTS",
-  "MEDIA_BASE_PATH_ICONS",
-  "MEDIA_COLUMN",
-]);
+const mapConfigKeys = computed(() => {
+  const keys = [
+    "MAPBOX_STYLE",
+    "MAPBOX_ACCESS_TOKEN",
+    "MAPBOX_ZOOM",
+    "MAPBOX_CENTER_LATITUDE",
+    "MAPBOX_CENTER_LONGITUDE",
+    "MAPBOX_PROJECTION",
+    "MAPBOX_BEARING",
+    "MAPBOX_PITCH",
+    "MAPBOX_3D",
+    "MAPBOX_3D_TERRAIN_EXAGGERATION",
+    "MAP_LEGEND_LAYER_IDS",
+    "PLANET_API_KEY",
+  ];
+  if (props.viewType === "map") {
+    keys.push("COLOR_COLUMN", "ICON_COLUMN");
+  }
+  return keys;
+});
+const mediaKeys = computed(() => {
+  const keys = ["MEDIA_BASE_PATH"];
+  if (props.viewType === "alerts") {
+    keys.push("MEDIA_BASE_PATH_ALERTS");
+  }
+  if (props.viewType === "map") {
+    keys.push("MEDIA_BASE_PATH_ICONS");
+  }
+  if (props.viewType === "map" || props.viewType === "gallery") {
+    keys.push("MEDIA_COLUMN");
+  }
+  return keys;
+});
 const filterKeys = computed(() =>
   props.viewType === "alerts"
     ? ["FRONT_END_FILTER_COLUMN", "SECONDARY_FILTER_VALUES"]
     : ["FRONT_END_FILTER_COLUMN", "TIMESTAMP_COLUMN", "UNWANTED_COLUMNS"],
 );
-const viewInfoKeys = computed(() => [
-  "DATASET_TABLE",
-  "VIEW_DESCRIPTION",
-  "VIEW_HEADER_IMAGE",
-  "LOGO_URL",
-]);
+const viewInfoKeys = computed(() => {
+  const keys = ["DATASET_TABLE", "VIEW_DESCRIPTION", "VIEW_HEADER_IMAGE"];
+  if (props.viewType !== "gallery") {
+    keys.push("LOGO_URL");
+  }
+  return keys;
+});
 
 // The child config components expect a `views` array; wrap the single view type
 const viewTypeList = computed(() => [props.viewType]);

--- a/components/config/ConfigMap.vue
+++ b/components/config/ConfigMap.vue
@@ -600,7 +600,7 @@ const fullWidthKeys = [
         </template>
 
         <!-- Color Column -->
-        <template v-else-if="key === 'COLOR_COLUMN'">
+        <template v-else-if="key === 'COLOR_COLUMN' && views.includes('map')">
           <ConfigColumnSelect
             :id="`${tableName}-${key}`"
             :model-value="getStringConfigValue(key)"
@@ -614,7 +614,7 @@ const fullWidthKeys = [
         </template>
 
         <!-- Icon Column -->
-        <template v-else-if="key === 'ICON_COLUMN'">
+        <template v-else-if="key === 'ICON_COLUMN' && views.includes('map')">
           <ConfigColumnSelect
             :id="`${tableName}-${key}`"
             :model-value="getStringConfigValue(key)"

--- a/components/config/ConfigMedia.vue
+++ b/components/config/ConfigMedia.vue
@@ -534,7 +534,13 @@ watch(
     </div>
 
     <!-- MEDIA_COLUMN -->
-    <div v-if="keys.includes('MEDIA_COLUMN')" class="space-y-2">
+    <div
+      v-if="
+        keys.includes('MEDIA_COLUMN') &&
+        (views.includes('map') || views.includes('gallery'))
+      "
+      class="space-y-2"
+    >
       <p class="text-xs text-gray-500 mb-2">
         {{ $t("mediaColumnDescription") }}
       </p>

--- a/components/config/ConfigViewInfo.vue
+++ b/components/config/ConfigViewInfo.vue
@@ -19,170 +19,172 @@ const emit = defineEmits(["updateConfig"]);
     class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-6"
     data-testid="config-field-grid"
   >
-    <div
-      v-for="key in keys"
-      :key="key"
-      class="space-y-2"
-      :class="{
-        'md:col-span-2': key === 'DATASET_TABLE' || key === 'VIEW_DESCRIPTION',
-      }"
-    >
-      <template v-if="key === 'LOGO_URL'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t(toCamelCase(key)) }}
-        </label>
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          placeholder="https://…"
-          type="url"
-          :value="config[key]"
-          @input="
-            (e) =>
-              emit('updateConfig', {
-                [key]: (e.target as HTMLInputElement).value,
-              })
-          "
-        />
-        <ConfigImagePreview
-          :src="config.LOGO_URL ?? ''"
-          :alt="$t(toCamelCase(key))"
-          fit="contain"
-        />
-      </template>
-      <template v-else-if="key === 'DATASET_TABLE'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t("viewDisplayName") }}
-        </label>
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          :placeholder="$t('viewDisplayNamePlaceholder')"
-          type="text"
-          :maxlength="CONFIG_LIMITS.DATASET_TABLE"
-          :value="config[key]"
-          @input="
-            (e) => {
-              const value = (e.target as HTMLInputElement).value;
-              const trimmedValue = value.substring(
-                0,
-                CONFIG_LIMITS.DATASET_TABLE,
-              );
-              (e.target as HTMLInputElement).value = trimmedValue;
-              emit('updateConfig', {
-                [key]: trimmedValue,
-              });
-            }
-          "
-          @paste="
-            (e) => {
-              e.preventDefault();
-              const clipboardData = e.clipboardData;
-              const pastedText = clipboardData
-                ? clipboardData.getData('text')
-                : '';
-              const trimmedValue = pastedText.substring(
-                0,
-                CONFIG_LIMITS.DATASET_TABLE,
-              );
-              (e.target as HTMLInputElement).value = trimmedValue;
-              emit('updateConfig', {
-                [key]: trimmedValue,
-              });
-            }
-          "
-        />
-        <p class="text-gray-500 text-sm">
-          {{ $t("viewDisplayNameDescription") }}
-        </p>
-      </template>
-      <template v-else-if="key === 'VIEW_HEADER_IMAGE'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t("viewHeaderImage") }}
-        </label>
-        <input
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
-          placeholder="https://…"
-          type="url"
-          :value="config[key]"
-          @input="
-            (e) =>
-              emit('updateConfig', {
-                [key]: (e.target as HTMLInputElement).value,
-              })
-          "
-        />
-        <p class="text-gray-500 text-sm">
-          {{
-            $t("viewHeaderImageDescription") ||
-            "Optional: URL for the header background image"
-          }}
-        </p>
-        <ConfigImagePreview
-          :src="config.VIEW_HEADER_IMAGE ?? ''"
-          :alt="$t('viewHeaderImage')"
-          fit="cover"
-        />
-      </template>
-      <template v-else-if="key === 'VIEW_DESCRIPTION'">
-        <label
-          :for="`${tableName}-${key}`"
-          class="block text-sm font-medium text-gray-700"
-        >
-          {{ $t("viewDescription") }}
-        </label>
-        <textarea
-          :id="`${tableName}-${key}`"
-          class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors resize-y"
-          rows="3"
-          :maxlength="CONFIG_LIMITS.VIEW_DESCRIPTION"
-          :placeholder="$t('viewDescriptionPlaceholder')"
-          :value="config[key]"
-          @input="
-            (e) => {
-              const value = (e.target as HTMLTextAreaElement).value;
-              const trimmedValue = value.substring(
-                0,
-                CONFIG_LIMITS.VIEW_DESCRIPTION,
-              );
-              (e.target as HTMLTextAreaElement).value = trimmedValue;
-              emit('updateConfig', {
-                [key]: trimmedValue,
-              });
-            }
-          "
-          @paste="
-            (e) => {
-              e.preventDefault();
-              const clipboardData = e.clipboardData;
-              const pastedText = clipboardData
-                ? clipboardData.getData('text')
-                : '';
-              const trimmedValue = pastedText.substring(
-                0,
-                CONFIG_LIMITS.VIEW_DESCRIPTION,
-              );
-              (e.target as HTMLTextAreaElement).value = trimmedValue;
-              emit('updateConfig', {
-                [key]: trimmedValue,
-              });
-            }
-          "
-        ></textarea>
-        <p class="text-gray-500 text-sm">
-          {{ $t("viewDescriptionDescription") }}
-        </p>
-      </template>
-    </div>
+    <template v-for="key in keys" :key="key">
+      <div
+        v-if="key !== 'LOGO_URL' || !views.includes('gallery')"
+        class="space-y-2"
+        :class="{
+          'md:col-span-2':
+            key === 'DATASET_TABLE' || key === 'VIEW_DESCRIPTION',
+        }"
+      >
+        <template v-if="key === 'LOGO_URL'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t(toCamelCase(key)) }}
+          </label>
+          <input
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            placeholder="https://…"
+            type="url"
+            :value="config[key]"
+            @input="
+              (e) =>
+                emit('updateConfig', {
+                  [key]: (e.target as HTMLInputElement).value,
+                })
+            "
+          />
+          <ConfigImagePreview
+            :src="config.LOGO_URL ?? ''"
+            :alt="$t(toCamelCase(key))"
+            fit="contain"
+          />
+        </template>
+        <template v-else-if="key === 'DATASET_TABLE'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t("viewDisplayName") }}
+          </label>
+          <input
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            :placeholder="$t('viewDisplayNamePlaceholder')"
+            type="text"
+            :maxlength="CONFIG_LIMITS.DATASET_TABLE"
+            :value="config[key]"
+            @input="
+              (e) => {
+                const value = (e.target as HTMLInputElement).value;
+                const trimmedValue = value.substring(
+                  0,
+                  CONFIG_LIMITS.DATASET_TABLE,
+                );
+                (e.target as HTMLInputElement).value = trimmedValue;
+                emit('updateConfig', {
+                  [key]: trimmedValue,
+                });
+              }
+            "
+            @paste="
+              (e) => {
+                e.preventDefault();
+                const clipboardData = e.clipboardData;
+                const pastedText = clipboardData
+                  ? clipboardData.getData('text')
+                  : '';
+                const trimmedValue = pastedText.substring(
+                  0,
+                  CONFIG_LIMITS.DATASET_TABLE,
+                );
+                (e.target as HTMLInputElement).value = trimmedValue;
+                emit('updateConfig', {
+                  [key]: trimmedValue,
+                });
+              }
+            "
+          />
+          <p class="text-gray-500 text-sm">
+            {{ $t("viewDisplayNameDescription") }}
+          </p>
+        </template>
+        <template v-else-if="key === 'VIEW_HEADER_IMAGE'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t("viewHeaderImage") }}
+          </label>
+          <input
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors"
+            placeholder="https://…"
+            type="url"
+            :value="config[key]"
+            @input="
+              (e) =>
+                emit('updateConfig', {
+                  [key]: (e.target as HTMLInputElement).value,
+                })
+            "
+          />
+          <p class="text-gray-500 text-sm">
+            {{
+              $t("viewHeaderImageDescription") ||
+              "Optional: URL for the header background image"
+            }}
+          </p>
+          <ConfigImagePreview
+            :src="config.VIEW_HEADER_IMAGE ?? ''"
+            :alt="$t('viewHeaderImage')"
+            fit="cover"
+          />
+        </template>
+        <template v-else-if="key === 'VIEW_DESCRIPTION'">
+          <label
+            :for="`${tableName}-${key}`"
+            class="block text-sm font-medium text-gray-700"
+          >
+            {{ $t("viewDescription") }}
+          </label>
+          <textarea
+            :id="`${tableName}-${key}`"
+            class="w-full px-4 py-2 bg-violet-100 border border-violet-200 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500 transition-colors resize-y"
+            rows="3"
+            :maxlength="CONFIG_LIMITS.VIEW_DESCRIPTION"
+            :placeholder="$t('viewDescriptionPlaceholder')"
+            :value="config[key]"
+            @input="
+              (e) => {
+                const value = (e.target as HTMLTextAreaElement).value;
+                const trimmedValue = value.substring(
+                  0,
+                  CONFIG_LIMITS.VIEW_DESCRIPTION,
+                );
+                (e.target as HTMLTextAreaElement).value = trimmedValue;
+                emit('updateConfig', {
+                  [key]: trimmedValue,
+                });
+              }
+            "
+            @paste="
+              (e) => {
+                e.preventDefault();
+                const clipboardData = e.clipboardData;
+                const pastedText = clipboardData
+                  ? clipboardData.getData('text')
+                  : '';
+                const trimmedValue = pastedText.substring(
+                  0,
+                  CONFIG_LIMITS.VIEW_DESCRIPTION,
+                );
+                (e.target as HTMLTextAreaElement).value = trimmedValue;
+                emit('updateConfig', {
+                  [key]: trimmedValue,
+                });
+              }
+            "
+          ></textarea>
+          <p class="text-gray-500 text-sm">
+            {{ $t("viewDescriptionDescription") }}
+          </p>
+        </template>
+      </div>
+    </template>
   </div>
 </template>

--- a/tests/unit/components/ConfigCard.fieldVisibility.test.ts
+++ b/tests/unit/components/ConfigCard.fieldVisibility.test.ts
@@ -48,8 +48,10 @@ const mountConfigCard = (viewType: ViewType) =>
   });
 
 const keysFrom = (wrapper: ReturnType<typeof mount>, testId: string) =>
-  wrapper.get(`[data-testid='${testId}']`).attributes("data-keys")?.split(",") ??
-  [];
+  wrapper
+    .get(`[data-testid='${testId}']`)
+    .attributes("data-keys")
+    ?.split(",") ?? [];
 
 describe("ConfigCard field visibility by view type", () => {
   it("shows logo, map color/icon, icon media path, and unwanted columns for map", () => {

--- a/tests/unit/components/ConfigCard.fieldVisibility.test.ts
+++ b/tests/unit/components/ConfigCard.fieldVisibility.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { computed, nextTick, ref, watch } from "vue";
+
+import ConfigCard from "@/components/config/ConfigCard.vue";
+import type { ViewConfig, ViewType } from "@/types";
+
+Object.assign(globalThis, {
+  computed,
+  nextTick,
+  ref,
+  watch,
+});
+
+const keysStub = (testId: string) => ({
+  props: ["keys"],
+  template: `<div data-testid="${testId}" :data-keys="keys.join(',')" />`,
+});
+
+const mountConfigCard = (viewType: ViewType) =>
+  mount(ConfigCard, {
+    props: {
+      tableName: "primary_dataset",
+      viewType,
+      viewConfig: {
+        MAPBOX_ACCESS_TOKEN: "pk.ey.test-token",
+        ROUTE_LEVEL_PERMISSION: "member",
+      } as ViewConfig,
+    },
+    global: {
+      stubs: {
+        ConfigCollapsibleSection: {
+          template: "<div><slot /></div>",
+        },
+        ConfigViewInfo: keysStub("config-view-info"),
+        ConfigMap: keysStub("config-map"),
+        ConfigMedia: keysStub("config-media"),
+        ConfigFilters: keysStub("config-filters"),
+        ConfigPermissions: {
+          template: "<div />",
+          emits: ["updateConfig", "updateValidation"],
+        },
+      },
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+
+const keysFrom = (wrapper: ReturnType<typeof mount>, testId: string) =>
+  wrapper.get(`[data-testid='${testId}']`).attributes("data-keys")?.split(",") ??
+  [];
+
+describe("ConfigCard field visibility by view type", () => {
+  it("shows logo, map color/icon, icon media path, and unwanted columns for map", () => {
+    const wrapper = mountConfigCard("map");
+
+    expect(keysFrom(wrapper, "config-view-info")).toEqual([
+      "DATASET_TABLE",
+      "VIEW_DESCRIPTION",
+      "VIEW_HEADER_IMAGE",
+      "LOGO_URL",
+    ]);
+    expect(keysFrom(wrapper, "config-map")).toEqual(
+      expect.arrayContaining(["COLOR_COLUMN", "ICON_COLUMN", "PLANET_API_KEY"]),
+    );
+    expect(keysFrom(wrapper, "config-media")).toEqual([
+      "MEDIA_BASE_PATH",
+      "MEDIA_BASE_PATH_ICONS",
+      "MEDIA_COLUMN",
+    ]);
+    expect(keysFrom(wrapper, "config-filters")).toEqual([
+      "FRONT_END_FILTER_COLUMN",
+      "TIMESTAMP_COLUMN",
+      "UNWANTED_COLUMNS",
+    ]);
+  });
+
+  it("shows logo, alerts media path, and secondary filter values for alerts", () => {
+    const wrapper = mountConfigCard("alerts");
+
+    expect(keysFrom(wrapper, "config-view-info")).toContain("LOGO_URL");
+    expect(keysFrom(wrapper, "config-map")).not.toContain("COLOR_COLUMN");
+    expect(keysFrom(wrapper, "config-map")).not.toContain("ICON_COLUMN");
+    expect(keysFrom(wrapper, "config-media")).toEqual([
+      "MEDIA_BASE_PATH",
+      "MEDIA_BASE_PATH_ALERTS",
+    ]);
+    expect(keysFrom(wrapper, "config-filters")).toEqual([
+      "FRONT_END_FILTER_COLUMN",
+      "SECONDARY_FILTER_VALUES",
+    ]);
+  });
+
+  it("hides logo, map section fields, and map-only media for gallery", () => {
+    const wrapper = mountConfigCard("gallery");
+
+    expect(keysFrom(wrapper, "config-view-info")).toEqual([
+      "DATASET_TABLE",
+      "VIEW_DESCRIPTION",
+      "VIEW_HEADER_IMAGE",
+    ]);
+    expect(wrapper.find("[data-testid='config-map']").exists()).toBe(false);
+    expect(keysFrom(wrapper, "config-media")).toEqual([
+      "MEDIA_BASE_PATH",
+      "MEDIA_COLUMN",
+    ]);
+    expect(keysFrom(wrapper, "config-filters")).toEqual([
+      "FRONT_END_FILTER_COLUMN",
+      "TIMESTAMP_COLUMN",
+      "UNWANTED_COLUMNS",
+    ]);
+  });
+});

--- a/tests/unit/components/ConfigMap.test.ts
+++ b/tests/unit/components/ConfigMap.test.ts
@@ -703,6 +703,24 @@ describe("ConfigMap component", () => {
     expect(vm.basemaps[1].isDefault).toBe(false);
   });
 
+  it("does not render COLOR_COLUMN or ICON_COLUMN for alerts even when keys include them", () => {
+    const wrapper = mount(ConfigMap, {
+      props: {
+        ...baseProps,
+        views: ["alerts"],
+        keys: [...baseProps.keys, "COLOR_COLUMN", "ICON_COLUMN"],
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find('select[id="test_table-COLOR_COLUMN"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('select[id="test_table-ICON_COLUMN"]').exists()).toBe(
+      false,
+    );
+  });
+
   it("renders COLOR_COLUMN field when included in keys", () => {
     const propsWithColorColumn = {
       ...baseProps,

--- a/tests/unit/components/ConfigMedia.test.ts
+++ b/tests/unit/components/ConfigMedia.test.ts
@@ -752,6 +752,19 @@ describe("ConfigMedia component", () => {
     expect(input.element.value).toBe("keep-me");
   });
 
+  it("does not render MEDIA_COLUMN when the view is alerts", () => {
+    const wrapper = mount(ConfigMedia, {
+      props: {
+        ...baseProps,
+        views: ["alerts"],
+        keys: ["MEDIA_COLUMN"],
+      },
+      global: globalConfig,
+    });
+
+    expect(wrapper.find("#test_table-media-column").exists()).toBe(false);
+  });
+
   it("associates the media column label with its input", () => {
     const wrapper = mount(ConfigMedia, {
       props: {

--- a/tests/unit/components/ConfigViewInfo.test.ts
+++ b/tests/unit/components/ConfigViewInfo.test.ts
@@ -11,7 +11,7 @@ const viewKeys = [
   "LOGO_URL",
 ];
 
-const mountViewInfo = () =>
+const mountViewInfo = (views: string[] = ["alerts"]) =>
   mount(ConfigViewInfo, {
     props: {
       tableName: "test_table",
@@ -21,7 +21,7 @@ const mountViewInfo = () =>
         VIEW_HEADER_IMAGE: "https://example.test/header.jpg",
         LOGO_URL: "https://example.test/logo.png",
       } as ViewConfig,
-      views: ["map"],
+      views,
       keys: viewKeys,
     },
     global: {
@@ -94,5 +94,24 @@ describe("ConfigViewInfo", () => {
     expect(wrapper.emitted("updateConfig")?.[0]?.[0]).toEqual({
       DATASET_TABLE: "Updated View",
     });
+  });
+
+  it.each(["alerts", "map"])("renders LOGO_URL when the view is %s", (view) => {
+    const wrapper = mountViewInfo([view]);
+
+    expect(wrapper.find("#test_table-LOGO_URL").exists()).toBe(true);
+  });
+
+  it("does not render LOGO_URL when the view is gallery", () => {
+    const wrapper = mountViewInfo(["gallery"]);
+
+    expect(wrapper.find("#test_table-LOGO_URL").exists()).toBe(false);
+    expect(
+      wrapper.findAll("input, textarea").map((field) => field.attributes("id")),
+    ).toEqual([
+      "test_table-DATASET_TABLE",
+      "test_table-VIEW_DESCRIPTION",
+      "test_table-VIEW_HEADER_IMAGE",
+    ]);
   });
 });


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/gc-explorer/issues/605

**Hide unused config fields by view type**

## What I changed and why

Config was showing several fields on views that never use them. That made the form longer than it needed to be and implied settings that do nothing for that view.

`ConfigCard` now only passes keys that belong to the current view, and the child forms still guard those fields:

- `LOGO_URL` is hidden on Gallery (Map and Alerts still show it)
- `COLOR_COLUMN` and `ICON_COLUMN` are Map-only
- `MEDIA_COLUMN` is Map and Gallery only
- `MEDIA_BASE_PATH_ALERTS` stays Alerts-only; `MEDIA_BASE_PATH_ICONS` stays Map-only (already gated in `ConfigMedia`, now also omitted from other views’ keys)

`UNWANTED_COLUMNS` is unchanged: still Map and Gallery, not Alerts.

| Field | Alerts | Map | Gallery |
|---|---|---|---|
| `LOGO_URL` | still shown | still shown | **hidden** (was shown) |
| `COLOR_COLUMN` | **hidden** (was shown) | still shown | still hidden (no Map section) |
| `ICON_COLUMN` | **hidden** (was shown) | still shown | still hidden (no Map section) |
| `MEDIA_COLUMN` | **hidden** (was shown) | still shown | still shown |

## How I convinced myself this is right

Checked each field against what Map, Alerts, and Gallery actually read from the API and render. Then covered the new key lists and child guards with unit tests:

`UNWANTED_COLUMNS`, because I think we should rip it out. (PR forthcoming)

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

I had Cursor Grok 4.5 do an audit after I did LOGO_URL manually. Then Cursor Grok 4.5 did the rest.