### PR TITLE
Pin CI pnpm to 10.34.5 so GitHub runners do not install pnpm 11.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "20"
       - name: Install dependencies
         run: |
-          npm install -g pnpm
+          npm install -g pnpm@10.34.5
           pnpm install
       - name: Run linting and formatting
         run: |
@@ -52,7 +52,7 @@ jobs:
           node-version: "20"
       - name: Install dependencies and run unit tests
         run: |
-          npm install -g pnpm
+          npm install -g pnpm@10.34.5
           pnpm install
           pnpm run test:unit
 
@@ -71,7 +71,7 @@ jobs:
           node-version: "20"
       - name: Install dependencies
         run: |
-          npm install -g pnpm
+          npm install -g pnpm@10.34.5
           pnpm install
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps


### PR DESCRIPTION
## Goal

Restore GitHub Actions lint, unit-test, and Playwright jobs to pnpm 10.34.5 so `pnpm install` does not fail with `ERR_PNPM_IGNORED_BUILDS`. Closes #628 


## Screenshots

N/A


## What I changed and why

The three GitHub Actions jobs that install dependencies on the runner used `npm install -g pnpm` with no version. That command now installs pnpm 11, where `strictDepBuilds` defaults to true and ignored dependency build scripts fail the job. I pin those three installs to `pnpm@10.34.5`, the last version that completed CI.

I do not change the Docker image install. That path already uses `pnpm@10`, so it stays on 10.x and is not the test runner.


## How I convinced myself this is right

pnpm's current `latest` tag is 11.24.0 and `latest-10` is 10.34.5. The v11 release notes set `strictDepBuilds` to true and document `ERR_PNPM_IGNORED_BUILDS` for unreviewed scripts. Our failed run used store v11 after a successful Nuxt postinstall, which matches an install-time policy failure, not a broken app dependency. pnpm 11 also requires Node 22+, and these jobs still use Node 20, so a v11 upgrade does not belong in this PR.


## What I'm not doing here

I am not migrating to pnpm 11. I am not adding `allowBuilds`. I am not approving dependency build scripts. I am not changing the Dockerfile pnpm major pin. I am not switching to `pnpm/action-setup`.


## LLM use disclosure

None