### PR TITLE
Make public access view-specific

### DIFF
--- a/middleware/oauth.global.ts
+++ b/middleware/oauth.global.ts
@@ -1,5 +1,10 @@
 import { defineNuxtRouteMiddleware, useRuntimeConfig } from "#imports";
-import type { User, RouteLevelPermission } from "@/types";
+import type {
+  PublicViewRow,
+  RouteLevelPermission,
+  User,
+  ViewType,
+} from "@/types";
 import { Role } from "@/types";
 import { decodeDatasetNameFromUrl } from "@/utils/identifierUtils";
 
@@ -45,11 +50,19 @@ export default defineNuxtRouteMiddleware(async (to) => {
           ? to.params.tablename
           : to.path.split("/").pop()!;
       const tableName = decodeDatasetNameFromUrl(rawTableName);
-      const publicTableNames = await $fetch<string[]>(
+      const viewType = to.path.split("/")[1] as ViewType;
+      const publicViews = await $fetch<PublicViewRow[]>(
         "/api/config/public_views",
       );
       // Public access: no login needed
-      if (publicTableNames.includes(tableName)) return;
+      if (
+        publicViews.some(
+          (view) =>
+            view.primaryDataset === tableName && view.viewType === viewType,
+        )
+      ) {
+        return;
+      }
 
       // Require authentication
       if (!loggedIn.value) {
@@ -62,10 +75,12 @@ export default defineNuxtRouteMiddleware(async (to) => {
         views: Array<{
           primaryDataset: string;
           viewConfig: { ROUTE_LEVEL_PERMISSION?: RouteLevelPermission };
+          viewType: ViewType;
         }>;
       }>("/api/config");
       const viewEntry = response.views?.find(
-        (view) => view.primaryDataset === tableName,
+        (view) =>
+          view.primaryDataset === tableName && view.viewType === viewType,
       );
       const permission: RouteLevelPermission =
         viewEntry?.viewConfig?.ROUTE_LEVEL_PERMISSION ?? "member";

--- a/server/api/config/public_views.get.ts
+++ b/server/api/config/public_views.get.ts
@@ -1,9 +1,9 @@
-import { fetchPublicViewTableNames } from "@/server/database/dbOperations";
+import { fetchPublicViews } from "@/server/database/dbOperations";
 
 /**
- * Open API: returns list of table names that are public (no auth required).
+ * Open API: returns stable identities for public views (no auth required).
  * Used by middleware to allow unauthenticated access to public dataset routes.
  */
 export default defineEventHandler(async () => {
-  return await fetchPublicViewTableNames();
+  return await fetchPublicViews();
 });

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -5,6 +5,7 @@ import {
   type ColumnEntry,
   type DataEntry,
   type FetchDataOptions,
+  type PublicViewRow,
   type RouteLevelPermission,
   type Views,
   type ViewConfig,
@@ -753,38 +754,43 @@ export const fetchViewConfigForDatasetRead = async (
 };
 
 /**
- * Keeps public_views in sync with view config: add table if permission is anyone, remove otherwise.
- * @param tableName - The table name to sync.
- * @param permission - The ROUTE_LEVEL_PERMISSION for that table.
+ * Keeps public_views in sync with one view's permission.
+ *
+ * @param viewId - View row to synchronize.
+ * @param permission - Current route-level permission.
+ * @returns {Promise<void>}
  */
 export const syncPublicViews = async (
-  tableName: string,
+  viewId: number,
   permission: RouteLevelPermission | undefined,
 ): Promise<void> => {
-  const normalizedTable = normalizeTableName(tableName);
   if (permission === "anyone") {
-    await configDb
-      .insert(publicViews)
-      .values({ tableName: normalizedTable })
-      .onConflictDoNothing();
+    await configDb.insert(publicViews).values({ viewId }).onConflictDoNothing();
   } else {
-    // Ensure table is not in public_views. If it was never there or already removed,
-    // delete affects 0 rows and does not throw; save flow continues normally.
-    await configDb
-      .delete(publicViews)
-      .where(eq(publicViews.tableName, normalizedTable));
+    await configDb.delete(publicViews).where(eq(publicViews.viewId, viewId));
   }
 };
 
 /**
- * Returns the list of table names that are public (ROUTE_LEVEL_PERMISSION = anyone).
- * Used by the open public_views API for middleware auth bypass.
+ * Returns stable identities for views that allow public access.
+ *
+ * @returns {Promise<PublicViewRow[]>} Public view descriptors.
  */
-export const fetchPublicViewTableNames = async (): Promise<string[]> => {
+export const fetchPublicViews = async (): Promise<PublicViewRow[]> => {
   const rows = await configDb
-    .select({ tableName: publicViews.tableName })
-    .from(publicViews);
-  return rows.map((row) => normalizeTableName(row.tableName));
+    .select({
+      primaryDataset: viewConfig.primaryDataset,
+      viewId: viewConfig.viewId,
+      viewType: viewConfig.viewType,
+    })
+    .from(publicViews)
+    .innerJoin(viewConfig, eq(publicViews.viewId, viewConfig.viewId));
+
+  return rows.map((row) => ({
+    primaryDataset: normalizeTableName(row.primaryDataset),
+    viewId: row.viewId,
+    viewType: row.viewType as ViewType,
+  }));
 };
 
 /**
@@ -882,7 +888,7 @@ export const updateConfig = async (
       normalizedSecondary,
     );
 
-    await configDb
+    const updatedRows = await configDb
       .update(viewConfig)
       .set(viewColumns)
       .where(
@@ -890,9 +896,16 @@ export const updateConfig = async (
           eq(viewConfig.primaryDataset, normalizedTable),
           eq(viewConfig.viewType, viewType),
         ),
-      );
+      )
+      .returning({ viewId: viewConfig.viewId });
 
-    await syncPublicViews(normalizedTable, typedConfig.ROUTE_LEVEL_PERMISSION);
+    if (updatedRows.length === 0) {
+      throw createMissingViewConfigError(normalizedTable);
+    }
+    await syncPublicViews(
+      updatedRows[0].viewId,
+      typedConfig.ROUTE_LEVEL_PERMISSION,
+    );
   } catch (error) {
     console.error("Error updating config:", error);
     throw error;
@@ -926,14 +939,21 @@ export const addNewTableToConfig = async (
       viewType,
       normalizedSecondary,
     );
-    await configDb.insert(viewConfig).values({
-      ...buildViewConfigColumns(
-        normalizedTable,
-        config ?? {},
-        viewType,
-        normalizedSecondary,
-      ),
-    });
+    const insertedRows = await configDb
+      .insert(viewConfig)
+      .values({
+        ...buildViewConfigColumns(
+          normalizedTable,
+          config ?? {},
+          viewType,
+          normalizedSecondary,
+        ),
+      })
+      .returning({ viewId: viewConfig.viewId });
+    await syncPublicViews(
+      insertedRows[0].viewId,
+      config?.ROUTE_LEVEL_PERMISSION,
+    );
   } catch (error) {
     // (view_type, primary_dataset) is unique, so re-adding a view type the dataset
     // already has trips a 23505. Translate it into a clear 409 instead of leaking a
@@ -948,7 +968,6 @@ export const addNewTableToConfig = async (
 
 /**
  * Deletes the view config row for the given primary dataset and view type.
- * If that was the dataset's last remaining view, also removes it from public_views.
  *
  * @param {string} tableName - Primary dataset / table name.
  * @param {ViewType} viewType - View type whose config row to delete.
@@ -968,17 +987,6 @@ export const removeTableFromConfig = async (
           eq(viewConfig.viewType, viewType),
         ),
       );
-
-    // Only drop the dataset's public_views entry once no views remain for it.
-    const remainingViews = await configDb
-      .select({ viewId: viewConfig.viewId })
-      .from(viewConfig)
-      .where(eq(viewConfig.primaryDataset, normalizedTable));
-    if (remainingViews.length === 0) {
-      await configDb
-        .delete(publicViews)
-        .where(eq(publicViews.tableName, normalizedTable));
-    }
   } catch (error) {
     console.error("Error removing table from config:", error);
     throw error;

--- a/server/database/migrations/0014_public_views_by_view_id.sql
+++ b/server/database/migrations/0014_public_views_by_view_id.sql
@@ -1,0 +1,23 @@
+ALTER TABLE public.public_views
+    ADD COLUMN view_id integer;
+
+ALTER TABLE public.public_views
+    DROP CONSTRAINT public_views_pkey,
+    ALTER COLUMN table_name DROP NOT NULL;
+
+INSERT INTO public.public_views (view_id)
+SELECT view_id
+FROM public.views
+WHERE view_config::jsonb ->> 'ROUTE_LEVEL_PERMISSION' = 'anyone';
+
+DELETE FROM public.public_views
+WHERE view_id IS NULL;
+
+ALTER TABLE public.public_views
+    DROP COLUMN table_name,
+    ALTER COLUMN view_id SET NOT NULL,
+    ADD CONSTRAINT public_views_pkey PRIMARY KEY (view_id),
+    ADD CONSTRAINT public_views_view_id_views_view_id_fk
+        FOREIGN KEY (view_id)
+        REFERENCES public.views(view_id)
+        ON DELETE CASCADE;

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1787490000000,
       "tag": "0013_strip_unwanted_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1787821200000,
+      "tag": "0014_public_views_by_view_id",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schemas/publicViews.ts
+++ b/server/database/schemas/publicViews.ts
@@ -1,5 +1,8 @@
-import { pgTable, text } from "drizzle-orm/pg-core";
+import { integer, pgTable } from "drizzle-orm/pg-core";
+import { viewConfig } from "./viewConfig";
 
 export const publicViews = pgTable("public_views", {
-  tableName: text("table_name").primaryKey(),
+  viewId: integer("view_id")
+    .primaryKey()
+    .references(() => viewConfig.viewId, { onDelete: "cascade" }),
 });

--- a/tests/db-seed/guardianconnector.sql
+++ b/tests/db-seed/guardianconnector.sql
@@ -1,9 +1,6 @@
 -- Guardian Connector test fixtures (data only).
 -- DDL is owned by Drizzle migrations; applied after migrate in CI (see server/plugins/migrate.ts).
 
-INSERT INTO public_views (table_name) VALUES ('seed_survey_data') ON CONFLICT DO NOTHING;
-INSERT INTO public_views (table_name) VALUES ('fake_alerts') ON CONFLICT DO NOTHING;
-
 -- MAPBOX_STYLE uses a minimal local style object so E2E map load does not depend on
 -- remote Mapbox style API availability in CI.
 INSERT INTO views (view_name, view_type, primary_dataset, secondary_dataset, view_config) VALUES
@@ -43,3 +40,9 @@ INSERT INTO views (view_name, view_type, primary_dataset, secondary_dataset, vie
     '{"EMBED_MEDIA":"NO","MEDIA_BASE_PATH_ALERTS":"","MEDIA_BASE_PATH":"","MAPBOX_STYLE":{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#f8fafc"}}]},"MAPBOX_PROJECTION":"globe","MAPBOX_CENTER_LATITUDE":"1.20","MAPBOX_CENTER_LONGITUDE":"34.60","MAPBOX_ZOOM":8,"MAPBOX_PITCH":0,"MAPBOX_BEARING":0,"MAPBOX_3D":false,"FRONT_END_FILTER_COLUMN":"p__categoryid","SECONDARY_FILTER_VALUES":"threat","MAP_LEGEND_LAYER_IDS":"road-primary,aerialway","ALERT_RESOURCES":"NO","MAPBOX_ACCESS_TOKEN":"{MAPBOX_ACCESS_TOKEN}","PLANET_API_KEY":"{PLANET_API_KEY}","ROUTE_LEVEL_PERMISSION":"anyone"}'
   )
 ON CONFLICT (view_type, primary_dataset) DO NOTHING;
+
+INSERT INTO public_views (view_id)
+SELECT view_id
+FROM views
+WHERE view_config::jsonb ->> 'ROUTE_LEVEL_PERMISSION' = 'anyone'
+ON CONFLICT DO NOTHING;

--- a/tests/e2e/13-public-views-api.spec.ts
+++ b/tests/e2e/13-public-views-api.spec.ts
@@ -1,47 +1,99 @@
+import type { APIRequestContext } from "@playwright/test";
+
 import { test, expect } from "@/tests/e2e/fixtures/auth-storage";
 import {
   createApiTestView,
   deleteApiTestView,
 } from "@/tests/e2e/helpers/apiTestData";
-import type { PublicViewRow } from "@/types";
+import type { ApiTestView, PublicViewRow } from "@/types";
 
-test("public view synchronization isolates sibling view permissions", async ({
-  authenticatedRequestAsAdmin: request,
-}) => {
+/**
+ * Returns the public view list for the current admin session.
+ *
+ * @param {APIRequestContext} request - Authenticated Playwright request.
+ * @returns {Promise<PublicViewRow[]>} Public view rows.
+ */
+const listPublicViews = async (
+  request: APIRequestContext,
+): Promise<PublicViewRow[]> => {
+  const response = await request.get("/api/config/public_views");
+  expect(response.status()).toBe(200);
+  return (await response.json()) as PublicViewRow[];
+};
+
+/**
+ * Creates a member gallery and an anyone map on the same dataset.
+ *
+ * @param {APIRequestContext} request - Authenticated Playwright request.
+ * @returns {Promise<ApiTestView>} Gallery fixture to tear down after the map is deleted.
+ */
+const createMemberGalleryWithAnyoneMap = async (
+  request: APIRequestContext,
+): Promise<ApiTestView> => {
   const galleryView = await createApiTestView({
     sourceTable: "seed_survey_data",
     viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
     viewType: "gallery",
   });
-  const mapPath = `/api/config/delete_table/${galleryView.primaryDataset}?view_type=map`;
+  const createMapResponse = await request.post(
+    `/api/config/new_table/${galleryView.primaryDataset}?view_type=map`,
+    {
+      data: {
+        config: { ROUTE_LEVEL_PERMISSION: "anyone" },
+      },
+    },
+  );
+  expect(createMapResponse.status()).toBe(200);
+  return galleryView;
+};
+
+/**
+ * Deletes the map sibling, then the gallery warehouse fixture.
+ *
+ * @param {APIRequestContext} request - Authenticated Playwright request.
+ * @param {ApiTestView} galleryView - Gallery fixture created for the test.
+ * @returns {Promise<void>}
+ */
+const deleteGalleryAndMap = async (
+  request: APIRequestContext,
+  galleryView: ApiTestView,
+): Promise<void> => {
+  await request.post(
+    `/api/config/delete_table/${galleryView.primaryDataset}?view_type=map`,
+  );
+  await deleteApiTestView(galleryView);
+};
+
+test("anyone map is public when sibling gallery is member", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const galleryView = await createMemberGalleryWithAnyoneMap(request);
 
   try {
-    const createMapResponse = await request.post(
-      `/api/config/new_table/${galleryView.primaryDataset}?view_type=map`,
-      {
-        data: {
-          config: { ROUTE_LEVEL_PERMISSION: "anyone" },
-        },
-      },
-    );
-    expect(createMapResponse.status()).toBe(200);
-
-    const initialPublicViews = (await (
-      await request.get("/api/config/public_views")
-    ).json()) as PublicViewRow[];
-    expect(initialPublicViews).toContainEqual(
+    const publicViews = await listPublicViews(request);
+    expect(publicViews).toContainEqual(
       expect.objectContaining({
         primaryDataset: galleryView.primaryDataset,
         viewType: "map",
       }),
     );
-    expect(initialPublicViews).not.toContainEqual(
+    expect(publicViews).not.toContainEqual(
       expect.objectContaining({
         primaryDataset: galleryView.primaryDataset,
         viewType: "gallery",
       }),
     );
+  } finally {
+    await deleteGalleryAndMap(request, galleryView);
+  }
+});
 
+test("anyone gallery is public without hiding sibling anyone map", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const galleryView = await createMemberGalleryWithAnyoneMap(request);
+
+  try {
     const updateGalleryResponse = await request.post(
       `/api/config/update_config/${galleryView.primaryDataset}?view_type=gallery`,
       {
@@ -52,19 +104,35 @@ test("public view synchronization isolates sibling view permissions", async ({
     );
     expect(updateGalleryResponse.status()).toBe(200);
 
-    const updatedPublicViews = (await (
-      await request.get("/api/config/public_views")
-    ).json()) as PublicViewRow[];
-    expect(
-      updatedPublicViews.filter(
-        (view) => view.primaryDataset === galleryView.primaryDataset,
-      ),
-    ).toEqual(
+    const publicViews = (await listPublicViews(request)).filter(
+      (view) => view.primaryDataset === galleryView.primaryDataset,
+    );
+    expect(publicViews).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ viewType: "gallery" }),
         expect.objectContaining({ viewType: "map" }),
       ]),
     );
+  } finally {
+    await deleteGalleryAndMap(request, galleryView);
+  }
+});
+
+test("member map is not public when sibling gallery stays anyone", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const galleryView = await createMemberGalleryWithAnyoneMap(request);
+
+  try {
+    const updateGalleryResponse = await request.post(
+      `/api/config/update_config/${galleryView.primaryDataset}?view_type=gallery`,
+      {
+        data: {
+          config: { ROUTE_LEVEL_PERMISSION: "anyone" },
+        },
+      },
+    );
+    expect(updateGalleryResponse.status()).toBe(200);
 
     const updateMapResponse = await request.post(
       `/api/config/update_config/${galleryView.primaryDataset}?view_type=map`,
@@ -76,23 +144,20 @@ test("public view synchronization isolates sibling view permissions", async ({
     );
     expect(updateMapResponse.status()).toBe(200);
 
-    const finalPublicViews = (await (
-      await request.get("/api/config/public_views")
-    ).json()) as PublicViewRow[];
-    expect(finalPublicViews).toContainEqual(
+    const publicViews = await listPublicViews(request);
+    expect(publicViews).toContainEqual(
       expect.objectContaining({
         primaryDataset: galleryView.primaryDataset,
         viewType: "gallery",
       }),
     );
-    expect(finalPublicViews).not.toContainEqual(
+    expect(publicViews).not.toContainEqual(
       expect.objectContaining({
         primaryDataset: galleryView.primaryDataset,
         viewType: "map",
       }),
     );
   } finally {
-    await request.post(mapPath);
-    await deleteApiTestView(galleryView);
+    await deleteGalleryAndMap(request, galleryView);
   }
 });

--- a/tests/e2e/13-public-views-api.spec.ts
+++ b/tests/e2e/13-public-views-api.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "@/tests/e2e/fixtures/auth-storage";
+import {
+  createApiTestView,
+  deleteApiTestView,
+} from "@/tests/e2e/helpers/apiTestData";
+import type { PublicViewRow } from "@/types";
+
+test("public view synchronization isolates sibling view permissions", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const galleryView = await createApiTestView({
+    sourceTable: "seed_survey_data",
+    viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
+    viewType: "gallery",
+  });
+  const mapPath = `/api/config/delete_table/${galleryView.primaryDataset}?view_type=map`;
+
+  try {
+    const createMapResponse = await request.post(
+      `/api/config/new_table/${galleryView.primaryDataset}?view_type=map`,
+      {
+        data: {
+          config: { ROUTE_LEVEL_PERMISSION: "anyone" },
+        },
+      },
+    );
+    expect(createMapResponse.status()).toBe(200);
+
+    const initialPublicViews = (await (
+      await request.get("/api/config/public_views")
+    ).json()) as PublicViewRow[];
+    expect(initialPublicViews).toContainEqual(
+      expect.objectContaining({
+        primaryDataset: galleryView.primaryDataset,
+        viewType: "map",
+      }),
+    );
+    expect(initialPublicViews).not.toContainEqual(
+      expect.objectContaining({
+        primaryDataset: galleryView.primaryDataset,
+        viewType: "gallery",
+      }),
+    );
+
+    const updateGalleryResponse = await request.post(
+      `/api/config/update_config/${galleryView.primaryDataset}?view_type=gallery`,
+      {
+        data: {
+          config: { ROUTE_LEVEL_PERMISSION: "anyone" },
+        },
+      },
+    );
+    expect(updateGalleryResponse.status()).toBe(200);
+
+    const updatedPublicViews = (await (
+      await request.get("/api/config/public_views")
+    ).json()) as PublicViewRow[];
+    expect(
+      updatedPublicViews.filter(
+        (view) => view.primaryDataset === galleryView.primaryDataset,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ viewType: "gallery" }),
+        expect.objectContaining({ viewType: "map" }),
+      ]),
+    );
+
+    const updateMapResponse = await request.post(
+      `/api/config/update_config/${galleryView.primaryDataset}?view_type=map`,
+      {
+        data: {
+          config: { ROUTE_LEVEL_PERMISSION: "member" },
+        },
+      },
+    );
+    expect(updateMapResponse.status()).toBe(200);
+
+    const finalPublicViews = (await (
+      await request.get("/api/config/public_views")
+    ).json()) as PublicViewRow[];
+    expect(finalPublicViews).toContainEqual(
+      expect.objectContaining({
+        primaryDataset: galleryView.primaryDataset,
+        viewType: "gallery",
+      }),
+    );
+    expect(finalPublicViews).not.toContainEqual(
+      expect.objectContaining({
+        primaryDataset: galleryView.primaryDataset,
+        viewType: "map",
+      }),
+    );
+  } finally {
+    await request.post(mapPath);
+    await deleteApiTestView(galleryView);
+  }
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -198,6 +198,11 @@ export type ViewConfigRow = {
   viewConfig: ViewConfig;
 };
 
+export type PublicViewRow = Pick<
+  ViewConfigRow,
+  "primaryDataset" | "viewId" | "viewType"
+>;
+
 export type ApiTestViewInput = {
   secondaryDataset?: string | null;
   sourceTable: string;


### PR DESCRIPTION

## Goal

> Part 1 of 3 for [#552: Refactor view configuration CRUD into a RESTful /api/views API](https://github.com/ConservationMetrics/gc-explorer/issues/552).

Make public access view-specific so views of the same dataset can have independent permissions.

## Screenshots

Not applicable 

## What I changed and why

- Changed `public_views` from dataset-name identity to `view_id`.
- Added an in-place migration that preserves the table and backfills public views from existing configuration.
- Added a cascading foreign key from `public_views.view_id` to `views.view_id`.
- Updated public-view synchronization to operate on individual views.
- Updated middleware to match both dataset and view type.
- Updated database fixtures for the new schema.
- Added Playwright coverage for sibling-view permission isolation.

A dataset can expose multiple view types with different permissions. Using only the dataset name could accidentally grant public access to a private sibling view.

## How I convinced myself this is right

ompose stack with the migration.
- Ran dataset API, public-view synchronization, and visibility Playwright tests against Docker.
- Verified public status changes affect only the selected view.

## What I'm not doing here

- Adding RESTful `/api/views` CRUD endpoints.
- Migrating configuration pages to the new API.
- Removing legacy `/api/config` controllers.

## LLM use disclosure

GPT Sol 5.6 helped