### PR TITLE
Add 'Explorer' to brand

### DIFF
--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -22,53 +22,55 @@ const toggleMobileMenu = () => {
   >
     <!-- Desktop Layout - show above 1000px -->
     <div
-      class="flex max-[1000px]:hidden relative items-end justify-between gap-4"
+      class="flex max-[1000px]:hidden items-end justify-between gap-4"
     >
-      <HeaderBrand />
+      <div class="relative">
+        <HeaderBrand />
 
-      <!-- Tab with Community Name -->
-      <div
-        class="tab-container flex absolute left-[34%] min-[1109px]:left-[32%] min-[1230px]:left-[28%] -bottom-3 z-10 flex-col items-center"
-      >
-        <NuxtLink to="/" class="tab-trigger active">
-          <svg
-            class="left-curve"
-            xmlns="http://www.w3.org/2000/svg"
-            xml:space="preserve"
-            style="
-              fill-rule: evenodd;
-              clip-rule: evenodd;
-              stroke-linejoin: round;
-              stroke-miterlimit: 2;
-            "
-            viewBox="0 0 608 647"
-          >
-            <path
-              d="M1347.436 2760H740v-646.902s200.986 16.142 313.006 311.678c104.814 276.525 231.346 327.558 294.43 335.224Z"
-              style="fill: currentColor"
-              transform="translate(-740 -2113.0982)"
-            />
-          </svg>
-          <span class="text-lg font-bold">{{ communityName }}</span>
-          <svg
-            class="right-curve"
-            xmlns="http://www.w3.org/2000/svg"
-            xml:space="preserve"
-            style="
-              fill-rule: evenodd;
-              clip-rule: evenodd;
-              stroke-linejoin: round;
-              stroke-miterlimit: 2;
-            "
-            viewBox="0 0 608 647"
-          >
-            <path
-              d="M1347.436 2760H740v-646.902s200.986 16.142 313.006 311.678c104.814 276.525 231.346 327.558 294.43 335.224Z"
-              style="fill: currentColor"
-              transform="translate(-740 -2113.0982)"
-            />
-          </svg>
-        </NuxtLink>
+        <!-- Tab with Community Name -->
+        <div
+          class="tab-container flex absolute left-full -bottom-3 z-10 flex-col items-center"
+        >
+          <NuxtLink to="/" class="tab-trigger active">
+            <svg
+              class="left-curve"
+              xmlns="http://www.w3.org/2000/svg"
+              xml:space="preserve"
+              style="
+                fill-rule: evenodd;
+                clip-rule: evenodd;
+                stroke-linejoin: round;
+                stroke-miterlimit: 2;
+              "
+              viewBox="0 0 608 647"
+            >
+              <path
+                d="M1347.436 2760H740v-646.902s200.986 16.142 313.006 311.678c104.814 276.525 231.346 327.558 294.43 335.224Z"
+                style="fill: currentColor"
+                transform="translate(-740 -2113.0982)"
+              />
+            </svg>
+            <span class="text-lg font-bold">{{ communityName }}</span>
+            <svg
+              class="right-curve"
+              xmlns="http://www.w3.org/2000/svg"
+              xml:space="preserve"
+              style="
+                fill-rule: evenodd;
+                clip-rule: evenodd;
+                stroke-linejoin: round;
+                stroke-miterlimit: 2;
+              "
+              viewBox="0 0 608 647"
+            >
+              <path
+                d="M1347.436 2760H740v-646.902s200.986 16.142 313.006 311.678c104.814 276.525 231.346 327.558 294.43 335.224Z"
+                style="fill: currentColor"
+                transform="translate(-740 -2113.0982)"
+              />
+            </svg>
+          </NuxtLink>
+        </div>
       </div>
 
       <!-- Right: Action buttons -->

--- a/components/shared/AppHeader.vue
+++ b/components/shared/AppHeader.vue
@@ -21,9 +21,7 @@ const toggleMobileMenu = () => {
     class="bg-gradient-to-r mb-2 from-violet-100 to-violet-50 w-5/6 place-self-center mt-2 rounded-xl p-3"
   >
     <!-- Desktop Layout - show above 1000px -->
-    <div
-      class="flex max-[1000px]:hidden items-end justify-between gap-4"
-    >
+    <div class="flex max-[1000px]:hidden items-end justify-between gap-4">
       <div class="relative">
         <HeaderBrand />
 

--- a/components/shared/HeaderBrand.vue
+++ b/components/shared/HeaderBrand.vue
@@ -16,7 +16,7 @@ const logoSrc = withBase("/gcexplorer.png", useRuntimeConfig().app.baseURL);
     />
     <div class="min-w-0 rounded-lg py-2 pl-0 pr-1 min-[1001px]:pr-2">
       <h1 class="m-0 text-lg font-bold leading-tight whitespace-nowrap">
-        Guardian Connector
+        Guardian Connector Explorer
       </h1>
     </div>
   </NuxtLink>


### PR DESCRIPTION
## Goal

Small thing -- adds "Explorer" to the brand, and move the tab more to the right to create space for it.

## Screenshots

<img width="847" height="138" alt="image" src="https://github.com/user-attachments/assets/76a18a4f-7d41-42b8-865b-f9d61a4056b3" />

## What I changed and why

`relative` has to live on the element the tab is positioned against. It used to be on the whole header row, so absolute left was a percent of the bar. Putting it on a wrapper around `HeaderBrand` makes `left-full` mean “just after the title,” which is what we needed.

## How I convinced myself this is right

We explicitly call this tool "Explorer" on the landing page.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->
