### PR TITLE
Fix z-index for autocomplete fields in config

### DIFF
--- a/assets/config-form.css
+++ b/assets/config-form.css
@@ -4,6 +4,7 @@
   width: 100%;
   max-width: none;
   position: relative;
+  overflow: visible;
   background-color: #ede9fe;
   border: 1px solid #ddd6fe;
   border-radius: 0.5rem;
@@ -80,4 +81,8 @@
 
 .tag-field.vue-tags-input .ti-new-tag-input:focus {
   outline: none;
+}
+
+.tag-field.vue-tags-input .ti-autocomplete {
+  z-index: 30;
 }

--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -270,10 +270,8 @@ const handleSubmit = () => {
 </script>
 
 <template>
-  <div
-    class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden"
-  >
-    <div class="border-b border-slate-200 bg-slate-50 px-6 py-4">
+  <div class="bg-white rounded-lg shadow-sm border border-gray-200">
+    <div class="rounded-t-lg border-b border-slate-200 bg-slate-50 px-6 py-4">
       <h2 class="text-balance text-xl font-bold text-slate-800">
         {{ $t("configurationOptions") }}
       </h2>

--- a/components/config/ConfigCollapsibleSection.vue
+++ b/components/config/ConfigCollapsibleSection.vue
@@ -20,12 +20,13 @@ const toggle = () => {
 <template>
   <div
     data-testid="config-section-collapsible"
-    class="mb-4 last:mb-0 overflow-hidden rounded-3xl bg-slate-50 shadow-[0px_0px_0px_1px_rgba(0,0,0,0.06),0px_1px_2px_-1px_rgba(0,0,0,0.06),0px_2px_4px_0px_rgba(0,0,0,0.04)]"
+    class="relative mb-4 last:mb-0 rounded-3xl bg-slate-50 shadow-[0px_0px_0px_1px_rgba(0,0,0,0.06),0px_1px_2px_-1px_rgba(0,0,0,0.06),0px_2px_4px_0px_rgba(0,0,0,0.04)] focus-within:z-20"
   >
     <button
       type="button"
       :data-testid="`config-section-${title.toLowerCase()}-toggle`"
       class="flex min-h-10 w-full items-center justify-between bg-slate-100 py-4 pl-4 pr-3.5 text-left transition-[background-color] duration-150 ease-out hover:bg-slate-200/80"
+      :class="isOpen ? 'rounded-t-3xl' : 'rounded-3xl'"
       @click="toggle"
     >
       <h3 class="text-balance text-lg font-semibold text-slate-800">


### PR DESCRIPTION
## Goal

Closes #609.

## Screenshots

Before:

<img width="1475" height="597" alt="image" src="https://github.com/user-attachments/assets/ce46a070-ea5f-488a-be7c-6f1faa850f60" />

After:

<img width="1475" height="597" alt="image" src="https://github.com/user-attachments/assets/3ce2cada-43a3-4d6e-b24b-82927ace7dc7" />

## What I changed and why

- The Unwanted columns typeahead was clipped by `overflow-hidden` on the collapsible section (and the config card), so I dropped those overflow clips.
- The next section still painted over the list, so I also raised `stacking: focus-within:z-20` on the open section, and `z-index: 30` on `.ti-autocomplete`.

## How I convinced myself this is right

Trying it in runtime -- see screenshots.

## What I'm not doing here

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Grok 4.5