### PR TITLE
Fit the map to incident features when opening an `?incidentId=` link

### DIFF
--- a/composables/useIncidents.ts
+++ b/composables/useIncidents.ts
@@ -9,6 +9,10 @@ import type {
   CollectionEntryInput,
   Incident,
 } from "@/types";
+import {
+  getIncidentEntriesBbox,
+  INCIDENT_FIT_BOUNDS_OPTIONS,
+} from "@/utils/incidentHelpers";
 /**
  * Small in-memory cache to avoid refetching incident details repeatedly.
  * (Also used for hover-prefetch.)
@@ -408,6 +412,16 @@ export const useIncidents = (
   };
 
   /**
+   * Fits the map to the combined extent of incident entry geometries, with padding.
+   */
+  const fitMapToIncidentEntries = (entries: CollectionEntry[]) => {
+    if (!map.value) return;
+    const bounds = getIncidentEntriesBbox(entries);
+    if (!bounds) return;
+    map.value.fitBounds(bounds, { ...INCIDENT_FIT_BOUNDS_OPTIONS });
+  };
+
+  /**
    * Opens a saved incident in the sidebar and highlights its entries on the map
    */
   const openIncidentDetails = async (incidentId: string) => {
@@ -430,6 +444,7 @@ export const useIncidents = (
 
       clearSourceHighlighting();
       highlightIncidentEntries(response.entries || []);
+      fitMapToIncidentEntries(response.entries || []);
 
       // Add incidentId to URL; remove alert/secondary params so address bar matches "copy link to incident"
       const query = { ...route.query };

--- a/tests/e2e/07-annotated-collections.spec.ts
+++ b/tests/e2e/07-annotated-collections.spec.ts
@@ -52,6 +52,22 @@ async function getSelectableFeatureLngLat(page: Page): Promise<LngLat | null> {
   });
 }
 
