### PR TITLE
Omit `ViewInfo` fields from copy composable

### DIFF
--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -6,6 +6,7 @@ import {
   type ViewConfig,
   type ViewType,
 } from "@/types";
+import { VIEW_INFO_CONFIG_KEYS } from "@/composables/useCopyConfig";
 import { CONFIG_LIMITS } from "@/utils";
 import { validateViewConfigColumns } from "@/utils/viewConfigColumns";
 import ConfigPermissions from "./ConfigPermissions.vue";
@@ -75,12 +76,7 @@ const filterKeys = computed(() =>
     ? ["FRONT_END_FILTER_COLUMN", "SECONDARY_FILTER_VALUES"]
     : ["FRONT_END_FILTER_COLUMN", "TIMESTAMP_COLUMN", "UNWANTED_COLUMNS"],
 );
-const viewInfoKeys = computed(() => [
-  "DATASET_TABLE",
-  "VIEW_DESCRIPTION",
-  "VIEW_HEADER_IMAGE",
-  "LOGO_URL",
-]);
+const viewInfoKeys: string[] = [...VIEW_INFO_CONFIG_KEYS];
 
 // The child config components expect a `views` array; wrap the single view type
 const viewTypeList = computed(() => [props.viewType]);
@@ -137,12 +133,19 @@ watch(
   { deep: true },
 );
 
-// Apply copied config from another dataset without resetting the saved baseline
+// Apply copied config from another dataset without resetting the saved baseline.
+// View identity fields are omitted from the copy; keep this view's values.
 watch(
   () => props.configToCopy,
   (copiedConfig) => {
     if (copiedConfig) {
-      replaceConfig(localConfig.value, copiedConfig);
+      const preserved = Object.fromEntries(
+        VIEW_INFO_CONFIG_KEYS.flatMap((key) => {
+          const value = localConfig.value[key];
+          return value === undefined ? [] : [[key, value]];
+        }),
+      );
+      replaceConfig(localConfig.value, { ...copiedConfig, ...preserved });
     }
   },
 );

--- a/composables/useCopyConfig.ts
+++ b/composables/useCopyConfig.ts
@@ -2,11 +2,34 @@ import type { ViewConfig, ViewConfigRow, ViewType } from "@/types";
 import type { MaybeRefOrGetter } from "vue";
 import { toValue } from "vue";
 
