### PR TITLE
Use background image from `gc_settings`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,3 @@ NUXT_PORT=8080
 # Public App Variables
 # ==========================================
 NUXT_PUBLIC_COMMUNITY_NAME=your_community_name
-
-# optional: Login page background image URL or path (falls back to public/background.jpg if not set)
-NUXT_PUBLIC_BACKGROUND_IMAGE=

--- a/components/LoginScreen.vue
+++ b/components/LoginScreen.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
-import { computed } from "vue";
-import { onMounted, useI18n, useRuntimeConfig, useUserSession } from "#imports";
+import { onMounted, useI18n, useUserSession } from "#imports";
 import GlassCard from "@/components/shared/GlassCard.vue";
 import GlobeLanguagePicker from "./shared/GlobeLanguagePicker.vue";
 
@@ -10,11 +9,7 @@ interface Props {
 const props = defineProps<Props>();
 const { loggedIn } = useUserSession();
 const { t } = useI18n();
-const runtimeConfig = useRuntimeConfig();
-const loginBackgroundSrc = computed(() => {
-  const url = String(runtimeConfig.public.backgroundImage ?? "").trim();
-  return url || "/background.jpg";
-});
+const loginBackgroundSrc = "/background.jpg";
 const loginWithAuth0 = () => {
   window.location.href = "/api/auth/auth0";
 };

--- a/components/LoginScreen.vue
+++ b/components/LoginScreen.vue
@@ -2,6 +2,7 @@
 import { onMounted, useI18n, useUserSession } from "#imports";
 import GlassCard from "@/components/shared/GlassCard.vue";
 import GlobeLanguagePicker from "./shared/GlobeLanguagePicker.vue";
+import { useLoginBackground } from "@/composables/useLoginBackground";
 
 interface Props {
   errorMessage: string;
@@ -9,7 +10,7 @@ interface Props {
 const props = defineProps<Props>();
 const { loggedIn } = useUserSession();
 const { t } = useI18n();
-const loginBackgroundSrc = "/background.jpg";
+const { backgroundImage: loginBackgroundSrc } = useLoginBackground();
 const loginWithAuth0 = () => {
   window.location.href = "/api/auth/auth0";
 };

--- a/composables/useLoginBackground.ts
+++ b/composables/useLoginBackground.ts
@@ -1,0 +1,18 @@
+import { computed } from "vue";
+import { useFetch } from "#imports";
+
+const DEFAULT_BACKGROUND = "/background.jpg";
+
+export const useLoginBackground = () => {
+  const { data } = useFetch<{ backgroundImage: string }>(
+    "/api/background-image",
+    { key: "gc-login-background" },
+  );
+
+  const backgroundImage = computed(() => {
+    const url = data.value?.backgroundImage?.trim() || "";
+    return url || DEFAULT_BACKGROUND;
+  });
+
+  return { backgroundImage };
+};

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -139,8 +139,6 @@ export default defineNuxtConfig({
       },
     },
     public: {
-      // Login hero background; set NUXT_PUBLIC_BACKGROUND_IMAGE (URL or path), or leave empty for /background.jpg.
-      backgroundImage: "",
       // Max rows returned by dataset view APIs (map, gallery, alerts, etc.).
       rowLimit: 10_000,
       allowedFileExtensions: {

--- a/server/api/background-image.get.ts
+++ b/server/api/background-image.get.ts
@@ -1,0 +1,18 @@
+import { getBackgroundImage } from "@/server/utils/gcSettings";
+
+/** Public: login background is site branding, not a secret. */
+export default defineEventHandler(async () => {
+  try {
+    const backgroundImage = await getBackgroundImage();
+    return { backgroundImage };
+  } catch (error) {
+    console.error("Error fetching background image:", error);
+    if (error && typeof error === "object" && "statusCode" in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Internal server error",
+    });
+  }
+});

--- a/server/database/schemas/gcSettings.ts
+++ b/server/database/schemas/gcSettings.ts
@@ -1,0 +1,8 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/** Landing-page-owned table. Read-only here; omit from schema.ts so drizzle-kit does not migrate it. */
+export const gcSettings = pgTable("gc_settings", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+});

--- a/server/utils/gcSettings.ts
+++ b/server/utils/gcSettings.ts
@@ -1,0 +1,24 @@
+import { eq } from "drizzle-orm";
+
+import { configDb } from "@/server/database/dbConnection";
+import { gcSettings } from "@/server/database/schemas/gcSettings";
+
+export const BACKGROUND_IMAGE_KEY = "background_image";
+
+/**
+ * Reads `gc_settings.background_image` from the config database.
+ * Returns an empty string when the row is missing or the table is unavailable.
+ */
+export const getBackgroundImage = async (): Promise<string> => {
+  try {
+    const rows = await configDb
+      .select({ value: gcSettings.value })
+      .from(gcSettings)
+      .where(eq(gcSettings.key, BACKGROUND_IMAGE_KEY))
+      .limit(1);
+    return rows[0]?.value?.trim() ?? "";
+  } catch (error) {
+    console.warn("Could not read gc_settings.background_image:", error);
+    return "";
+  }
+};

--- a/tests/unit/components/LoginScreen.spec.ts
+++ b/tests/unit/components/LoginScreen.spec.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { createI18n } from "vue-i18n";
+import { ref } from "vue";
 import LoginScreen from "@/components/LoginScreen.vue";
 
-// Mock the composables at the top level
+const { useLoginBackgroundMock } = vi.hoisted(() => ({
+  useLoginBackgroundMock: vi.fn(),
+}));
+
+vi.mock("@/composables/useLoginBackground", () => ({
+  useLoginBackground: () => useLoginBackgroundMock(),
+}));
+
 vi.mock("#imports", () => ({
   useUserSession: () => ({
     loggedIn: { value: false },
@@ -32,7 +40,6 @@ vi.mock("#imports", () => ({
   }),
   navigateTo: vi.fn(),
   onMounted: vi.fn((callback) => {
-    // Execute the callback immediately for testing
     callback();
   }),
 }));
@@ -103,10 +110,34 @@ const mountLoginScreen = (
   });
 };
 
+const backgroundImg = (wrapper: ReturnType<typeof mountLoginScreen>) =>
+  wrapper.find("img.object-cover");
+
 describe("LoginScreen", () => {
+  beforeEach(() => {
+    useLoginBackgroundMock.mockReturnValue({
+      backgroundImage: ref("/background.jpg"),
+    });
+  });
+
   it("renders login button", () => {
     const wrapper = mountLoginScreen();
     expect(wrapper.find("[data-testid='login-button']").exists()).toBe(true);
+  });
+
+  it("uses /background.jpg when gc_settings.background_image is unset", () => {
+    const wrapper = mountLoginScreen();
+    expect(backgroundImg(wrapper).attributes("src")).toBe("/background.jpg");
+  });
+
+  it("uses gc_settings.background_image when set", () => {
+    useLoginBackgroundMock.mockReturnValue({
+      backgroundImage: ref("https://cdn.example/bg.jpg"),
+    });
+    const wrapper = mountLoginScreen();
+    expect(backgroundImg(wrapper).attributes("src")).toBe(
+      "https://cdn.example/bg.jpg",
+    );
   });
 
   it("displays error message when provided", () => {

--- a/tests/unit/components/LoginScreen.spec.ts
+++ b/tests/unit/components/LoginScreen.spec.ts
@@ -30,9 +30,6 @@ vi.mock("#imports", () => ({
       return messages[key] ?? key;
     },
   }),
-  useRuntimeConfig: () => ({
-    public: { backgroundImage: "" },
-  }),
   navigateTo: vi.fn(),
   onMounted: vi.fn((callback) => {
     // Execute the callback immediately for testing

--- a/tests/unit/composables/useLoginBackground.test.ts
+++ b/tests/unit/composables/useLoginBackground.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { useLoginBackground } from "@/composables/useLoginBackground";
+
 const { useFetchMock } = vi.hoisted(() => ({
   useFetchMock: vi.fn(),
 }));
@@ -7,8 +9,6 @@ const { useFetchMock } = vi.hoisted(() => ({
 vi.mock("#imports", () => ({
   useFetch: (...args: unknown[]) => useFetchMock(...args),
 }));
-
-import { useLoginBackground } from "@/composables/useLoginBackground";
 
 describe("useLoginBackground", () => {
   beforeEach(() => {

--- a/tests/unit/composables/useLoginBackground.test.ts
+++ b/tests/unit/composables/useLoginBackground.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { useFetchMock } = vi.hoisted(() => ({
+  useFetchMock: vi.fn(),
+}));
+
+vi.mock("#imports", () => ({
+  useFetch: (...args: unknown[]) => useFetchMock(...args),
+}));
+
+import { useLoginBackground } from "@/composables/useLoginBackground";
+
+describe("useLoginBackground", () => {
+  beforeEach(() => {
+    useFetchMock.mockReturnValue({
+      data: { value: { backgroundImage: "" } },
+    });
+  });
+
+  it("falls back to /background.jpg when the setting is empty", () => {
+    expect(useLoginBackground().backgroundImage.value).toBe("/background.jpg");
+  });
+
+  it("uses gc_settings.background_image when set", () => {
+    useFetchMock.mockReturnValue({
+      data: { value: { backgroundImage: "https://cdn.example/bg.jpg" } },
+    });
+    expect(useLoginBackground().backgroundImage.value).toBe(
+      "https://cdn.example/bg.jpg",
+    );
+  });
+});

--- a/tests/unit/server/gcSettings.test.ts
+++ b/tests/unit/server/gcSettings.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLimit } = vi.hoisted(() => ({
+  mockLimit: vi.fn(),
+}));
+
+vi.mock("@/server/database/dbConnection", () => ({
+  configDb: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: mockLimit,
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("/server/database/dbConnection", () => ({
+  configDb: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: mockLimit,
+        }),
+      }),
+    }),
+  },
+}));
+
+import { getBackgroundImage } from "@/server/utils/gcSettings";
+
+describe("getBackgroundImage", () => {
+  beforeEach(() => {
+    mockLimit.mockReset();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the trimmed background_image value", async () => {
+    mockLimit.mockResolvedValue([{ value: "  https://cdn.example/bg.jpg  " }]);
+    expect(await getBackgroundImage()).toBe("https://cdn.example/bg.jpg");
+  });
+
+  it("returns an empty string when the setting is missing", async () => {
+    mockLimit.mockResolvedValue([]);
+    expect(await getBackgroundImage()).toBe("");
+  });
+
+  it("returns an empty string when the table is unavailable", async () => {
+    mockLimit.mockRejectedValue(
+      new Error('relation "gc_settings" does not exist'),
+    );
+    expect(await getBackgroundImage()).toBe("");
+  });
+});

--- a/tests/unit/server/gcSettings.test.ts
+++ b/tests/unit/server/gcSettings.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getBackgroundImage } from "@/server/utils/gcSettings";
+
 const { mockLimit } = vi.hoisted(() => ({
   mockLimit: vi.fn(),
 }));
@@ -27,8 +29,6 @@ vi.mock("/server/database/dbConnection", () => ({
     }),
   },
 }));
-
-import { getBackgroundImage } from "@/server/utils/gcSettings";
 
 describe("getBackgroundImage", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Goal

Use the same `gc_settings.background_image` value as GC Landing Page for Explorer's login background, instead of `NUXT_PUBLIC_BACKGROUND_IMAGE`.

## What I changed and why

Dropped the env-based background. Login now reads `background_image` from `gc_settings` through `GET /api/background-image`. If that row is empty or the table isn't there, it falls back to `/background.jpg` (same bundled image as Landing Page).

The fetch lives in `useLoginBackground`, same pattern as Landing Page's `useThemeSettings`, without bringing over theme admin/logo settings. The Drizzle mapping is read-only and not wired into Explorer migrations, since Landing Page owns `gc_settings`.

## How I convinced myself this is right

- Unit tests and checking it in Runtime.

## What I'm not doing here

- No theme admin UI, logo URL, or writes to `gc_settings`, nor a migration for `gc_settings`.

## LLM use disclosure

Cursor Auto