### PR TITLE
Restore pulsing halo on most recent alerts

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -18,6 +18,14 @@ import {
   toggleLayerVisibility as utilsToggleLayerVisibility,
   resolveTerrainExaggeration,
 } from "@/utils/mapGLHelpers";
+import {
+  addPulsingHaloLayers,
+  CENTROID_CLUSTER_HALO_RADIUS,
+  CENTROID_HALO_RADIUS,
+  POINT_CLUSTER_HALO_RADIUS,
+  POINT_HALO_RADIUS,
+  stopPulsingHalo,
+} from "@/utils/pulsingHalo";
 
 import BasemapSelector from "@/components/shared/BasemapSelector.vue";
 import ViewSidebar from "@/components/shared/ViewSidebar.vue";
@@ -748,6 +756,13 @@ const addAlertsData = async () => {
       }
 
       if (type === "Point") {
+        if (layerId.startsWith("most-recent-alerts")) {
+          addPulsingHaloLayers(map.value, layerId, {
+            unclusteredRadius: POINT_HALO_RADIUS,
+            clusterRadius: POINT_CLUSTER_HALO_RADIUS,
+          });
+        }
+
         // Add cluster circle layer
         if (!map.value.getLayer(`${layerId}-clusters`)) {
           map.value.addLayer({
@@ -898,6 +913,14 @@ const addAlertsData = async () => {
     // At zoom 12+, actual polygon/linestring geometries show instead
     const CENTROID_MAX_ZOOM = 11;
 
+    if (layerId.startsWith("most-recent-alerts")) {
+      addPulsingHaloLayers(map.value, layerId, {
+        unclusteredRadius: CENTROID_HALO_RADIUS,
+        clusterRadius: CENTROID_CLUSTER_HALO_RADIUS,
+        maxzoom: CENTROID_MAX_ZOOM + 1,
+      });
+    }
+
     // Add cluster circle layer
     if (!map.value.getLayer(`${layerId}-clusters`)) {
       map.value.addLayer({
@@ -1041,7 +1064,8 @@ const addAlertsData = async () => {
   map.value.getStyle().layers.forEach((layer: Layer) => {
     if (
       (layer.id.startsWith("most-recent-alerts") &&
-        !layer.id.includes("stroke")) ||
+        !layer.id.includes("stroke") &&
+        !layer.id.includes("halo")) ||
       (layer.id.startsWith("previous-alerts") && !layer.id.includes("stroke"))
     ) {
       map.value.on(
@@ -1476,6 +1500,18 @@ const toggleLayerVisibility = (item: MapLegendItem) => {
             visibility,
           );
         }
+        const haloLayerId = `${layerId}-halo`;
+        const clusterHaloLayerId = `${layerId}-clusters-halo`;
+        if (map.value.getLayer(haloLayerId)) {
+          map.value.setLayoutProperty(haloLayerId, "visibility", visibility);
+        }
+        if (map.value.getLayer(clusterHaloLayerId)) {
+          map.value.setLayoutProperty(
+            clusterHaloLayerId,
+            "visibility",
+            visibility,
+          );
+        }
       }
     });
   } else if (item.id === "secondary-data") {
@@ -1675,6 +1711,21 @@ const resetToInitialState = () => {
             }
           }
 
+          if (type === "point" || type === "centroids") {
+            const haloLayerId = `${layerId}-halo`;
+            const clusterHaloLayerId = `${layerId}-clusters-halo`;
+            if (map.value.getLayer(haloLayerId)) {
+              map.value.setLayoutProperty(haloLayerId, "visibility", visibility);
+            }
+            if (map.value.getLayer(clusterHaloLayerId)) {
+              map.value.setLayoutProperty(
+                clusterHaloLayerId,
+                "visibility",
+                visibility,
+              );
+            }
+          }
+
           // Handle cluster layers for symbols
           if (type === "symbol") {
             const clusterLayerId = `${layerId}-clusters`;
@@ -1720,6 +1771,7 @@ const resetToInitialState = () => {
 };
 
 onBeforeUnmount(() => {
+  stopPulsingHalo();
   if (map.value) {
     removeBoundingBoxHandlers();
     map.value.remove();

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -1715,7 +1715,11 @@ const resetToInitialState = () => {
             const haloLayerId = `${layerId}-halo`;
             const clusterHaloLayerId = `${layerId}-clusters-halo`;
             if (map.value.getLayer(haloLayerId)) {
-              map.value.setLayoutProperty(haloLayerId, "visibility", visibility);
+              map.value.setLayoutProperty(
+                haloLayerId,
+                "visibility",
+                visibility,
+              );
             }
             if (map.value.getLayer(clusterHaloLayerId)) {
               map.value.setLayoutProperty(

--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -22,8 +22,10 @@ import {
   addPulsingHaloLayers,
   CENTROID_CLUSTER_HALO_RADIUS,
   CENTROID_HALO_RADIUS,
+  pausePulsingHalo,
   POINT_CLUSTER_HALO_RADIUS,
   POINT_HALO_RADIUS,
+  startPulsingHalo,
   stopPulsingHalo,
 } from "@/utils/pulsingHalo";
 
@@ -1388,6 +1390,7 @@ const handleBufferMouseEvent = (e: MapMouseEvent) => {
 /** Handles the change of the basemap style */
 const currentBasemap = ref<Basemap>({ id: "custom", style: props.mapboxStyle });
 const handleBasemapChange = (newBasemap: Basemap) => {
+  pausePulsingHalo();
   changeMapStyle(map.value, newBasemap, props.planetApiKey);
 
   currentBasemap.value = newBasemap;
@@ -1457,6 +1460,7 @@ const prepareMapLegendContent = () => {
     mapLegendContent.value = legendItems;
     // E2E tests wait for this after the idle-gated legend content is ready.
     mapReady.value = true;
+    startPulsingHalo();
   });
 };
 
@@ -1549,6 +1553,7 @@ const handleSidebarClose = () => {
  * Repositions the map to its initial view
  */
 const resetToInitialState = () => {
+  pausePulsingHalo();
   resetSelectedFeature();
   localAlertsData.value = props.alertsData;
   showSidebar.value = true;
@@ -1771,6 +1776,7 @@ const resetToInitialState = () => {
     });
 
     emit("reset-legend-visibility");
+    startPulsingHalo();
   });
 };
 

--- a/tests/unit/components/AlertsDashboard.test.ts
+++ b/tests/unit/components/AlertsDashboard.test.ts
@@ -207,6 +207,37 @@ describe("AlertsDashboard component", () => {
     );
   });
 
+  it("adds a pulsing halo on most recent alert points and clusters", async () => {
+    const props = JSON.parse(JSON.stringify(baseProps));
+    props.alertsData.mostRecentAlerts.features.push({
+      id: "alert1",
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [0, 0] },
+      properties: { alertID: "alert1", YYYYMM: "202401" },
+    });
+
+    mountComponent(props);
+    mapboxMock.fireLoad();
+    await flushPromises();
+
+    const layerIds = mapboxMock.layers.map((layer) => layer.id);
+    expect(layerIds).toContain("most-recent-alerts-point-halo");
+    expect(layerIds).toContain("most-recent-alerts-point-clusters-halo");
+    const clusterHalo = mapboxMock.layers.find(
+      (layer) => layer.id === "most-recent-alerts-point-clusters-halo",
+    );
+    expect(clusterHalo?.type).toBe("circle");
+    expect(clusterHalo?.filter).toEqual(["has", "point_count"]);
+
+    const callsBefore = mapboxMock.setFeatureState.mock.calls.length;
+    mapboxMock.fireClick("most-recent-alerts-point-halo", {
+      features: props.alertsData.mostRecentAlerts.features,
+      point: { x: 10, y: 10 },
+    });
+    await flushPromises();
+    expect(mapboxMock.setFeatureState.mock.calls.length).toBe(callsBefore);
+  });
+
   it("adds 3D terrain when mapbox3d is true", async () => {
     const propsWithTerrain = { ...baseProps, mapbox3d: true };
 

--- a/tests/unit/helpers/mapboxMock.ts
+++ b/tests/unit/helpers/mapboxMock.ts
@@ -39,11 +39,13 @@ export const mockMap = {
   ),
   hasImage: vi.fn(() => false),
   addImage: vi.fn(),
+  triggerRepaint: vi.fn(),
   setFeatureState,
   setTerrain: vi.fn(),
   queryRenderedFeatures: vi.fn(() => []),
   setFilter: vi.fn(),
   setLayoutProperty: vi.fn(),
+  setPaintProperty: vi.fn(),
   once: vi.fn(),
   flyTo: vi.fn(),
   fitBounds: vi.fn(),
@@ -84,6 +86,7 @@ export function reset(): void {
   setFeatureState.mockClear();
   mockMap.addSource.mockClear();
   mockMap.addLayer.mockClear();
+  mockMap.addImage.mockClear();
   mockMap.setTerrain.mockClear();
   mockMap.flyTo.mockClear();
   mockMap.remove.mockClear();

--- a/tests/unit/utils/pulsingHalo.test.ts
+++ b/tests/unit/utils/pulsingHalo.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Map as MapboxMap } from "mapbox-gl";
+
+import {
+  POINT_HALO_RADIUS,
+  POINT_CLUSTER_HALO_RADIUS,
+  addPulsingHaloLayers,
+  stopPulsingHalo,
+} from "@/utils/pulsingHalo";
+
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", vi.fn());
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+});
+
+afterEach(() => {
+  stopPulsingHalo();
+  vi.unstubAllGlobals();
+});
+
+describe("addPulsingHaloLayers", () => {
+  it("adds circle halo layers for unclustered points and clusters", () => {
+    const map = {
+      getLayer: vi.fn(() => undefined),
+      addLayer: vi.fn(),
+      setPaintProperty: vi.fn(),
+    };
+
+    addPulsingHaloLayers(map as unknown as MapboxMap, "most-recent-alerts-point", {
+      unclusteredRadius: POINT_HALO_RADIUS,
+      clusterRadius: POINT_CLUSTER_HALO_RADIUS,
+    });
+
+    expect(map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "most-recent-alerts-point-clusters-halo",
+        type: "circle",
+        source: "most-recent-alerts-point",
+        filter: ["has", "point_count"],
+      }),
+    );
+    expect(map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "most-recent-alerts-point-halo",
+        type: "circle",
+        source: "most-recent-alerts-point",
+        filter: ["!", ["has", "point_count"]],
+      }),
+    );
+
+    const clusterLayer = map.addLayer.mock.calls.find(
+      ([layer]) => layer.id === "most-recent-alerts-point-clusters-halo",
+    )?.[0];
+    expect(clusterLayer.paint["circle-radius"]).toEqual([
+      "+",
+      4,
+      POINT_CLUSTER_HALO_RADIUS,
+    ]);
+
+    map.getLayer.mockImplementation((id: string) =>
+      id.includes("halo") ? { id } : undefined,
+    );
+
+    addPulsingHaloLayers(map as unknown as MapboxMap, "most-recent-alerts-point", {
+      unclusteredRadius: POINT_HALO_RADIUS,
+      clusterRadius: POINT_CLUSTER_HALO_RADIUS,
+    });
+
+    expect(map.addLayer).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards maxzoom onto halo layers", () => {
+    const map = {
+      getLayer: vi.fn(() => undefined),
+      addLayer: vi.fn(),
+      setPaintProperty: vi.fn(),
+    };
+
+    addPulsingHaloLayers(
+      map as unknown as MapboxMap,
+      "most-recent-alerts-centroids",
+      {
+        unclusteredRadius: POINT_HALO_RADIUS,
+        clusterRadius: POINT_CLUSTER_HALO_RADIUS,
+        maxzoom: 12,
+      },
+    );
+
+    expect(map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "most-recent-alerts-centroids-clusters-halo",
+        maxzoom: 12,
+      }),
+    );
+  });
+});

--- a/tests/unit/utils/pulsingHalo.test.ts
+++ b/tests/unit/utils/pulsingHalo.test.ts
@@ -26,10 +26,14 @@ describe("addPulsingHaloLayers", () => {
       setPaintProperty: vi.fn(),
     };
 
-    addPulsingHaloLayers(map as unknown as MapboxMap, "most-recent-alerts-point", {
-      unclusteredRadius: POINT_HALO_RADIUS,
-      clusterRadius: POINT_CLUSTER_HALO_RADIUS,
-    });
+    addPulsingHaloLayers(
+      map as unknown as MapboxMap,
+      "most-recent-alerts-point",
+      {
+        unclusteredRadius: POINT_HALO_RADIUS,
+        clusterRadius: POINT_CLUSTER_HALO_RADIUS,
+      },
+    );
 
     expect(map.addLayer).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -61,10 +65,14 @@ describe("addPulsingHaloLayers", () => {
       id.includes("halo") ? { id } : undefined,
     );
 
-    addPulsingHaloLayers(map as unknown as MapboxMap, "most-recent-alerts-point", {
-      unclusteredRadius: POINT_HALO_RADIUS,
-      clusterRadius: POINT_CLUSTER_HALO_RADIUS,
-    });
+    addPulsingHaloLayers(
+      map as unknown as MapboxMap,
+      "most-recent-alerts-point",
+      {
+        unclusteredRadius: POINT_HALO_RADIUS,
+        clusterRadius: POINT_CLUSTER_HALO_RADIUS,
+      },
+    );
 
     expect(map.addLayer).toHaveBeenCalledTimes(2);
   });

--- a/tests/unit/utils/pulsingHalo.test.ts
+++ b/tests/unit/utils/pulsingHalo.test.ts
@@ -5,6 +5,7 @@ import {
   POINT_HALO_RADIUS,
   POINT_CLUSTER_HALO_RADIUS,
   addPulsingHaloLayers,
+  startPulsingHalo,
   stopPulsingHalo,
 } from "@/utils/pulsingHalo";
 
@@ -75,6 +76,28 @@ describe("addPulsingHaloLayers", () => {
     );
 
     expect(map.addLayer).toHaveBeenCalledTimes(2);
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it("does not start the pulse until startPulsingHalo is called", () => {
+    const map = {
+      getLayer: vi.fn(() => ({})),
+      addLayer: vi.fn(),
+      setPaintProperty: vi.fn(),
+    };
+
+    addPulsingHaloLayers(
+      map as unknown as MapboxMap,
+      "most-recent-alerts-point",
+      {
+        unclusteredRadius: POINT_HALO_RADIUS,
+        clusterRadius: POINT_CLUSTER_HALO_RADIUS,
+      },
+    );
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+
+    startPulsingHalo();
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
   });
 
   it("forwards maxzoom onto halo layers", () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,7 +9,11 @@ import type {
   Polygon,
   Position,
 } from "geojson";
-import type { StyleSpecification } from "mapbox-gl";
+import type {
+  ExpressionSpecification,
+  Map as MapboxMap,
+  StyleSpecification,
+} from "mapbox-gl";
 import type { viewTypes } from "../nuxt.config";
 
 export type ViewType = (typeof viewTypes)[number];
@@ -278,6 +282,17 @@ export type AlertsMetadata = {
 export type AlertsData = {
   mostRecentAlerts: FeatureCollection;
   previousAlerts: FeatureCollection;
+};
+
+export type HaloEntry = {
+  map: MapboxMap;
+  id: string;
+};
+
+export type PulsingHaloLayerOptions = {
+  unclusteredRadius: number;
+  clusterRadius: ExpressionSpecification;
+  maxzoom?: number;
 };
 
 export type AlertsPerMonth = Record<string, number>;

--- a/utils/pulsingHalo.ts
+++ b/utils/pulsingHalo.ts
@@ -1,7 +1,4 @@
-import type {
-  ExpressionSpecification,
-  Map as MapboxMap,
-} from "mapbox-gl";
+import type { ExpressionSpecification, Map as MapboxMap } from "mapbox-gl";
 
 const PULSE_DURATION_MS = 2000;
 const HALO_COLOR = "#FF0000";
@@ -62,7 +59,11 @@ const tick = () => {
       continue;
     }
     entry.map.setPaintProperty(entry.id, "circle-stroke-width", strokeWidth);
-    entry.map.setPaintProperty(entry.id, "circle-stroke-opacity", strokeOpacity);
+    entry.map.setPaintProperty(
+      entry.id,
+      "circle-stroke-opacity",
+      strokeOpacity,
+    );
   }
 
   animationFrame = haloEntries.length ? requestAnimationFrame(tick) : 0;
@@ -116,11 +117,7 @@ const addHaloCircleLayer = (
     });
     map.setPaintProperty(id, "circle-radius-transition", NO_TRANSITION);
     map.setPaintProperty(id, "circle-stroke-width-transition", NO_TRANSITION);
-    map.setPaintProperty(
-      id,
-      "circle-stroke-opacity-transition",
-      NO_TRANSITION,
-    );
+    map.setPaintProperty(id, "circle-stroke-opacity-transition", NO_TRANSITION);
   }
   registerHalo(map, id);
 };

--- a/utils/pulsingHalo.ts
+++ b/utils/pulsingHalo.ts
@@ -1,4 +1,5 @@
 import type { ExpressionSpecification, Map as MapboxMap } from "mapbox-gl";
+import type { HaloEntry, PulsingHaloLayerOptions } from "@/types";
 
 const PULSE_DURATION_MS = 2000;
 const HALO_COLOR = "#FF0000";
@@ -32,11 +33,6 @@ export const CENTROID_CLUSTER_HALO_RADIUS: ExpressionSpecification = [
   50,
   35,
 ];
-
-type HaloEntry = {
-  map: MapboxMap;
-  id: string;
-};
 
 const haloEntries: HaloEntry[] = [];
 let animationFrame = 0;
@@ -130,11 +126,7 @@ const addHaloCircleLayer = (
 export const addPulsingHaloLayers = (
   map: MapboxMap,
   sourceId: string,
-  options: {
-    unclusteredRadius: number;
-    clusterRadius: ExpressionSpecification;
-    maxzoom?: number;
-  },
+  options: PulsingHaloLayerOptions,
 ) => {
   addHaloCircleLayer(
     map,

--- a/utils/pulsingHalo.ts
+++ b/utils/pulsingHalo.ts
@@ -54,12 +54,16 @@ const tick = () => {
       haloEntries.splice(i, 1);
       continue;
     }
-    entry.map.setPaintProperty(entry.id, "circle-stroke-width", strokeWidth);
-    entry.map.setPaintProperty(
-      entry.id,
-      "circle-stroke-opacity",
-      strokeOpacity,
-    );
+    try {
+      entry.map.setPaintProperty(entry.id, "circle-stroke-width", strokeWidth);
+      entry.map.setPaintProperty(
+        entry.id,
+        "circle-stroke-opacity",
+        strokeOpacity,
+      );
+    } catch {
+      haloEntries.splice(i, 1);
+    }
   }
 
   animationFrame = haloEntries.length ? requestAnimationFrame(tick) : 0;
@@ -75,12 +79,21 @@ const registerHalo = (map: MapboxMap, id: string) => {
   if (!haloEntries.some((entry) => entry.map === map && entry.id === id)) {
     haloEntries.push({ map, id });
   }
+};
+
+/** Starts the pulse after the map can go idle (legend / e2e map-ready). */
+export const startPulsingHalo = () => {
   ensureAnimation();
 };
 
-export const stopPulsingHalo = () => {
+/** Stops paint updates so Mapbox can fire `idle`, without dropping layer ids. */
+export const pausePulsingHalo = () => {
   if (animationFrame) cancelAnimationFrame(animationFrame);
   animationFrame = 0;
+};
+
+export const stopPulsingHalo = () => {
+  pausePulsingHalo();
   haloEntries.length = 0;
 };
 

--- a/utils/pulsingHalo.ts
+++ b/utils/pulsingHalo.ts
@@ -1,0 +1,158 @@
+import type {
+  ExpressionSpecification,
+  Map as MapboxMap,
+} from "mapbox-gl";
+
+const PULSE_DURATION_MS = 2000;
+const HALO_COLOR = "#FF0000";
+const HALO_GAP_PX = 4;
+const STROKE_WIDTH_START = 4;
+const STROKE_WIDTH_END = 10;
+const NO_TRANSITION = { duration: 0, delay: 0 };
+
+/** Matches most-recent unclustered point radius (5px). */
+export const POINT_HALO_RADIUS = 5;
+/** Same steps as most-recent-alerts-point-clusters circle-radius. */
+export const POINT_CLUSTER_HALO_RADIUS: ExpressionSpecification = [
+  "step",
+  ["get", "point_count"],
+  10,
+  10,
+  20,
+  50,
+  30,
+];
+
+/** Matches most-recent unclustered centroid radius (8px). */
+export const CENTROID_HALO_RADIUS = 8;
+/** Same steps as most-recent-alerts-centroids-clusters circle-radius. */
+export const CENTROID_CLUSTER_HALO_RADIUS: ExpressionSpecification = [
+  "step",
+  ["get", "point_count"],
+  15,
+  10,
+  25,
+  50,
+  35,
+];
+
+type HaloEntry = {
+  map: MapboxMap;
+  id: string;
+};
+
+const haloEntries: HaloEntry[] = [];
+let animationFrame = 0;
+
+const withGap = (
+  base: number | ExpressionSpecification,
+): number | ExpressionSpecification =>
+  typeof base === "number" ? base + HALO_GAP_PX : ["+", HALO_GAP_PX, base];
+
+const tick = () => {
+  const t = (performance.now() % PULSE_DURATION_MS) / PULSE_DURATION_MS;
+  const strokeWidth =
+    STROKE_WIDTH_START + (STROKE_WIDTH_END - STROKE_WIDTH_START) * t;
+  const strokeOpacity = 1 - t;
+
+  for (let i = haloEntries.length - 1; i >= 0; i--) {
+    const entry = haloEntries[i];
+    if (!entry.map.getLayer(entry.id)) {
+      haloEntries.splice(i, 1);
+      continue;
+    }
+    entry.map.setPaintProperty(entry.id, "circle-stroke-width", strokeWidth);
+    entry.map.setPaintProperty(entry.id, "circle-stroke-opacity", strokeOpacity);
+  }
+
+  animationFrame = haloEntries.length ? requestAnimationFrame(tick) : 0;
+};
+
+const ensureAnimation = () => {
+  if (!animationFrame && haloEntries.length) {
+    animationFrame = requestAnimationFrame(tick);
+  }
+};
+
+const registerHalo = (map: MapboxMap, id: string) => {
+  if (!haloEntries.some((entry) => entry.map === map && entry.id === id)) {
+    haloEntries.push({ map, id });
+  }
+  ensureAnimation();
+};
+
+export const stopPulsingHalo = () => {
+  if (animationFrame) cancelAnimationFrame(animationFrame);
+  animationFrame = 0;
+  haloEntries.length = 0;
+};
+
+const addHaloCircleLayer = (
+  map: MapboxMap,
+  id: string,
+  sourceId: string,
+  filter: ExpressionSpecification,
+  baseRadius: number | ExpressionSpecification,
+  maxzoom?: number,
+) => {
+  if (!map.getLayer(id)) {
+    map.addLayer({
+      id,
+      type: "circle",
+      source: sourceId,
+      filter,
+      ...(maxzoom != null ? { maxzoom } : {}),
+      paint: {
+        "circle-color": HALO_COLOR,
+        "circle-radius": withGap(baseRadius),
+        "circle-opacity": 0,
+        "circle-stroke-width": STROKE_WIDTH_START,
+        "circle-stroke-color": HALO_COLOR,
+        "circle-stroke-opacity": 1,
+        "circle-radius-transition": NO_TRANSITION,
+        "circle-stroke-width-transition": NO_TRANSITION,
+        "circle-stroke-opacity-transition": NO_TRANSITION,
+      },
+    });
+    map.setPaintProperty(id, "circle-radius-transition", NO_TRANSITION);
+    map.setPaintProperty(id, "circle-stroke-width-transition", NO_TRANSITION);
+    map.setPaintProperty(
+      id,
+      "circle-stroke-opacity-transition",
+      NO_TRANSITION,
+    );
+  }
+  registerHalo(map, id);
+};
+
+/**
+ * Adds a red ring under most-recent alert dots and clusters.
+ * Radius stays locked to the marker size so every cluster gets a ring;
+ * only stroke width/opacity pulse, which avoids Mapbox expression crossfades.
+ */
+export const addPulsingHaloLayers = (
+  map: MapboxMap,
+  sourceId: string,
+  options: {
+    unclusteredRadius: number;
+    clusterRadius: ExpressionSpecification;
+    maxzoom?: number;
+  },
+) => {
+  addHaloCircleLayer(
+    map,
+    `${sourceId}-clusters-halo`,
+    sourceId,
+    ["has", "point_count"],
+    options.clusterRadius,
+    options.maxzoom,
+  );
+  addHaloCircleLayer(
+    map,
+    `${sourceId}-halo`,
+    sourceId,
+    ["!", ["has", "point_count"]],
+    options.unclusteredRadius,
+    options.maxzoom,
+  );
+};


### PR DESCRIPTION
## Goal

Closes #587.

Bring back the expanding red halo on most recent alerts (individual dots and clusters) so they read as urgent again. Clustering had dropped the old DOM pulse in favor of static red markers.

## Screenshots

<img width="334" height="292" alt="image" src="https://github.com/user-attachments/assets/d9b126ab-541b-4831-83b1-f7fc1515968b" />

## What I changed and why

- Added Mapbox circle halo layers under most-recent alert points, clusters, and centroids.
- Radius stays locked to the marker size (plus a small gap). Only stroke width and opacity animate over 2s, so the ring stays tight and does not jump or restart halfway.
- Halo layers follow the most-recent legend visibility toggle and are excluded from click/hover handling.
- Animation is stopped when the dashboard unmounts.

## How I convinced myself this is right

- Runtime and tests

## What I'm not doing here

## LLM use disclosure

Cursor Auto agent.