### PR TITLE
Adjust `GalleryDetailMetadata` height and carousel prev/next button location

### DIFF
--- a/components/gallery/GalleryDetailPanel.vue
+++ b/components/gallery/GalleryDetailPanel.vue
@@ -73,10 +73,10 @@ onBeforeUnmount(() => {
       </header>
 
       <div
-        class="flex flex-col gap-4 p-4 sm:gap-6 sm:p-6 lg:flex-row lg:items-stretch"
+        class="flex flex-col gap-4 p-4 sm:gap-6 sm:p-6 lg:grid lg:grid-cols-[minmax(0,1fr)_380px] lg:items-stretch"
       >
         <div
-          class="min-h-[240px] flex-1 min-w-0 overflow-hidden rounded-2xl bg-gray-50 sm:min-h-[320px] lg:min-h-[min(70vh,640px)]"
+          class="min-h-[240px] min-w-0 overflow-hidden rounded-2xl bg-gray-50 sm:min-h-[320px] lg:min-h-[min(70vh,640px)]"
           data-testid="gallery-detail-media"
         >
           <GalleryMediaCarousel
@@ -99,18 +99,20 @@ onBeforeUnmount(() => {
         </div>
 
         <div
-          class="w-full min-h-0 overflow-y-auto rounded-2xl bg-violet-50 p-4 sm:p-6 lg:w-[380px] lg:flex-shrink-0 lg:max-h-[min(70vh,640px)]"
+          class="w-full overflow-hidden rounded-2xl bg-violet-50 lg:relative lg:min-h-[min(70vh,640px)]"
           data-testid="gallery-detail-metadata"
         >
-          <GalleryDetailMetadata
-            :allowed-file-extensions="allowedFileExtensions"
-            :centroid="centroid"
-            :feature="feature"
-            :file-paths="filePaths"
-            :mapbox-access-token="mapboxAccessToken"
-            :mapbox-style="mapboxStyle"
-            :media-base-path="mediaBasePath"
-          />
+          <div class="p-4 sm:p-6 lg:absolute lg:inset-0 lg:overflow-y-auto">
+            <GalleryDetailMetadata
+              :allowed-file-extensions="allowedFileExtensions"
+              :centroid="centroid"
+              :feature="feature"
+              :file-paths="filePaths"
+              :mapbox-access-token="mapboxAccessToken"
+              :mapbox-style="mapboxStyle"
+              :media-base-path="mediaBasePath"
+            />
+          </div>
         </div>
       </div>
     </section>

--- a/components/gallery/GalleryDetailPanel.vue
+++ b/components/gallery/GalleryDetailPanel.vue
@@ -87,6 +87,7 @@ onBeforeUnmount(() => {
             :media-base-path="mediaBasePath"
             variant="gallery"
             :enable-image-modal="true"
+            pin-nav-buttons
           />
           <div
             v-else

--- a/components/gallery/GalleryMediaCarousel.vue
+++ b/components/gallery/GalleryMediaCarousel.vue
@@ -10,7 +10,15 @@ const props = defineProps<{
   mediaBasePath: string;
   variant?: "gallery" | "default";
   enableImageModal?: boolean;
+  /** Pin prev/next to the media min-height center instead of 50% of each slide. */
+  pinNavButtons?: boolean;
 }>();
+
+const navButtonPositionClass = computed(() =>
+  props.pinNavButtons
+    ? "top-[7.5rem] sm:top-40 lg:top-[min(35vh,20rem)]"
+    : "top-1/2",
+);
 
 const { t } = useI18n();
 
@@ -78,7 +86,8 @@ const blurCarouselControl = (event: Event) => {
     <template v-if="hasMultiple">
       <button
         type="button"
-        class="absolute left-2 top-1/2 z-10 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white transition-[background-color,transform] duration-150 ease-out hover:bg-black/70 active:scale-[0.96] focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        class="absolute left-2 z-10 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white transition-[background-color,transform] duration-150 ease-out hover:bg-black/70 active:scale-[0.96] focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        :class="navButtonPositionClass"
         data-testid="gallery-carousel-prev"
         :aria-label="t('galleryPreviousMedia')"
         @click.stop="
@@ -90,7 +99,8 @@ const blurCarouselControl = (event: Event) => {
       </button>
       <button
         type="button"
-        class="absolute right-2 top-1/2 z-10 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white transition-[background-color,transform] duration-150 ease-out hover:bg-black/70 active:scale-[0.96] focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        class="absolute right-2 z-10 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white transition-[background-color,transform] duration-150 ease-out hover:bg-black/70 active:scale-[0.96] focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        :class="navButtonPositionClass"
         data-testid="gallery-carousel-next"
         :aria-label="t('galleryNextMedia')"
         @click.stop="

--- a/tests/unit/components/gallery/GalleryDetailPanel.test.ts
+++ b/tests/unit/components/gallery/GalleryDetailPanel.test.ts
@@ -76,6 +76,22 @@ describe("GalleryDetailPanel", () => {
     expect(metadata.props("filePaths")).toEqual(["photo.jpg", "audio.mp3"]);
   });
 
+  it("stretches metadata to the media column instead of capping its height", () => {
+    const wrapper = mount(GalleryDetailPanel, {
+      props: {
+        allowedFileExtensions,
+        feature,
+        filePaths: ["photo.jpg"],
+        mediaBasePath: "/media",
+      },
+      global: globalConfig,
+    });
+
+    const metadata = wrapper.get('[data-testid="gallery-detail-metadata"]');
+    expect(metadata.classes().some((cls) => cls.includes("max-h"))).toBe(false);
+    expect(metadata.classes()).toContain("lg:min-h-[min(70vh,640px)]");
+  });
+
   it("emits close when the back-to-gallery control is clicked", async () => {
     const wrapper = mount(GalleryDetailPanel, {
       props: {

--- a/tests/unit/components/gallery/GalleryMediaCarousel.test.ts
+++ b/tests/unit/components/gallery/GalleryMediaCarousel.test.ts
@@ -87,6 +87,7 @@ describe("GalleryMediaCarousel", () => {
         allowedFileExtensions,
         filePaths: ["a.jpg", "recording.mp3"],
         mediaBasePath: "/media",
+        pinNavButtons: true,
       },
     });
 
@@ -101,7 +102,17 @@ describe("GalleryMediaCarousel", () => {
     expect(controlClasses()).toEqual(imageSlideClasses);
     for (const testId of ["gallery-carousel-prev", "gallery-carousel-next"]) {
       expect(wrapper.get(`[data-testid="${testId}"]`).classes()).toEqual(
-        expect.arrayContaining(["top-1/2", "-translate-y-1/2", "h-10", "w-10"]),
+        expect.arrayContaining([
+          "top-[7.5rem]",
+          "sm:top-40",
+          "lg:top-[min(35vh,20rem)]",
+          "-translate-y-1/2",
+          "h-10",
+          "w-10",
+        ]),
+      );
+      expect(wrapper.get(`[data-testid="${testId}"]`).classes()).not.toContain(
+        "top-1/2",
       );
     }
   });


### PR DESCRIPTION
## Goal

I noticed that with very long images, the `GalleryDetailMetadata` component stays fixed to a max height, when it could adjust to the height of the media.

Additionally, with the carousel rendering media of varying heights, the prev/next buttons jump to 50% of the height which makes for a somewhat jarring experience having to scroll up/down the page to cycle through the buttons.

This PR fixes both.

## What I changed and why

- On desktop, the detail layout is a two-column grid so the metadata column stretches to the media column instead of being capped at `min(70vh, 640px)`. The metadata panel fills that height and scrolls internally when the field list is longer than the media.
- Carousel prev/next in the detail view are pinned to the center of the media min-height (`pin-nav-buttons`) instead of `top: 50%` of the current slide. Cycling between short audio and tall images no longer moves the controls, so you can keep clicking without scrolling.

## How I convinced myself this is right

Trying in runtime + tests.

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

Cursor Auto