### PR TITLE
Playwright API tests should insert and tear down their own data

### DIFF
--- a/tests/e2e/12-view-dataset-api.spec.ts
+++ b/tests/e2e/12-view-dataset-api.spec.ts
@@ -1,74 +1,162 @@
 import { test, expect } from "@/tests/e2e/fixtures/auth-storage";
+import {
+  createApiTestView,
+  deleteApiTestView,
+} from "@/tests/e2e/helpers/apiTestData";
+import { VIEW_CONFIG_MISSING_COLUMNS_ERROR, type ApiTestView } from "@/types";
 
-test("GET /api/seed_survey_data/gallery returns the seeded gallery dataset contract", async ({
-  authenticatedRequestAsAdmin: request,
-}) => {
-  const response = await request.get("/api/seed_survey_data/gallery");
-  expect(response.status()).toBe(200);
+test.describe("gallery dataset API", () => {
+  let view: ApiTestView | null = null;
 
-  const body = await response.json();
-  expect(body.primary_dataset).toBe("seed_survey_data");
-  expect(body.table).toBe(body.primary_dataset);
-  expect(body.filterColumn).toBe("community");
-  expect(body.routeLevelPermission).toBe("anyone");
-  expect(typeof body.rowLimitReached).toBe("boolean");
-  expect(body.allowedFileExtensions).toEqual(
-    expect.objectContaining({
-      image: expect.any(Array),
-      audio: expect.any(Array),
-      video: expect.any(Array),
-    }),
-  );
+  test.beforeAll(async () => {
+    view = await createApiTestView({
+      sourceTable: "seed_survey_data",
+      viewConfig: {
+        FRONT_END_FILTER_COLUMN: "community",
+        MEDIA_COLUMN: "photo",
+        ROUTE_LEVEL_PERMISSION: "member",
+      },
+      viewType: "gallery",
+    });
+  });
 
-  expect(Array.isArray(body.data)).toBe(true);
-  expect(body.data.length).toBeGreaterThan(0);
-  for (const item of body.data) {
-    expect(item).toEqual(
+  test.afterAll(async () => {
+    if (view) await deleteApiTestView(view);
+  });
+
+  test("returns the gallery dataset contract", async ({
+    authenticatedRequestAsAdmin: request,
+  }) => {
+    if (!view) throw new Error("Gallery API test view was not created");
+
+    const response = await request.get(
+      `/api/${view.primaryDataset}/${view.viewType}`,
+    );
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.primary_dataset).toBe(view.primaryDataset);
+    expect(body.table).toBe(body.primary_dataset);
+    expect(body.filterColumn).toBe("community");
+    expect(body.routeLevelPermission).toBe("member");
+    expect(typeof body.rowLimitReached).toBe("boolean");
+    expect(body.allowedFileExtensions).toEqual(
       expect.objectContaining({
-        _id: expect.any(String),
+        image: expect.any(Array),
+        audio: expect.any(Array),
+        video: expect.any(Array),
       }),
     );
-  }
-  expect(
-    body.data.some(
-      (item: Record<string, unknown>) =>
-        typeof item.photo === "string" || typeof item.audio === "string",
-    ),
-  ).toBe(true);
+
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThan(0);
+    for (const item of body.data) {
+      expect(item).toEqual(
+        expect.objectContaining({
+          _id: expect.any(String),
+        }),
+      );
+    }
+    expect(
+      body.data.some(
+        (item: Record<string, unknown>) =>
+          typeof item.photo === "string" || typeof item.audio === "string",
+      ),
+    ).toBe(true);
+  });
 });
 
-test("GET /api/bcmform_responses/map returns the seeded map dataset contract", async ({
-  authenticatedRequestAsAdmin: request,
-}) => {
-  const response = await request.get("/api/bcmform_responses/map");
-  expect(response.status()).toBe(200);
+test.describe("map dataset API", () => {
+  let view: ApiTestView | null = null;
 
-  const body = await response.json();
-  expect(body.primary_dataset).toBe("bcmform_responses");
-  expect(body.table).toBe(body.primary_dataset);
-  expect(body.filterColumn).toBe("community");
-  expect(typeof body.rowLimitReached).toBe("boolean");
-  expect(body.mapboxLatitude).toEqual(expect.any(Number));
-  expect(body.mapboxLongitude).toEqual(expect.any(Number));
-  expect(body.mapboxZoom).toEqual(expect.any(Number));
-  expect(body.mapStatistics).toEqual(
-    expect.objectContaining({
-      totalFeatures: expect.any(Number),
-    }),
-  );
+  test.beforeAll(async () => {
+    view = await createApiTestView({
+      sourceTable: "bcmform_responses",
+      viewConfig: {
+        FRONT_END_FILTER_COLUMN: "community",
+        MAPBOX_CENTER_LATITUDE: "3.44704",
+        MAPBOX_CENTER_LONGITUDE: "-76.53995",
+        MAPBOX_ZOOM: 16,
+        ROUTE_LEVEL_PERMISSION: "member",
+      },
+      viewType: "map",
+    });
+  });
 
-  expect(body.data).toEqual(
-    expect.objectContaining({
-      type: "FeatureCollection",
-      features: expect.any(Array),
-    }),
-  );
-  expect(body.data.features.length).toBeGreaterThan(0);
-  expect(body.data.features[0]).toEqual(
-    expect.objectContaining({
-      type: "Feature",
-      geometry: expect.any(Object),
-      properties: expect.any(Object),
-    }),
-  );
+  test.afterAll(async () => {
+    if (view) await deleteApiTestView(view);
+  });
+
+  test("returns the map dataset contract", async ({
+    authenticatedRequestAsAdmin: request,
+  }) => {
+    if (!view) throw new Error("Map API test view was not created");
+
+    const response = await request.get(
+      `/api/${view.primaryDataset}/${view.viewType}`,
+    );
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.primary_dataset).toBe(view.primaryDataset);
+    expect(body.table).toBe(body.primary_dataset);
+    expect(body.filterColumn).toBe("community");
+    expect(typeof body.rowLimitReached).toBe("boolean");
+    expect(body.mapboxLatitude).toEqual(expect.any(Number));
+    expect(body.mapboxLongitude).toEqual(expect.any(Number));
+    expect(body.mapboxZoom).toEqual(expect.any(Number));
+    expect(body.mapStatistics).toEqual(
+      expect.objectContaining({
+        totalFeatures: expect.any(Number),
+      }),
+    );
+
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        type: "FeatureCollection",
+        features: expect.any(Array),
+      }),
+    );
+    expect(body.data.features.length).toBeGreaterThan(0);
+    expect(body.data.features[0]).toEqual(
+      expect.objectContaining({
+        type: "Feature",
+        geometry: expect.any(Object),
+        properties: expect.any(Object),
+      }),
+    );
+  });
+});
+
+test.describe("invalid view config", () => {
+  let view: ApiTestView | null = null;
+
+  test.beforeAll(async () => {
+    view = await createApiTestView({
+      sourceTable: "bcmform_responses",
+      viewConfig: {
+        COLOR_COLUMN: "missing_api_test_column",
+        ROUTE_LEVEL_PERMISSION: "member",
+      },
+      viewType: "map",
+    });
+  });
+
+  test.afterAll(async () => {
+    if (view) await deleteApiTestView(view);
+  });
+
+  test("returns 422 when a configured column is missing", async ({
+    authenticatedRequestAsAdmin: request,
+  }) => {
+    if (!view) throw new Error("Invalid-config API test view was not created");
+
+    const response = await request.get(
+      `/api/${view.primaryDataset}/${view.viewType}`,
+    );
+    expect(response.status()).toBe(422);
+    expect(JSON.stringify(await response.json())).toContain(
+      VIEW_CONFIG_MISSING_COLUMNS_ERROR,
+    );
+  });
 });

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,7 +2,10 @@ import { config } from "dotenv";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import postgres from "postgres";
+import {
+  createTestDatabaseClient,
+  TEST_CONFIG_DATABASE,
+} from "./helpers/testDatabase";
 import { isNuxtTestEnv } from "../../utils/nuxtTestEnv";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -12,14 +15,6 @@ config({ path: resolve(projectRoot, ".env.test.playwright") });
 
 // Must match docker-compose.tests.yml (database service + guardianconnector DB).
 const TEST_BACKEND_URL = "http://localhost:8080";