+async function getMapZoom(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    // @ts-expect-error _testMap is exposed for E2E testing only
+    return window._testMap.getZoom();
+  });
+}
+
+async function waitForMapIdle(page: Page): Promise<void> {
+  await page.locator("#map[data-map-ready='true']").waitFor();
+  await page.waitForFunction(() => {
+    // @ts-expect-error _testMap is exposed for E2E testing only
+    const map = window._testMap;
+    return !!map && !map.isMoving();
+  });
+}
+
 async function projectLngLatToPagePoint(
   page: Page,
   lngLat: LngLat,
@@ -219,6 +235,8 @@ test("annotated collections - shareable incident link URL parameter", async ({
   authenticatedPageAsAdmin: page,
 }) => {
   await navigateToAlertsDashboard(page);
+  await waitForMapIdle(page);
+  const defaultZoom = await getMapZoom(page);
 
   await page.getByTestId("incidents-multiselect-button").click();
 
@@ -249,6 +267,20 @@ test("annotated collections - shareable incident link URL parameter", async ({
 
   await page.goto(url);
   await expect(page.getByText("Shareable Link Test Incident")).toBeVisible();
+  await waitForMapIdle(page);
+
+  const afterLoad = await page.evaluate((featureLngLat) => {
+    // @ts-expect-error _testMap is exposed for E2E testing only
+    const map = window._testMap;
+    const bounds = map.getBounds();
+    return {
+      zoom: map.getZoom(),
+      containsFeature: bounds.contains(featureLngLat),
+    };
+  }, lngLat);
+
+  expect(afterLoad.containsFeature).toBe(true);
+  expect(afterLoad.zoom).toBeGreaterThan(defaultZoom);
 });
 
 test("annotated collections - incident detail shows CSV and GeoJSON download buttons", async ({

--- a/tests/unit/components/AlertsDashboard.test.ts
+++ b/tests/unit/components/AlertsDashboard.test.ts
@@ -15,6 +15,7 @@ import { createI18n } from "vue-i18n";
 import * as mapboxMock from "@/tests/unit/helpers/mapboxMock";
 
 import AlertsDashboard from "@/components/AlertsDashboard.vue";
+import { INCIDENT_FIT_BOUNDS_OPTIONS } from "@/utils/incidentHelpers";
 
 // Create i18n instance for template $t support (locales mirror app i18n config)
 const i18n = createI18n({
@@ -121,7 +122,9 @@ vi.mock("#imports", async () => {
 describe("AlertsDashboard component", () => {
   beforeEach(() => {
     mapboxMock.reset();
+    mockRoute.value = { params: {}, query: {} };
     document.body.innerHTML = '<div id="map"></div>';
+    hoisted.mockFetch.mockReset();
     // Mock $fetch to return empty incidents by default
     hoisted.mockFetch.mockResolvedValue({
       incidents: [],
@@ -644,6 +647,145 @@ describe("AlertsDashboard component", () => {
 
       expect(vm.showSidebar).toBe(false);
       expect(mapboxMock.setFeatureState.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("fits the map to incident entry extent when incidentId is in the URL", async () => {
+      mockRoute.value = {
+        params: {},
+        query: { incidentId: "inc-1" },
+      };
+
+      const entries = [
+        {
+          id: "e1",
+          collection_id: "inc-1",
+          source_table: "test_alerts",
+          source_id: "a1",
+          source_data: {
+            g__type: "Point",
+            g__coordinates: "[-59.81, 2.49]",
+          },
+          added_by: "u",
+          added_at: "2024-01-01T00:00:00.000Z",
+        },
+        {
+          id: "e2",
+          collection_id: "inc-1",
+          source_table: "test_alerts",
+          source_id: "a2",
+          source_data: {
+            g__type: "Point",
+            g__coordinates: "[-59.79, 2.51]",
+          },
+          added_by: "u",
+          added_at: "2024-01-01T00:00:00.000Z",
+        },
+      ];
+
+      hoisted.mockFetch.mockImplementation((url: string) => {
+        if (url === "/api/incidents/inc-1") {
+          return Promise.resolve({
+            incident: {
+              id: "inc-1",
+              name: "Illegal Mining Co.",
+              collection_type: "incident",
+              created_at: "2026-08-15T00:00:00.000Z",
+              updated_at: "2026-08-15T00:00:00.000Z",
+              metadata: {},
+            },
+            incidentData: {
+              collection_id: "inc-1",
+              status: "suspected",
+              is_active: true,
+            },
+            entries,
+          });
+        }
+        return Promise.resolve({
+          incidents: [],
+          total: 0,
+          limit: 10,
+          offset: 0,
+        });
+      });
+
+      mount(AlertsDashboard, {
+        props: baseProps,
+        global: {
+          plugins: [i18n],
+          stubs: {
+            ViewSidebar: true,
+            MapLegend: true,
+            BasemapSelector: true,
+            IncidentsSidebar: true,
+          },
+        },
+      });
+
+      mapboxMock.fireLoad();
+      await flushPromises();
+
+      expect(mapboxMock.mockMap.fitBounds).toHaveBeenCalledWith(
+        [-59.81, 2.49, -59.79, 2.51],
+        { ...INCIDENT_FIT_BOUNDS_OPTIONS },
+      );
+    });
+
+    it("does not fit bounds for an incident URL when entries have no geometry", async () => {
+      mockRoute.value = {
+        params: {},
+        query: { incidentId: "inc-empty" },
+      };
+
+      hoisted.mockFetch.mockImplementation((url: string) => {
+        if (url === "/api/incidents/inc-empty") {
+          return Promise.resolve({
+            incident: {
+              id: "inc-empty",
+              name: "Empty",
+              collection_type: "incident",
+              created_at: "2026-08-15T00:00:00.000Z",
+              updated_at: "2026-08-15T00:00:00.000Z",
+              metadata: {},
+            },
+            entries: [
+              {
+                id: "e1",
+                collection_id: "inc-empty",
+                source_table: "test_alerts",
+                source_id: "a1",
+                source_data: {},
+                added_by: "u",
+                added_at: "2024-01-01T00:00:00.000Z",
+              },
+            ],
+          });
+        }
+        return Promise.resolve({
+          incidents: [],
+          total: 0,
+          limit: 10,
+          offset: 0,
+        });
+      });
+
+      mount(AlertsDashboard, {
+        props: baseProps,
+        global: {
+          plugins: [i18n],
+          stubs: {
+            ViewSidebar: true,
+            MapLegend: true,
+            BasemapSelector: true,
+            IncidentsSidebar: true,
+          },
+        },
+      });
+
+      mapboxMock.fireLoad();
+      await flushPromises();
+
+      expect(mapboxMock.mockMap.fitBounds).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/helpers/mapboxMock.ts
+++ b/tests/unit/helpers/mapboxMock.ts
@@ -42,6 +42,7 @@ export const mockMap = {
   setFeatureState,
   setTerrain: vi.fn(),
   queryRenderedFeatures: vi.fn(() => []),
+  querySourceFeatures: vi.fn(() => []),
   setFilter: vi.fn(),
   setLayoutProperty: vi.fn(),
   once: vi.fn(),
@@ -86,6 +87,7 @@ export function reset(): void {
   mockMap.addLayer.mockClear();
   mockMap.setTerrain.mockClear();
   mockMap.flyTo.mockClear();
+  mockMap.fitBounds.mockClear();
   mockMap.remove.mockClear();
   layers.length = 0;
   loadCallback = undefined;

--- a/tests/unit/utils/incidentHelpers.test.ts
+++ b/tests/unit/utils/incidentHelpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildIncidentMetadataCsv,
   buildIncidentEntriesFeatureCollection,
+  getIncidentEntriesBbox,
 } from "@/utils/incidentHelpers";
 import type { AnnotatedCollection, CollectionEntry, Incident } from "@/types";
 
@@ -85,5 +86,58 @@ describe("buildIncidentEntriesFeatureCollection", () => {
     expect(fc.features).toHaveLength(1);
     expect(fc.features[0].geometry.type).toBe("Point");
     expect(fc.features[0].properties?.source_table).toBe("fake_alerts");
+  });
+});
+
+describe("getIncidentEntriesBbox", () => {
+  const pointEntry = (
+    id: string,
+    coordinates: [number, number],
+  ): CollectionEntry => ({
+    id,
+    collection_id: "c1",
+    source_table: "fake_alerts",
+    source_id: id,
+    source_data: {
+      g__type: "Point",
+      g__coordinates: JSON.stringify(coordinates),
+    },
+    added_by: "u",
+    added_at: "2024-01-01T00:00:00.000Z",
+  });
+
+  it("returns null when no entries have valid geometry", () => {
+    expect(
+      getIncidentEntriesBbox([
+        {
+          id: "e1",
+          collection_id: "c1",
+          source_table: "t",
+          source_id: "1",
+          source_data: { foo: 1 },
+          added_by: "u",
+          added_at: "2024-01-01T00:00:00.000Z",
+        },
+      ]),
+    ).toBeNull();
+    expect(getIncidentEntriesBbox([])).toBeNull();
+  });
+
+  it("returns the combined extent of entry geometries", () => {
+    expect(
+      getIncidentEntriesBbox([
+        pointEntry("e1", [-59.81, 2.49]),
+        pointEntry("e2", [-59.79, 2.51]),
+        {
+          id: "e3",
+          collection_id: "c1",
+          source_table: "t",
+          source_id: "skip",
+          source_data: {},
+          added_by: "u",
+          added_at: "2024-01-01T00:00:00.000Z",
+        },
+      ]),
+    ).toEqual([-59.81, 2.49, -59.79, 2.51]);
   });
 });

--- a/utils/incidentHelpers.ts
+++ b/utils/incidentHelpers.ts
@@ -1,3 +1,4 @@
+import { bbox } from "@turf/turf";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type {
   AnnotatedCollection,
@@ -7,6 +8,12 @@ import type {
 } from "@/types";
 import { escapeCSVValue, buildCsvFromObjects } from "@/utils/csvUtils";
 import { isValidGeolocation } from "@/utils/geoUtils";
+
+/** Match `?alertId=` polygon fit: 50px padding, cap zoom like point flyTo (15). */
+export const INCIDENT_FIT_BOUNDS_OPTIONS = {
+  padding: 50,
+  maxZoom: 15,
+} as const;
 
 const ENTRY_CSV_FIXED_HEADERS = [
   "collection_entry_id",
@@ -147,6 +154,26 @@ export const buildIncidentEntriesFeatureCollection = (
     type: "FeatureCollection",
     features,
   };
+};
+
+/**
+ * Bounding box of incident entry geometries: `[west, south, east, north]`.
+ * Entries without valid `g__` geometry are omitted. Returns null when none remain.
+ */
+export const getIncidentEntriesBbox = (
+  entries: CollectionEntry[],
+): [number, number, number, number] | null => {
+  const featureCollection = buildIncidentEntriesFeatureCollection(entries);
+  const featuresWithGeometry = featureCollection.features.filter(
+    (feature): feature is Feature<Geometry> => feature.geometry != null,
+  );
+  if (featuresWithGeometry.length === 0) {
+    return null;
+  }
+  return bbox({
+    type: "FeatureCollection",
+    features: featuresWithGeometry,
+  }) as [number, number, number, number];
 };
 
 /**


### PR DESCRIPTION
## Goal

Closes #585.

When someone opens a shareable `?incidentId=` link (or an incident from the list), the map should zoom to the combined extent of that incident’s features with padding, the same way `?alertId=` already frames a single alert. Today the incident panel opens but the map stays at the default territory view.

## Screenshots

<img width="1919" height="1064" alt="image" src="https://github.com/user-attachments/assets/1d42e88d-07b7-4846-beda-d623b6043e3c" />

_Zoomed to this state upon opening URL with `?incidentId=`_

## What I changed and why

I cadded a helper function to ompute the bounding box from each entry’s stored `g__` geometry (not clustered map features, which would be wrong when zoomed out), then `fitBounds` with 50px padding and `maxZoom: 15` so a single point does not over-zoom.

That runs in `openIncidentDetails`, so it covers both the URL path and clicking an incident in the sidebar.

## How I convinced myself this is right

Trying in runtime and unit tests.

## What I'm not doing here

## LLM use disclosure

Cursor agent used for implementation and tests.