+/** Identity fields from ConfigViewInfo; never copied between views. */
+export const VIEW_INFO_CONFIG_KEYS = [
+  "DATASET_TABLE",
+  "VIEW_DESCRIPTION",
+  "VIEW_HEADER_IMAGE",
+  "LOGO_URL",
+] as const satisfies ReadonlyArray<keyof ViewConfig>;
+
 export type CopyConfigSource = {
   key: string;
   label: string;
   viewConfig: ViewConfig;
   secondaryDataset?: string | null;
+};
+
+/**
+ * Deep-clones a view config without ConfigViewInfo identity fields.
+ *
+ * @param {ViewConfig} config - Source view configuration.
+ * @returns {ViewConfig} Cloned config with view identity keys removed.
+ */
+export const omitViewInfoFields = (config: ViewConfig): ViewConfig => {
+  const cloned: ViewConfig = JSON.parse(JSON.stringify(config));
+  return Object.fromEntries(
+    Object.entries(cloned).filter(
+      ([key]) => !(VIEW_INFO_CONFIG_KEYS as readonly string[]).includes(key),
+    ),
+  ) as ViewConfig;
 };
 
 /**
@@ -51,18 +74,14 @@ export const useCopyConfig = (
     const primary = toValue(currentDataset);
 
     return viewRows.value
-      .filter(
-        (row) =>
-          row.viewType === type &&
-          row.primaryDataset !== primary &&
-          Object.keys(row.viewConfig).length > 0,
-      )
+      .filter((row) => row.viewType === type && row.primaryDataset !== primary)
       .map((row) => ({
         key: copySourceKey(row.primaryDataset, row.viewType),
         label: row.viewName || row.primaryDataset,
-        viewConfig: row.viewConfig,
+        viewConfig: omitViewInfoFields(row.viewConfig),
         secondaryDataset: row.secondaryDataset ?? null,
       }))
+      .filter((source) => Object.keys(source.viewConfig).length > 0)
       .sort((first, second) => first.label.localeCompare(second.label));
   });
 
@@ -77,7 +96,7 @@ export const useCopyConfig = (
       (candidate) => candidate.key === selectedCopySource.value,
     );
     if (source) {
-      configToCopy.value = JSON.parse(JSON.stringify(source.viewConfig));
+      configToCopy.value = omitViewInfoFields(source.viewConfig);
       secondaryDatasetToCopy.value = source.secondaryDataset ?? null;
     }
     showCopyModal.value = false;

--- a/tests/unit/components/ConfigCard.mapInit.test.ts
+++ b/tests/unit/components/ConfigCard.mapInit.test.ts
@@ -130,4 +130,28 @@ describe("ConfigCard map initialization", () => {
     expect(latitudeInput.element.value).toBe("-9.24");
     expect(longitudeInput.element.value).toBe("160.98377");
   });
+
+  it("preserves view identity fields when applying a copied config", async () => {
+    const wrapper = mountConfigCard();
+    const cardVm = wrapper.vm as unknown as { localConfig: ViewConfig };
+    cardVm.localConfig.DATASET_TABLE = "My Map";
+    cardVm.localConfig.VIEW_DESCRIPTION = "Mine";
+    cardVm.localConfig.VIEW_HEADER_IMAGE = "https://example.test/header.jpg";
+    cardVm.localConfig.LOGO_URL = "https://example.test/logo.png";
+    await nextTick();
+
+    await wrapper.setProps({
+      configToCopy: { MAPBOX_ZOOM: 3, MAPBOX_PROJECTION: "globe" },
+    });
+    await nextTick();
+
+    expect(cardVm.localConfig.DATASET_TABLE).toBe("My Map");
+    expect(cardVm.localConfig.VIEW_DESCRIPTION).toBe("Mine");
+    expect(cardVm.localConfig.VIEW_HEADER_IMAGE).toBe(
+      "https://example.test/header.jpg",
+    );
+    expect(cardVm.localConfig.LOGO_URL).toBe("https://example.test/logo.png");
+    expect(cardVm.localConfig.MAPBOX_ZOOM).toBe(3);
+    expect(cardVm.localConfig.MAPBOX_PROJECTION).toBe("globe");
+  });
 });

--- a/tests/unit/composables/useCopyConfig.test.ts
+++ b/tests/unit/composables/useCopyConfig.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { ref, computed } from "vue";
 import type { ViewConfig, ViewConfigRow, ViewType } from "@/types";
-import { copySourceKey, useCopyConfig } from "@/composables/useCopyConfig";
+import {
+  copySourceKey,
+  useCopyConfig,
+  VIEW_INFO_CONFIG_KEYS,
+} from "@/composables/useCopyConfig";
 
 Object.assign(globalThis, { ref, computed });
 
@@ -100,11 +104,12 @@ describe("useCopyConfig", () => {
     selectedCopySource.value = otherCopySources.value[0].key;
     handleConfirmCopy();
 
-    expect(configToCopy.value).toEqual(galleryConfigB);
+    expect(configToCopy.value).toEqual({ EMBED_MEDIA: "NO" });
+    expect(configToCopy.value).not.toHaveProperty("DATASET_TABLE");
     expect(configToCopy.value).not.toEqual(mapConfigB);
   });
 
-  it("excludes the current view and empty configs", () => {
+  it("excludes the current view, empty configs, and view-info-only configs", () => {
     viewRows.value.push(
       makeRow({
         viewId: 5,
@@ -112,6 +117,18 @@ describe("useCopyConfig", () => {
         viewType: "map",
         viewName: "Empty",
         viewConfig: {},
+      }),
+      makeRow({
+        viewId: 6,
+        primaryDataset: "identity_only",
+        viewType: "map",
+        viewName: "Identity Only",
+        viewConfig: {
+          DATASET_TABLE: "Named",
+          VIEW_DESCRIPTION: "Desc",
+          VIEW_HEADER_IMAGE: "https://example.test/header.jpg",
+          LOGO_URL: "https://example.test/logo.png",
+        },
       }),
     );
 
@@ -122,12 +139,28 @@ describe("useCopyConfig", () => {
       currentViewType,
     );
 
-    expect(otherCopySources.value.map((source) => source.key)).not.toContain(
-      copySourceKey("dataset_a", "map"),
-    );
-    expect(otherCopySources.value.map((source) => source.key)).not.toContain(
-      copySourceKey("empty_map", "map"),
-    );
+    const sourceKeys = otherCopySources.value.map((source) => source.key);
+    expect(sourceKeys).not.toContain(copySourceKey("dataset_a", "map"));
+    expect(sourceKeys).not.toContain(copySourceKey("empty_map", "map"));
+    expect(sourceKeys).not.toContain(copySourceKey("identity_only", "map"));
+  });
+
+  it("omits all ConfigViewInfo fields from the copied config", () => {
+    const currentViewType = ref<ViewType | undefined>("map");
+    const {
+      otherCopySources,
+      selectedCopySource,
+      handleConfirmCopy,
+      configToCopy,
+    } = useCopyConfig(viewRows, "dataset_a", currentViewType);
+
+    selectedCopySource.value = otherCopySources.value[0].key;
+    handleConfirmCopy();
+
+    expect(configToCopy.value).toEqual({ MAPBOX_ZOOM: 5 });
+    for (const key of VIEW_INFO_CONFIG_KEYS) {
+      expect(configToCopy.value).not.toHaveProperty(key);
+    }
   });
 
   it("returns no sources when the current view type is unset", () => {


### PR DESCRIPTION
## Goal

Closes #612.

## What I changed and why

- `useCopyConfig` now strips every ConfigViewInfo field (`DATASET_TABLE`, `VIEW_DESCRIPTION`, `VIEW_HEADER_IMAGE`, `LOGO_URL`) from a copied config. 
- `ConfigCard` keeps the destination’s current identity values when applying a copy, so an existing view does not lose its name, description, or images when you paste another view’s settings.

## How I convinced myself this is right

- Trying in runtime
- Tests

## What I'm not doing here

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Grok 4.5