-const TEST_DB = {
-  host: "127.0.0.1",
-  port: 5433,
-  user: "testuser",
-  password: "testpassword",
-  database: "guardianconnector",
-} as const;
-
 async function waitForBackend(timeoutMs = 120_000) {
   const deadline = Date.now() + timeoutMs;
 
@@ -49,15 +44,7 @@ export default async function globalSetup() {
 
   await waitForBackend();
 
-  const sql = postgres({
-    host: TEST_DB.host,
-    port: TEST_DB.port,
-    database: TEST_DB.database,
-    username: TEST_DB.user,
-    password: TEST_DB.password,
-    ssl: false,
-    max: 1,
-  });
+  const sql = createTestDatabaseClient(TEST_CONFIG_DATABASE);
 
   try {
     await sql.unsafe(readFileSync(seedPath, "utf-8"));

--- a/tests/e2e/helpers/apiTestData.ts
+++ b/tests/e2e/helpers/apiTestData.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from "node:crypto";
+
+import type { ApiTestView, ApiTestViewInput } from "@/types";
+import {
+  createTestDatabaseClient,
+  TEST_CONFIG_DATABASE,
+  TEST_WAREHOUSE_DATABASE,
+} from "./testDatabase";
+
+const quoteIdentifier = (value: string): string =>
+  `"${value.replaceAll('"', '""')}"`;
+
+/**
+ * Creates a unique warehouse table and its matching view row for one API test.
+ *
+ * @param input - Source table and view fields needed by the test.
+ * @returns {Promise<ApiTestView>} Identity used by the route and teardown.
+ */
+export const createApiTestView = async (
+  input: ApiTestViewInput,
+): Promise<ApiTestView> => {
+  const primaryDataset = `api_test_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+  const configSql = createTestDatabaseClient(TEST_CONFIG_DATABASE);
+  const warehouseSql = createTestDatabaseClient(TEST_WAREHOUSE_DATABASE);
+
+  try {
+    await warehouseSql.unsafe(
+      `CREATE TABLE ${quoteIdentifier(primaryDataset)} AS TABLE ${quoteIdentifier(input.sourceTable)}`,
+    );
+    await configSql`
+      INSERT INTO views (
+        view_name,
+        view_type,
+        primary_dataset,
+        secondary_dataset,
+        view_config
+      )
+      VALUES (
+        ${primaryDataset},
+        ${input.viewType},
+        ${primaryDataset},
+        ${input.secondaryDataset ?? null},
+        ${JSON.stringify(input.viewConfig)}
+      )
+    `;
+
+    return {
+      primaryDataset,
+      secondaryDataset: input.secondaryDataset ?? null,
+      viewType: input.viewType,
+    };
+  } catch (error) {
+    await configSql`
+      DELETE FROM views
+      WHERE primary_dataset = ${primaryDataset}
+    `;
+    await warehouseSql.unsafe(
+      `DROP TABLE IF EXISTS ${quoteIdentifier(primaryDataset)}`,
+    );
+    throw error;
+  } finally {
+    await Promise.all([
+      configSql.end({ timeout: 5 }),
+      warehouseSql.end({ timeout: 5 }),
+    ]);
+  }
+};
+
+/**
+ * Deletes one test-owned view row and its copied warehouse table.
+ *
+ * @param view - Identity returned by createApiTestView.
+ * @returns {Promise<void>}
+ */
+export const deleteApiTestView = async (view: ApiTestView): Promise<void> => {
+  const configSql = createTestDatabaseClient(TEST_CONFIG_DATABASE);
+  const warehouseSql = createTestDatabaseClient(TEST_WAREHOUSE_DATABASE);
+
+  try {
+    await configSql`
+      DELETE FROM views
+      WHERE primary_dataset = ${view.primaryDataset}
+        AND view_type = ${view.viewType}
+    `;
+    await warehouseSql.unsafe(
+      `DROP TABLE IF EXISTS ${quoteIdentifier(view.primaryDataset)}`,
+    );
+  } finally {
+    await Promise.all([
+      configSql.end({ timeout: 5 }),
+      warehouseSql.end({ timeout: 5 }),
+    ]);
+  }
+};

--- a/tests/e2e/helpers/apiTestData.ts
+++ b/tests/e2e/helpers/apiTestData.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
 
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+
+import { viewConfig as viewsTable } from "@/server/database/schemas/viewConfig";
 import type { ApiTestView, ApiTestViewInput } from "@/types";
 import {
   createTestDatabaseClient,
@@ -21,28 +25,20 @@ export const createApiTestView = async (
 ): Promise<ApiTestView> => {
   const primaryDataset = `api_test_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
   const configSql = createTestDatabaseClient(TEST_CONFIG_DATABASE);
+  const configDb = drizzle(configSql);
   const warehouseSql = createTestDatabaseClient(TEST_WAREHOUSE_DATABASE);
 
   try {
     await warehouseSql.unsafe(
       `CREATE TABLE ${quoteIdentifier(primaryDataset)} AS TABLE ${quoteIdentifier(input.sourceTable)}`,
     );
-    await configSql`
-      INSERT INTO views (
-        view_name,
-        view_type,
-        primary_dataset,
-        secondary_dataset,
-        view_config
-      )
-      VALUES (
-        ${primaryDataset},
-        ${input.viewType},
-        ${primaryDataset},
-        ${input.secondaryDataset ?? null},
-        ${JSON.stringify(input.viewConfig)}
-      )
-    `;
+    await configDb.insert(viewsTable).values({
+      primaryDataset,
+      secondaryDataset: input.secondaryDataset ?? null,
+      viewConfig: JSON.stringify(input.viewConfig),
+      viewName: primaryDataset,
+      viewType: input.viewType,
+    });
 
     return {
       primaryDataset,
@@ -50,10 +46,9 @@ export const createApiTestView = async (
       viewType: input.viewType,
     };
   } catch (error) {
-    await configSql`
-      DELETE FROM views
-      WHERE primary_dataset = ${primaryDataset}
-    `;
+    await configDb
+      .delete(viewsTable)
+      .where(eq(viewsTable.primaryDataset, primaryDataset));
     await warehouseSql.unsafe(
       `DROP TABLE IF EXISTS ${quoteIdentifier(primaryDataset)}`,
     );
@@ -74,14 +69,18 @@ export const createApiTestView = async (
  */
 export const deleteApiTestView = async (view: ApiTestView): Promise<void> => {
   const configSql = createTestDatabaseClient(TEST_CONFIG_DATABASE);
+  const configDb = drizzle(configSql);
   const warehouseSql = createTestDatabaseClient(TEST_WAREHOUSE_DATABASE);
 
   try {
-    await configSql`
-      DELETE FROM views
-      WHERE primary_dataset = ${view.primaryDataset}
-        AND view_type = ${view.viewType}
-    `;
+    await configDb
+      .delete(viewsTable)
+      .where(
+        and(
+          eq(viewsTable.primaryDataset, view.primaryDataset),
+          eq(viewsTable.viewType, view.viewType),
+        ),
+      );
     await warehouseSql.unsafe(
       `DROP TABLE IF EXISTS ${quoteIdentifier(view.primaryDataset)}`,
     );

--- a/tests/e2e/helpers/testDatabase.ts
+++ b/tests/e2e/helpers/testDatabase.ts
@@ -1,0 +1,25 @@
+import postgres from "postgres";
+
+export const TEST_DB_HOST = "127.0.0.1";
+export const TEST_DB_PORT = 5433;
+export const TEST_DB_USER = "testuser";
+export const TEST_DB_PASSWORD = "testpassword";
+export const TEST_CONFIG_DATABASE = "guardianconnector";
+export const TEST_WAREHOUSE_DATABASE = "test_warehouse";
+
+/**
+ * Creates a single-connection client for a Docker test database.
+ *
+ * @param database - Database name on the test Postgres service.
+ * @returns Postgres client for test setup or teardown.
+ */
+export const createTestDatabaseClient = (database: string) =>
+  postgres({
+    host: TEST_DB_HOST,
+    port: TEST_DB_PORT,
+    database,
+    username: TEST_DB_USER,
+    password: TEST_DB_PASSWORD,
+    ssl: false,
+    max: 1,
+  });

--- a/types/index.ts
+++ b/types/index.ts
@@ -198,6 +198,19 @@ export type ViewConfigRow = {
   viewConfig: ViewConfig;
 };
 
+export type ApiTestViewInput = {
+  secondaryDataset?: string | null;
+  sourceTable: string;
+  viewConfig: ViewConfig;
+  viewType: ViewType;
+};
+
+export type ApiTestView = {
+  primaryDataset: string;
+  secondaryDataset: string | null;
+  viewType: ViewType;
+};
+
 export type ViewTables = {
   primaryTable: string;
   secondaryTable: string | null;


### PR DESCRIPTION
## Goal

Make API test create and remove its own database records so test runs do not depend on shared view configurations. Closes #627 

## Screenshots

Not applicable. 

## What I changed and why

I added shared Docker test database settings and helpers that create a unique warehouse table and matching view row for each API test in `gc-exp/tests/e2e/12-view-dataset-api.spec.ts` (our only API test for now). The helpers delete both resources after each test group. I updated the gallery and map API tests to use these fixtures and added coverage for a view configuration that refers to a missing column.

## How I convinced myself this is right

I ran the updated API spec against the Docker Compose stack. All seven setup and API tests passed, including the new 422 case. After the run, I queried the config and warehouse databases and confirmed that no `api_test_` rows or tables remained. 

## What I'm not doing here

This change does not modify browser E2E fixtures or remove the global database seed. It does not change application API behavior or production database code.

## LLM use disclosure

GPT Sol 5.6 Helped