### PR TITLE
Add RESTful view config API

### DIFF
--- a/server/api/views/[view_id].delete.ts
+++ b/server/api/views/[view_id].delete.ts
@@ -1,0 +1,11 @@
+import { deleteView } from "@/server/database/dbOperations";
+import { parseViewId } from "@/server/utils/viewApi";
+import { validatePermissions } from "@/utils/accessControls";
+
+import type { H3Event } from "h3";
+
+export default defineEventHandler(async (event: H3Event) => {
+  await validatePermissions(event, "admin");
+  await deleteView(parseViewId(event));
+  setResponseStatus(event, 204);
+});

--- a/server/api/views/[view_id].get.ts
+++ b/server/api/views/[view_id].get.ts
@@ -1,0 +1,10 @@
+import { fetchViewConfigRow } from "@/server/database/dbOperations";
+import { parseViewId } from "@/server/utils/viewApi";
+import { validateUserSession } from "@/utils/accessControls";
+
+import type { H3Event } from "h3";
+
+export default defineEventHandler(async (event: H3Event) => {
+  await validateUserSession(event);
+  return await fetchViewConfigRow(parseViewId(event));
+});

--- a/server/api/views/[view_id].patch.ts
+++ b/server/api/views/[view_id].patch.ts
@@ -1,0 +1,12 @@
+import { updateView } from "@/server/database/dbOperations";
+import { parseUpdateViewBody, parseViewId } from "@/server/utils/viewApi";
+import { validatePermissions } from "@/utils/accessControls";
+
+import type { H3Event } from "h3";
+
+export default defineEventHandler(async (event: H3Event) => {
+  await validatePermissions(event, "admin");
+  const viewId = parseViewId(event);
+  const body = parseUpdateViewBody(await readBody(event));
+  return await updateView(viewId, body);
+});

--- a/server/api/views/[view_id].patch.ts
+++ b/server/api/views/[view_id].patch.ts
@@ -3,10 +3,11 @@ import { parseUpdateViewBody, parseViewId } from "@/server/utils/viewApi";
 import { validatePermissions } from "@/utils/accessControls";
 
 import type { H3Event } from "h3";
+import type { UpdateViewBody } from "@/types";
 
 export default defineEventHandler(async (event: H3Event) => {
   await validatePermissions(event, "admin");
   const viewId = parseViewId(event);
-  const body = parseUpdateViewBody(await readBody(event));
+  const body = parseUpdateViewBody(await readBody<UpdateViewBody>(event));
   return await updateView(viewId, body);
 });

--- a/server/api/views/index.get.ts
+++ b/server/api/views/index.get.ts
@@ -1,0 +1,21 @@
+import { fetchViewConfigRows } from "@/server/database/dbOperations";
+import { validateUserSession } from "@/utils/accessControls";
+
+import type { H3Event } from "h3";
+
+export default defineEventHandler(async (event: H3Event) => {
+  await validateUserSession(event);
+  const primaryDataset = getQuery(event).primary_dataset;
+
+  if (
+    primaryDataset !== undefined &&
+    (typeof primaryDataset !== "string" || primaryDataset.trim() === "")
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "primary_dataset must be a single non-empty value",
+    });
+  }
+
+  return await fetchViewConfigRows(primaryDataset);
+});

--- a/server/api/views/index.post.ts
+++ b/server/api/views/index.post.ts
@@ -3,10 +3,11 @@ import { parseCreateViewBody } from "@/server/utils/viewApi";
 import { validatePermissions } from "@/utils/accessControls";
 
 import type { H3Event } from "h3";
+import type { CreateViewBody } from "@/types";
 
 export default defineEventHandler(async (event: H3Event) => {
   await validatePermissions(event, "admin");
-  const body = parseCreateViewBody(await readBody(event));
+  const body = parseCreateViewBody(await readBody<CreateViewBody>(event));
   const view = await createView(body);
   setResponseStatus(event, 201);
   return view;

--- a/server/api/views/index.post.ts
+++ b/server/api/views/index.post.ts
@@ -1,0 +1,13 @@
+import { createView } from "@/server/database/dbOperations";
+import { parseCreateViewBody } from "@/server/utils/viewApi";
+import { validatePermissions } from "@/utils/accessControls";
+
+import type { H3Event } from "h3";
+
+export default defineEventHandler(async (event: H3Event) => {
+  await validatePermissions(event, "admin");
+  const body = parseCreateViewBody(await readBody(event));
+  const view = await createView(body);
+  setResponseStatus(event, 201);
+  return view;
+});

--- a/server/api/views/public.get.ts
+++ b/server/api/views/public.get.ts
@@ -1,0 +1,5 @@
+import { fetchPublicViews } from "@/server/database/dbOperations";
+
+export default defineEventHandler(async () => {
+  return await fetchPublicViews();
+});

--- a/server/api/warehouse/tables.get.ts
+++ b/server/api/warehouse/tables.get.ts
@@ -1,0 +1,14 @@
+import { getFilteredTableNames, getGeospatialTableNames } from "@/server/utils";
+import { validateUserSession } from "@/utils/accessControls";
+
+import type { H3Event } from "h3";
+
+export default defineEventHandler(async (event: H3Event) => {
+  await validateUserSession(event);
+  const [tables, geospatialTables] = await Promise.all([
+    getFilteredTableNames(),
+    getGeospatialTableNames(),
+  ]);
+
+  return { geospatialTables, tables };
+});

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -3,10 +3,12 @@ import { and, eq, sql } from "drizzle-orm";
 import {
   supportsSecondaryDataset,
   type ColumnEntry,
+  type CreateViewBody,
   type DataEntry,
   type FetchDataOptions,
   type PublicViewRow,
   type RouteLevelPermission,
+  type UpdateViewBody,
   type Views,
   type ViewConfig,
   type ViewConfigRow,
@@ -37,7 +39,7 @@ const createMissingViewConfigError = (table: string) => {
   return error;
 };
 
-const createInvalidConfigColumnsError = (message: string) => {
+const createBadRequestError = (message: string) => {
   const error = new Error(message) as Error & {
     statusCode: number;
     statusMessage: string;
@@ -57,14 +59,17 @@ const PG_UNIQUE_VIOLATION = "23505";
  * @returns {boolean} Whether the error is a unique violation.
  */
 const isUniqueViolation = (error: unknown): boolean =>
-  // `error` is `unknown` (catch clauses always are), so we cannot just read
-  // `error.code`. Each clause narrows the type step by step before that access is
-  // legal: it must be an object, not null (`typeof null === "object"`), and actually
-  // have a `code` property. Only then is reading `code` type-safe.
+  // Postgres errors expose SQLSTATE directly, while DrizzleQueryError wraps
+  // the underlying Postgres error in `cause`.
   typeof error === "object" &&
   error !== null &&
-  "code" in error &&
-  (error as { code?: unknown }).code === PG_UNIQUE_VIOLATION;
+  (("code" in error &&
+    (error as { code?: unknown }).code === PG_UNIQUE_VIOLATION) ||
+    ("cause" in error &&
+      typeof error.cause === "object" &&
+      error.cause !== null &&
+      "code" in error.cause &&
+      (error.cause as { code?: unknown }).code === PG_UNIQUE_VIOLATION));
 
 /**
  * Builds a 409-style error for adding a view type a dataset already exposes.
@@ -583,27 +588,46 @@ export const viewRowsToConfig = (rows: ViewConfigRow[]): Views => {
 };
 
 /**
+ * Maps one database view row to the public API shape.
+ *
+ * @param row - Raw row selected from the views table.
+ * @returns Parsed view configuration row.
+ */
+const mapViewConfigRow = (
+  row: typeof viewConfig.$inferSelect,
+): ViewConfigRow => ({
+  primaryDataset: normalizeTableName(row.primaryDataset),
+  secondaryDataset: row.secondaryDataset
+    ? normalizeTableName(row.secondaryDataset)
+    : row.secondaryDataset,
+  viewConfig: JSON.parse(row.viewConfig) as ViewConfig,
+  viewId: row.viewId,
+  viewName: row.viewName,
+  viewType: row.viewType as ViewType,
+});
+
+/**
  * Fetches each configured view as its own row with parsed JSON config.
  *
+ * @param {string} [primaryDataset] - Optional primary dataset filter.
  * @returns {Promise<ViewConfigRow[]>} View rows used by config management pages.
  */
-export const fetchViewConfigRows = async (): Promise<ViewConfigRow[]> => {
+export const fetchViewConfigRows = async (
+  primaryDataset?: string,
+): Promise<ViewConfigRow[]> => {
   try {
-    const result = await configDb.select().from(viewConfig);
+    const normalizedDataset = primaryDataset
+      ? normalizeTableName(primaryDataset)
+      : undefined;
+    const query = configDb.select().from(viewConfig).$dynamic();
+    const result = normalizedDataset
+      ? await query.where(eq(viewConfig.primaryDataset, normalizedDataset))
+      : await query;
 
-    return result.map((row) => ({
-      primaryDataset: normalizeTableName(row.primaryDataset),
-      secondaryDataset: row.secondaryDataset
-        ? normalizeTableName(row.secondaryDataset)
-        : row.secondaryDataset,
-      viewConfig: JSON.parse(row.viewConfig) as ViewConfig,
-      viewId: row.viewId,
-      viewName: row.viewName,
-      viewType: row.viewType as ViewType,
-    }));
+    return result.map(mapViewConfigRow);
   } catch (error) {
     console.error("Error fetching view config rows:", error);
-    return [];
+    throw error;
   }
 };
 
@@ -615,31 +639,32 @@ export const fetchViewConfigRows = async (): Promise<ViewConfigRow[]> => {
  */
 export const fetchViewConfigRowsForTable = async (
   primaryDataset: string,
-): Promise<ViewConfigRow[]> => {
-  const normalizedDataset = normalizeTableName(primaryDataset);
-  try {
-    const result = await configDb
-      .select()
-      .from(viewConfig)
-      .where(eq(viewConfig.primaryDataset, normalizedDataset));
+): Promise<ViewConfigRow[]> => fetchViewConfigRows(primaryDataset);
 
-    return result.map((row) => ({
-      primaryDataset: normalizeTableName(row.primaryDataset),
-      secondaryDataset: row.secondaryDataset
-        ? normalizeTableName(row.secondaryDataset)
-        : row.secondaryDataset,
-      viewConfig: JSON.parse(row.viewConfig) as ViewConfig,
-      viewId: row.viewId,
-      viewName: row.viewName,
-      viewType: row.viewType as ViewType,
-    }));
-  } catch (error) {
-    console.error(
-      `Error fetching view config rows for table "${normalizedDataset}":`,
-      error,
-    );
-    return [];
+/**
+ * Fetches one configured view by its stable ID.
+ *
+ * @param {number} viewId - Stable view row ID.
+ * @returns {Promise<ViewConfigRow>} Matching view row.
+ */
+export const fetchViewConfigRow = async (
+  viewId: number,
+): Promise<ViewConfigRow> => {
+  const result = await configDb
+    .select()
+    .from(viewConfig)
+    .where(eq(viewConfig.viewId, viewId))
+    .limit(1);
+
+  if (result.length === 0) {
+    const statusMessage = `View ${viewId} was not found`;
+    throw Object.assign(new Error(statusMessage), {
+      statusCode: 404,
+      statusMessage,
+    });
   }
+
+  return mapViewConfigRow(result[0]);
 };
 
 /**
@@ -831,7 +856,33 @@ const assertValidViewConfigColumns = async (
     ),
   ];
 
-  throw createInvalidConfigColumnsError(details.join("; "));
+  throw createBadRequestError(details.join("; "));
+};
+
+/**
+ * Validates text limits enforced by the configuration form.
+ *
+ * @param config - View configuration to validate.
+ * @returns {void}
+ */
+const assertViewConfigTextLimits = (config: ViewConfig): void => {
+  if (
+    config.DATASET_TABLE &&
+    config.DATASET_TABLE.length > CONFIG_LIMITS.DATASET_TABLE
+  ) {
+    throw createBadRequestError(
+      `DATASET_TABLE must be at most ${CONFIG_LIMITS.DATASET_TABLE} characters (received ${config.DATASET_TABLE.length})`,
+    );
+  }
+
+  if (
+    config.VIEW_DESCRIPTION &&
+    config.VIEW_DESCRIPTION.length > CONFIG_LIMITS.VIEW_DESCRIPTION
+  ) {
+    throw createBadRequestError(
+      `VIEW_DESCRIPTION must be at most ${CONFIG_LIMITS.VIEW_DESCRIPTION} characters (received ${config.VIEW_DESCRIPTION.length})`,
+    );
+  }
 };
 
 export const updateConfig = async (
@@ -848,24 +899,7 @@ export const updateConfig = async (
         : secondaryDataset;
     const typedConfig = config as ViewConfig;
 
-    // Validate character limits - check even if field exists as empty string
-    if (typedConfig.DATASET_TABLE) {
-      const datasetTableValue = String(typedConfig.DATASET_TABLE);
-      if (datasetTableValue.length > CONFIG_LIMITS.DATASET_TABLE) {
-        throw new Error(
-          `DATASET_TABLE must be at most ${CONFIG_LIMITS.DATASET_TABLE} characters (received ${datasetTableValue.length})`,
-        );
-      }
-    }
-
-    if (typedConfig.VIEW_DESCRIPTION) {
-      const viewDescriptionValue = String(typedConfig.VIEW_DESCRIPTION);
-      if (viewDescriptionValue.length > CONFIG_LIMITS.VIEW_DESCRIPTION) {
-        throw new Error(
-          `VIEW_DESCRIPTION must be at most ${CONFIG_LIMITS.VIEW_DESCRIPTION} characters (received ${viewDescriptionValue.length})`,
-        );
-      }
-    }
+    assertViewConfigTextLimits(typedConfig);
 
     // A view type is required: a dataset can have several views (e.g. map +
     // gallery), so we must identify exactly one (primary_dataset, view_type) row.
@@ -991,4 +1025,114 @@ export const removeTableFromConfig = async (
     console.error("Error removing table from config:", error);
     throw error;
   }
+};
+
+/**
+ * Creates one view resource and returns its stable identity.
+ *
+ * @param input - New view fields.
+ * @returns {Promise<ViewConfigRow>} Created view row.
+ */
+export const createView = async (
+  input: CreateViewBody,
+): Promise<ViewConfigRow> => {
+  const normalizedTable = normalizeTableName(input.primaryDataset);
+  const normalizedSecondary =
+    input.secondaryDataset != null && input.secondaryDataset !== ""
+      ? normalizeTableName(input.secondaryDataset)
+      : input.secondaryDataset;
+  const config = input.viewConfig ?? {};
+
+  try {
+    assertViewConfigTextLimits(config);
+    await assertValidViewConfigColumns(
+      normalizedTable,
+      config,
+      input.viewType,
+      normalizedSecondary,
+    );
+    const result = await configDb
+      .insert(viewConfig)
+      .values(
+        buildViewConfigColumns(
+          normalizedTable,
+          config,
+          input.viewType,
+          normalizedSecondary,
+        ),
+      )
+      .returning();
+    const createdView = mapViewConfigRow(result[0]);
+    await syncPublicViews(
+      createdView.viewId,
+      createdView.viewConfig.ROUTE_LEVEL_PERMISSION,
+    );
+    return createdView;
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw createDuplicateViewError(normalizedTable, input.viewType);
+    }
+    console.error("Error creating view:", error);
+    throw error;
+  }
+};
+
+/**
+ * Updates one view resource by stable ID.
+ *
+ * @param viewId - View row to update.
+ * @param input - Mutable view fields.
+ * @returns {Promise<ViewConfigRow>} Updated view row.
+ */
+export const updateView = async (
+  viewId: number,
+  input: UpdateViewBody,
+): Promise<ViewConfigRow> => {
+  const existingView = await fetchViewConfigRow(viewId);
+  const secondaryDataset =
+    input.secondaryDataset === undefined
+      ? existingView.secondaryDataset
+      : input.secondaryDataset;
+  const normalizedSecondary =
+    secondaryDataset != null && secondaryDataset !== ""
+      ? normalizeTableName(secondaryDataset)
+      : secondaryDataset;
+
+  assertViewConfigTextLimits(input.viewConfig);
+  await assertValidViewConfigColumns(
+    existingView.primaryDataset,
+    input.viewConfig,
+    existingView.viewType,
+    normalizedSecondary,
+  );
+
+  const result = await configDb
+    .update(viewConfig)
+    .set(
+      buildViewConfigColumns(
+        existingView.primaryDataset,
+        input.viewConfig,
+        existingView.viewType,
+        normalizedSecondary,
+      ),
+    )
+    .where(eq(viewConfig.viewId, viewId))
+    .returning();
+  const updatedView = mapViewConfigRow(result[0]);
+  await syncPublicViews(
+    updatedView.viewId,
+    updatedView.viewConfig.ROUTE_LEVEL_PERMISSION,
+  );
+  return updatedView;
+};
+
+/**
+ * Deletes one view resource by stable ID.
+ *
+ * @param viewId - View row to delete.
+ * @returns {Promise<void>}
+ */
+export const deleteView = async (viewId: number): Promise<void> => {
+  await fetchViewConfigRow(viewId);
+  await configDb.delete(viewConfig).where(eq(viewConfig.viewId, viewId));
 };

--- a/server/utils/viewApi.ts
+++ b/server/utils/viewApi.ts
@@ -1,15 +1,7 @@
 import { useAppConfig } from "#imports";
 import type { H3Event } from "h3";
 
-import type {
-  CreateViewBody,
-  UpdateViewBody,
-  ViewConfig,
-  ViewType,
-} from "@/types";
-
-const isObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+import type { CreateViewBody, UpdateViewBody } from "@/types";
 
 /**
  * Parses a positive integer view ID from the route.
@@ -39,18 +31,12 @@ export const parseViewId = (event: H3Event): number => {
  * @param value - Parsed request body.
  * @returns {CreateViewBody} Valid creation fields.
  */
-export const parseCreateViewBody = (value: unknown): CreateViewBody => {
-  if (!isObject(value)) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: "Request body must be an object",
-    });
-  }
-
-  const primaryDataset = value.primaryDataset;
-  const viewType = value.viewType;
-  const secondaryDataset = value.secondaryDataset;
-  const viewConfig = value.viewConfig;
+export const parseCreateViewBody = ({
+  primaryDataset,
+  secondaryDataset,
+  viewConfig,
+  viewType,
+}: CreateViewBody): CreateViewBody => {
   const viewTypes = useAppConfig().viewTypes as readonly string[];
 
   if (typeof primaryDataset !== "string" || primaryDataset.trim() === "") {
@@ -75,18 +61,12 @@ export const parseCreateViewBody = (value: unknown): CreateViewBody => {
       statusMessage: "secondaryDataset must be a string or null",
     });
   }
-  if (viewConfig !== undefined && !isObject(viewConfig)) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: "viewConfig must be an object",
-    });
-  }
 
   return {
     primaryDataset,
     secondaryDataset,
-    viewConfig: viewConfig as ViewConfig | undefined,
-    viewType: viewType as ViewType,
+    viewConfig,
+    viewType,
   };
 };
 
@@ -96,15 +76,10 @@ export const parseCreateViewBody = (value: unknown): CreateViewBody => {
  * @param value - Parsed request body.
  * @returns {UpdateViewBody} Valid update fields.
  */
-export const parseUpdateViewBody = (value: unknown): UpdateViewBody => {
-  if (!isObject(value) || !isObject(value.viewConfig)) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: "viewConfig is required and must be an object",
-    });
-  }
-
-  const secondaryDataset = value.secondaryDataset;
+export const parseUpdateViewBody = ({
+  secondaryDataset,
+  viewConfig,
+}: UpdateViewBody): UpdateViewBody => {
   if (
     secondaryDataset !== undefined &&
     secondaryDataset !== null &&
@@ -118,6 +93,6 @@ export const parseUpdateViewBody = (value: unknown): UpdateViewBody => {
 
   return {
     secondaryDataset,
-    viewConfig: value.viewConfig as ViewConfig,
+    viewConfig,
   };
 };

--- a/server/utils/viewApi.ts
+++ b/server/utils/viewApi.ts
@@ -1,0 +1,123 @@
+import { useAppConfig } from "#imports";
+import type { H3Event } from "h3";
+
+import type {
+  CreateViewBody,
+  UpdateViewBody,
+  ViewConfig,
+  ViewType,
+} from "@/types";
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Parses a positive integer view ID from the route.
+ *
+ * @param event - Request event with a view_id route parameter.
+ * @returns {number} Valid view ID.
+ */
+export const parseViewId = (event: H3Event): number => {
+  const rawViewId = event.context.params?.view_id;
+  if (
+    typeof rawViewId !== "string" ||
+    !/^\d+$/.test(rawViewId) ||
+    rawViewId === "0"
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "view_id must be a positive integer",
+    });
+  }
+
+  return parseInt(rawViewId, 10);
+};
+
+/**
+ * Validates a request body for view creation.
+ *
+ * @param value - Parsed request body.
+ * @returns {CreateViewBody} Valid creation fields.
+ */
+export const parseCreateViewBody = (value: unknown): CreateViewBody => {
+  if (!isObject(value)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Request body must be an object",
+    });
+  }
+
+  const primaryDataset = value.primaryDataset;
+  const viewType = value.viewType;
+  const secondaryDataset = value.secondaryDataset;
+  const viewConfig = value.viewConfig;
+  const viewTypes = useAppConfig().viewTypes as readonly string[];
+
+  if (typeof primaryDataset !== "string" || primaryDataset.trim() === "") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "primaryDataset is required",
+    });
+  }
+  if (typeof viewType !== "string" || !viewTypes.includes(viewType)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `viewType must be one of: ${viewTypes.join(", ")}`,
+    });
+  }
+  if (
+    secondaryDataset !== undefined &&
+    secondaryDataset !== null &&
+    typeof secondaryDataset !== "string"
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "secondaryDataset must be a string or null",
+    });
+  }
+  if (viewConfig !== undefined && !isObject(viewConfig)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "viewConfig must be an object",
+    });
+  }
+
+  return {
+    primaryDataset,
+    secondaryDataset,
+    viewConfig: viewConfig as ViewConfig | undefined,
+    viewType: viewType as ViewType,
+  };
+};
+
+/**
+ * Validates a request body for view updates.
+ *
+ * @param value - Parsed request body.
+ * @returns {UpdateViewBody} Valid update fields.
+ */
+export const parseUpdateViewBody = (value: unknown): UpdateViewBody => {
+  if (!isObject(value) || !isObject(value.viewConfig)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "viewConfig is required and must be an object",
+    });
+  }
+
+  const secondaryDataset = value.secondaryDataset;
+  if (
+    secondaryDataset !== undefined &&
+    secondaryDataset !== null &&
+    typeof secondaryDataset !== "string"
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "secondaryDataset must be a string or null",
+    });
+  }
+
+  return {
+    secondaryDataset,
+    viewConfig: value.viewConfig as ViewConfig,
+  };
+};

--- a/tests/e2e/14-views-rest-api.spec.ts
+++ b/tests/e2e/14-views-rest-api.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from "@/tests/e2e/fixtures/auth-storage";
+import {
+  createApiTestView,
+  deleteApiTestView,
+} from "@/tests/e2e/helpers/apiTestData";
+import type {
+  PublicViewRow,
+  ViewConfigRow,
+  WarehouseTablesResponse,
+} from "@/types";
+
+test("view REST API isolates sibling views and synchronizes public access", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const testView = await createApiTestView({
+    sourceTable: "seed_survey_data",
+    viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
+    viewType: "gallery",
+  });
+  const primaryDataset = testView.primaryDataset;
+
+  try {
+    const mapResponse = await request.post("/api/views", {
+      data: {
+        primaryDataset,
+        viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
+        viewType: "map",
+      },
+    });
+    expect(mapResponse.status()).toBe(201);
+    const mapView = (await mapResponse.json()) as ViewConfigRow;
+
+    const collectionResponse = await request.get(
+      `/api/views?primary_dataset=${primaryDataset}`,
+    );
+    expect(collectionResponse.status()).toBe(200);
+    const collection = (await collectionResponse.json()) as ViewConfigRow[];
+    expect(collection.map((view) => view.viewType).sort()).toEqual([
+      "gallery",
+      "map",
+    ]);
+    const galleryView = collection.find((view) => view.viewType === "gallery");
+    expect(galleryView).toBeDefined();
+
+    const singleResponse = await request.get(
+      `/api/views/${galleryView!.viewId}`,
+    );
+    expect(singleResponse.status()).toBe(200);
+    expect(await singleResponse.json()).toEqual(galleryView!);
+
+    const duplicateResponse = await request.post("/api/views", {
+      data: {
+        primaryDataset,
+        viewConfig: {},
+        viewType: "gallery",
+      },
+    });
+    expect(duplicateResponse.status()).toBe(409);
+
+    const patchResponse = await request.patch(
+      `/api/views/${galleryView!.viewId}`,
+      {
+        data: {
+          viewConfig: {
+            DATASET_TABLE: "Test View",
+            ROUTE_LEVEL_PERMISSION: "anyone",
+          },
+        },
+      },
+    );
+    expect(patchResponse.status()).toBe(200);
+    expect(await patchResponse.json()).toEqual(
+      expect.objectContaining({
+        viewId: galleryView!.viewId,
+        viewName: "Test View",
+      }),
+    );
+
+    const publicResponse = await request.get("/api/views/public");
+    expect(publicResponse.status()).toBe(200);
+    const publicViews = (await publicResponse.json()) as PublicViewRow[];
+    expect(publicViews).toContainEqual({
+      primaryDataset,
+      viewId: galleryView!.viewId,
+      viewType: "gallery",
+    });
+    expect(publicViews).not.toContainEqual(
+      expect.objectContaining({ viewId: mapView.viewId }),
+    );
+
+    const deleteGalleryResponse = await request.delete(
+      `/api/views/${galleryView!.viewId}`,
+    );
+    expect(deleteGalleryResponse.status()).toBe(204);
+
+    const remainingMapResponse = await request.get(
+      `/api/views/${mapView.viewId}`,
+    );
+    expect(remainingMapResponse.status()).toBe(200);
+    expect(await remainingMapResponse.json()).toEqual(
+      expect.objectContaining({
+        primaryDataset,
+        viewId: mapView.viewId,
+        viewType: "map",
+      }),
+    );
+
+    const deleteMapResponse = await request.delete(
+      `/api/views/${mapView.viewId}`,
+    );
+    expect(deleteMapResponse.status()).toBe(204);
+    expect((await request.get(`/api/views/${mapView.viewId}`)).status()).toBe(
+      404,
+    );
+  } finally {
+    await deleteApiTestView(testView);
+  }
+});
+
+test("view REST API validates authorization, IDs, bodies, and missing views", async ({
+  authenticatedRequestAsAdmin: adminRequest,
+  authenticatedRequestAsMember: memberRequest,
+  request,
+}) => {
+  const body = {
+    primaryDataset: "api_test_forbidden",
+    viewConfig: {},
+    viewType: "gallery",
+  };
+
+  expect((await request.post("/api/views", { data: body })).status()).toBe(401);
+  expect(
+    (await memberRequest.post("/api/views", { data: body })).status(),
+  ).toBe(403);
+  expect((await adminRequest.post("/api/views", { data: {} })).status()).toBe(
+    400,
+  );
+  expect((await adminRequest.get("/api/views/0")).status()).toBe(400);
+
+  const missingViewId = 2147483647;
+  expect((await adminRequest.get(`/api/views/${missingViewId}`)).status()).toBe(
+    404,
+  );
+  expect(
+    (
+      await adminRequest.patch(`/api/views/${missingViewId}`, {
+        data: { viewConfig: {} },
+      })
+    ).status(),
+  ).toBe(404);
+  expect(
+    (await adminRequest.delete(`/api/views/${missingViewId}`)).status(),
+  ).toBe(404);
+});
+
+test("warehouse tables API preserves table inventory", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const response = await request.get("/api/warehouse/tables");
+  expect(response.status()).toBe(200);
+
+  const body = (await response.json()) as WarehouseTablesResponse;
+  expect(body.tables).toContain("seed_survey_data");
+  expect(body.geospatialTables).toContain("bcmform_responses");
+});

--- a/tests/e2e/14-views-rest-api.spec.ts
+++ b/tests/e2e/14-views-rest-api.spec.ts
@@ -1,64 +1,157 @@
+import type { APIRequestContext } from "@playwright/test";
+
 import { test, expect } from "@/tests/e2e/fixtures/auth-storage";
 import {
   createApiTestView,
   deleteApiTestView,
 } from "@/tests/e2e/helpers/apiTestData";
 import type {
+  ApiTestView,
   PublicViewRow,
   ViewConfigRow,
   WarehouseTablesResponse,
 } from "@/types";
 
-test("view REST API isolates sibling views and synchronizes public access", async ({
-  authenticatedRequestAsAdmin: request,
-}) => {
-  const testView = await createApiTestView({
+const MISSING_VIEW_ID = 2147483647;
+
+const forbiddenCreateBody = {
+  primaryDataset: "api_test_forbidden",
+  viewConfig: {},
+  viewType: "gallery",
+};
+
+/**
+ * Returns views for one primary dataset.
+ *
+ * @param {APIRequestContext} request - Authenticated Playwright request.
+ * @param {string} primaryDataset - Dataset whose views are listed.
+ * @returns {Promise<ViewConfigRow[]>} View rows for that dataset.
+ */
+const listViewsForDataset = async (
+  request: APIRequestContext,
+  primaryDataset: string,
+): Promise<ViewConfigRow[]> => {
+  const response = await request.get(
+    `/api/views?primary_dataset=${encodeURIComponent(primaryDataset)}`,
+  );
+  expect(response.status()).toBe(200);
+  return (await response.json()) as ViewConfigRow[];
+};
+
+/**
+ * Creates a member gallery fixture and a member map sibling through the REST API.
+ *
+ * @param {APIRequestContext} request - Authenticated Playwright request.
+ * @returns {Promise<{ fixture: ApiTestView; gallery: ViewConfigRow; map: ViewConfigRow }>}
+ *   Fixture plus both view rows.
+ */
+const createMemberGalleryAndMap = async (
+  request: APIRequestContext,
+): Promise<{
+  fixture: ApiTestView;
+  gallery: ViewConfigRow;
+  map: ViewConfigRow;
+}> => {
+  const fixture = await createApiTestView({
     sourceTable: "seed_survey_data",
     viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
     viewType: "gallery",
   });
-  const primaryDataset = testView.primaryDataset;
+  const mapResponse = await request.post("/api/views", {
+    data: {
+      primaryDataset: fixture.primaryDataset,
+      viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
+      viewType: "map",
+    },
+  });
+  expect(mapResponse.status()).toBe(201);
+  const map = (await mapResponse.json()) as ViewConfigRow;
+  const collection = await listViewsForDataset(request, fixture.primaryDataset);
+  const gallery = collection.find((view) => view.viewType === "gallery");
+  expect(gallery).toBeDefined();
+  return { fixture, gallery: gallery as ViewConfigRow, map };
+};
+
+/**
+ * Deletes REST view rows, then the warehouse fixture.
+ *
+ * @param {APIRequestContext} request - Authenticated Playwright request.
+ * @param {{ fixture: ApiTestView; gallery: ViewConfigRow; map: ViewConfigRow }} views - Views to remove.
+ * @returns {Promise<void>}
+ */
+const deleteMemberGalleryAndMap = async (
+  request: APIRequestContext,
+  views: {
+    fixture: ApiTestView;
+    gallery: ViewConfigRow;
+    map: ViewConfigRow;
+  },
+): Promise<void> => {
+  await request.delete(`/api/views/${views.map.viewId}`);
+  await request.delete(`/api/views/${views.gallery.viewId}`);
+  await deleteApiTestView(views.fixture);
+};
+
+test("creating a map does not replace the sibling gallery", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const views = await createMemberGalleryAndMap(request);
 
   try {
-    const mapResponse = await request.post("/api/views", {
-      data: {
-        primaryDataset,
-        viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
-        viewType: "map",
-      },
-    });
-    expect(mapResponse.status()).toBe(201);
-    const mapView = (await mapResponse.json()) as ViewConfigRow;
-
-    const collectionResponse = await request.get(
-      `/api/views?primary_dataset=${primaryDataset}`,
+    const collection = await listViewsForDataset(
+      request,
+      views.fixture.primaryDataset,
     );
-    expect(collectionResponse.status()).toBe(200);
-    const collection = (await collectionResponse.json()) as ViewConfigRow[];
     expect(collection.map((view) => view.viewType).sort()).toEqual([
       "gallery",
       "map",
     ]);
-    const galleryView = collection.find((view) => view.viewType === "gallery");
-    expect(galleryView).toBeDefined();
+  } finally {
+    await deleteMemberGalleryAndMap(request, views);
+  }
+});
 
-    const singleResponse = await request.get(
-      `/api/views/${galleryView!.viewId}`,
-    );
-    expect(singleResponse.status()).toBe(200);
-    expect(await singleResponse.json()).toEqual(galleryView!);
+test("a view can be read by id", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const views = await createMemberGalleryAndMap(request);
 
-    const duplicateResponse = await request.post("/api/views", {
+  try {
+    const response = await request.get(`/api/views/${views.gallery.viewId}`);
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual(views.gallery);
+  } finally {
+    await deleteMemberGalleryAndMap(request, views);
+  }
+});
+
+test("creating a second gallery for the same dataset is rejected", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const views = await createMemberGalleryAndMap(request);
+
+  try {
+    const response = await request.post("/api/views", {
       data: {
-        primaryDataset,
+        primaryDataset: views.fixture.primaryDataset,
         viewConfig: {},
         viewType: "gallery",
       },
     });
-    expect(duplicateResponse.status()).toBe(409);
+    expect(response.status()).toBe(409);
+  } finally {
+    await deleteMemberGalleryAndMap(request, views);
+  }
+});
 
+test("anyone gallery is public while sibling member map is not", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const views = await createMemberGalleryAndMap(request);
+
+  try {
     const patchResponse = await request.patch(
-      `/api/views/${galleryView!.viewId}`,
+      `/api/views/${views.gallery.viewId}`,
       {
         data: {
           viewConfig: {
@@ -71,7 +164,7 @@ test("view REST API isolates sibling views and synchronizes public access", asyn
     expect(patchResponse.status()).toBe(200);
     expect(await patchResponse.json()).toEqual(
       expect.objectContaining({
-        viewId: galleryView!.viewId,
+        viewId: views.gallery.viewId,
         viewName: "Test View",
       }),
     );
@@ -80,80 +173,122 @@ test("view REST API isolates sibling views and synchronizes public access", asyn
     expect(publicResponse.status()).toBe(200);
     const publicViews = (await publicResponse.json()) as PublicViewRow[];
     expect(publicViews).toContainEqual({
-      primaryDataset,
-      viewId: galleryView!.viewId,
+      primaryDataset: views.fixture.primaryDataset,
+      viewId: views.gallery.viewId,
       viewType: "gallery",
     });
     expect(publicViews).not.toContainEqual(
-      expect.objectContaining({ viewId: mapView.viewId }),
+      expect.objectContaining({ viewId: views.map.viewId }),
     );
+  } finally {
+    await deleteMemberGalleryAndMap(request, views);
+  }
+});
 
-    const deleteGalleryResponse = await request.delete(
-      `/api/views/${galleryView!.viewId}`,
-    );
-    expect(deleteGalleryResponse.status()).toBe(204);
+test("deleting a gallery leaves the sibling map", async ({
+  authenticatedRequestAsAdmin: request,
+}) => {
+  const views = await createMemberGalleryAndMap(request);
+
+  try {
+    expect(
+      (await request.delete(`/api/views/${views.gallery.viewId}`)).status(),
+    ).toBe(204);
 
     const remainingMapResponse = await request.get(
-      `/api/views/${mapView.viewId}`,
+      `/api/views/${views.map.viewId}`,
     );
     expect(remainingMapResponse.status()).toBe(200);
     expect(await remainingMapResponse.json()).toEqual(
       expect.objectContaining({
-        primaryDataset,
-        viewId: mapView.viewId,
+        primaryDataset: views.fixture.primaryDataset,
+        viewId: views.map.viewId,
         viewType: "map",
       }),
     );
-
-    const deleteMapResponse = await request.delete(
-      `/api/views/${mapView.viewId}`,
-    );
-    expect(deleteMapResponse.status()).toBe(204);
-    expect((await request.get(`/api/views/${mapView.viewId}`)).status()).toBe(
-      404,
-    );
   } finally {
-    await deleteApiTestView(testView);
+    await request.delete(`/api/views/${views.map.viewId}`);
+    await deleteApiTestView(views.fixture);
   }
 });
 
-test("view REST API validates authorization, IDs, bodies, and missing views", async ({
-  authenticatedRequestAsAdmin: adminRequest,
-  authenticatedRequestAsMember: memberRequest,
-  request,
+test("deleting a view removes it", async ({
+  authenticatedRequestAsAdmin: request,
 }) => {
-  const body = {
-    primaryDataset: "api_test_forbidden",
-    viewConfig: {},
-    viewType: "gallery",
-  };
+  const views = await createMemberGalleryAndMap(request);
 
-  expect((await request.post("/api/views", { data: body })).status()).toBe(401);
+  try {
+    expect(
+      (await request.delete(`/api/views/${views.map.viewId}`)).status(),
+    ).toBe(204);
+    expect((await request.get(`/api/views/${views.map.viewId}`)).status()).toBe(
+      404,
+    );
+  } finally {
+    await request.delete(`/api/views/${views.gallery.viewId}`);
+    await deleteApiTestView(views.fixture);
+  }
+});
+
+test("unauthenticated user cannot create a view", async ({ request }) => {
   expect(
-    (await memberRequest.post("/api/views", { data: body })).status(),
+    (await request.post("/api/views", { data: forbiddenCreateBody })).status(),
+  ).toBe(401);
+});
+
+test("member cannot create a view", async ({
+  authenticatedRequestAsMember: memberRequest,
+}) => {
+  expect(
+    (
+      await memberRequest.post("/api/views", { data: forbiddenCreateBody })
+    ).status(),
   ).toBe(403);
+});
+
+test("admin create with an empty body is rejected", async ({
+  authenticatedRequestAsAdmin: adminRequest,
+}) => {
   expect((await adminRequest.post("/api/views", { data: {} })).status()).toBe(
     400,
   );
-  expect((await adminRequest.get("/api/views/0")).status()).toBe(400);
+});
 
-  const missingViewId = 2147483647;
-  expect((await adminRequest.get(`/api/views/${missingViewId}`)).status()).toBe(
-    404,
-  );
+test("invalid view id is rejected", async ({
+  authenticatedRequestAsAdmin: adminRequest,
+}) => {
+  expect((await adminRequest.get("/api/views/0")).status()).toBe(400);
+});
+
+test("missing view cannot be read", async ({
+  authenticatedRequestAsAdmin: adminRequest,
+}) => {
+  expect(
+    (await adminRequest.get(`/api/views/${MISSING_VIEW_ID}`)).status(),
+  ).toBe(404);
+});
+
+test("missing view cannot be updated", async ({
+  authenticatedRequestAsAdmin: adminRequest,
+}) => {
   expect(
     (
-      await adminRequest.patch(`/api/views/${missingViewId}`, {
+      await adminRequest.patch(`/api/views/${MISSING_VIEW_ID}`, {
         data: { viewConfig: {} },
       })
     ).status(),
   ).toBe(404);
+});
+
+test("missing view cannot be deleted", async ({
+  authenticatedRequestAsAdmin: adminRequest,
+}) => {
   expect(
-    (await adminRequest.delete(`/api/views/${missingViewId}`)).status(),
+    (await adminRequest.delete(`/api/views/${MISSING_VIEW_ID}`)).status(),
   ).toBe(404);
 });
 
-test("warehouse tables API preserves table inventory", async ({
+test("warehouse tables API lists seeded survey and geospatial tables", async ({
   authenticatedRequestAsAdmin: request,
 }) => {
   const response = await request.get("/api/warehouse/tables");

--- a/tests/e2e/fixtures/auth-storage.ts
+++ b/tests/e2e/fixtures/auth-storage.ts
@@ -93,6 +93,7 @@ export const test = baseTest.extend<{
   authenticatedPageAsMember: Page;
   authenticatedPageAsAdmin: Page;
   authenticatedRequestAsAdmin: APIRequestContext;
+  authenticatedRequestAsMember: APIRequestContext;
 }>({
   /**
    * Fixture that provides a page authenticated as SignedIn user.
@@ -190,6 +191,16 @@ export const test = baseTest.extend<{
    */
   authenticatedRequestAsAdmin: async ({ playwright, baseURL }, use) => {
     const authFile = getAuthFile("admin");
+    const requestContext = await playwright.request.newContext({
+      storageState: authFile,
+      baseURL,
+    });
+    await use(requestContext);
+    await requestContext.dispose();
+  },
+
+  authenticatedRequestAsMember: async ({ playwright, baseURL }, use) => {
+    const authFile = getAuthFile("member");
     const requestContext = await playwright.request.newContext({
       storageState: authFile,
       baseURL,

--- a/tests/unit/helpers/serverGlobals.ts
+++ b/tests/unit/helpers/serverGlobals.ts
@@ -1,0 +1,15 @@
+import { vi } from "vitest";
+
+vi.stubGlobal(
+  "createError",
+  vi.fn((input: { statusCode: number; statusMessage: string }) =>
+    Object.assign(new Error(input.statusMessage), input),
+  ),
+);
+vi.stubGlobal("defineEventHandler", <T>(handler: T): T => handler);
+vi.stubGlobal(
+  "getQuery",
+  vi.fn(() => ({})),
+);
+vi.stubGlobal("readBody", vi.fn());
+vi.stubGlobal("setResponseStatus", vi.fn());

--- a/tests/unit/server/viewApi.test.ts
+++ b/tests/unit/server/viewApi.test.ts
@@ -6,6 +6,7 @@ import {
   parseUpdateViewBody,
   parseViewId,
 } from "@/server/utils/viewApi";
+import type { CreateViewBody, UpdateViewBody } from "@/types";
 
 describe("view API input parsing", () => {
   it("parses a valid view ID", () => {
@@ -45,7 +46,6 @@ describe("view API input parsing", () => {
 
   it("rejects invalid create bodies", () => {
     for (const body of [
-      null,
       {},
       { primaryDataset: "", viewType: "gallery" },
       { primaryDataset: "test_dataset", viewType: "dashboard" },
@@ -54,23 +54,20 @@ describe("view API input parsing", () => {
         secondaryDataset: 2,
         viewType: "gallery",
       },
-      {
-        primaryDataset: "test_dataset",
-        viewConfig: [],
-        viewType: "gallery",
-      },
     ]) {
-      expect(() => parseCreateViewBody(body)).toThrow(
+      expect(() => parseCreateViewBody(body as CreateViewBody)).toThrow(
         expect.objectContaining({ statusCode: 400 }),
       );
     }
   });
 
-  it("requires an object viewConfig for updates", () => {
-    expect(() => parseUpdateViewBody({})).toThrow(
-      expect.objectContaining({ statusCode: 400 }),
-    );
-    expect(() => parseUpdateViewBody({ viewConfig: [] })).toThrow(
+  it("rejects an invalid secondary dataset in an update body", () => {
+    const body = {
+      secondaryDataset: 2,
+      viewConfig: {},
+    } as unknown as UpdateViewBody;
+
+    expect(() => parseUpdateViewBody(body)).toThrow(
       expect.objectContaining({ statusCode: 400 }),
     );
   });

--- a/tests/unit/server/viewApi.test.ts
+++ b/tests/unit/server/viewApi.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type { H3Event } from "h3";
+import {
+  parseCreateViewBody,
+  parseUpdateViewBody,
+  parseViewId,
+} from "@/server/utils/viewApi";
+
+describe("view API input parsing", () => {
+  it("parses a valid view ID", () => {
+    const event = {
+      context: { params: { view_id: "42" } },
+    } as H3Event;
+
+    expect(parseViewId(event)).toBe(42);
+  });
+
+  it("rejects invalid view IDs", () => {
+    for (const viewId of [undefined, "", "0", "-1", "1.5", "view"]) {
+      const event = {
+        context: { params: { view_id: viewId } },
+      } as H3Event;
+
+      expect(() => parseViewId(event)).toThrow(
+        expect.objectContaining({ statusCode: 400 }),
+      );
+    }
+  });
+
+  it("parses a valid create body", () => {
+    expect(
+      parseCreateViewBody({
+        primaryDataset: "test_dataset",
+        viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
+        viewType: "gallery",
+      }),
+    ).toEqual({
+      primaryDataset: "test_dataset",
+      secondaryDataset: undefined,
+      viewConfig: { ROUTE_LEVEL_PERMISSION: "member" },
+      viewType: "gallery",
+    });
+  });
+
+  it("rejects invalid create bodies", () => {
+    for (const body of [
+      null,
+      {},
+      { primaryDataset: "", viewType: "gallery" },
+      { primaryDataset: "test_dataset", viewType: "dashboard" },
+      {
+        primaryDataset: "test_dataset",
+        secondaryDataset: 2,
+        viewType: "gallery",
+      },
+      {
+        primaryDataset: "test_dataset",
+        viewConfig: [],
+        viewType: "gallery",
+      },
+    ]) {
+      expect(() => parseCreateViewBody(body)).toThrow(
+        expect.objectContaining({ statusCode: 400 }),
+      );
+    }
+  });
+
+  it("requires an object viewConfig for updates", () => {
+    expect(() => parseUpdateViewBody({})).toThrow(
+      expect.objectContaining({ statusCode: 400 }),
+    );
+    expect(() => parseUpdateViewBody({ viewConfig: [] })).toThrow(
+      expect.objectContaining({ statusCode: 400 }),
+    );
+  });
+});

--- a/tests/unit/server/viewsRestApi.test.ts
+++ b/tests/unit/server/viewsRestApi.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { H3Event } from "h3";
+import deleteViewHandler from "@/server/api/views/[view_id].delete";
+import getViewHandler from "@/server/api/views/[view_id].get";
+import patchViewHandler from "@/server/api/views/[view_id].patch";
+import getViewsHandler from "@/server/api/views/index.get";
+import postViewHandler from "@/server/api/views/index.post";
+
+const mocks = vi.hoisted(() => ({
+  createView: vi.fn(),
+  deleteView: vi.fn(),
+  fetchViewConfigRow: vi.fn(),
+  fetchViewConfigRows: vi.fn(),
+  updateView: vi.fn(),
+  validatePermissions: vi.fn(),
+  validateUserSession: vi.fn(),
+}));
+
+vi.mock("@/server/database/dbOperations", () => ({
+  createView: mocks.createView,
+  deleteView: mocks.deleteView,
+  fetchViewConfigRow: mocks.fetchViewConfigRow,
+  fetchViewConfigRows: mocks.fetchViewConfigRows,
+  updateView: mocks.updateView,
+}));
+
+vi.mock("@/utils/accessControls", () => ({
+  validatePermissions: mocks.validatePermissions,
+  validateUserSession: mocks.validateUserSession,
+}));
+
+const eventWithViewId = (viewId: string) =>
+  ({ context: { params: { view_id: viewId } } }) as H3Event;
+
+const viewRow = {
+  primaryDataset: "test_dataset",
+  secondaryDataset: null,
+  viewConfig: { ROUTE_LEVEL_PERMISSION: "member" as const },
+  viewId: 42,
+  viewName: "Test Dataset",
+  viewType: "gallery" as const,
+};
+
+describe("/api/views handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "getQuery",
+      vi.fn(() => ({})),
+    );
+  });
+
+  it("lists views with an optional primary dataset filter", async () => {
+    vi.mocked(getQuery).mockReturnValue({ primary_dataset: "test_dataset" });
+    mocks.fetchViewConfigRows.mockResolvedValue([viewRow]);
+
+    const result = await (
+      getViewsHandler as unknown as (event: H3Event) => Promise<unknown>
+    )({ context: {} } as H3Event);
+
+    expect(mocks.validateUserSession).toHaveBeenCalledOnce();
+    expect(mocks.fetchViewConfigRows).toHaveBeenCalledWith("test_dataset");
+    expect(result).toEqual([viewRow]);
+  });
+
+  it("creates a view and returns 201", async () => {
+    vi.mocked(readBody).mockResolvedValue({
+      primaryDataset: "test_dataset",
+      viewConfig: viewRow.viewConfig,
+      viewType: "gallery",
+    });
+    mocks.createView.mockResolvedValue(viewRow);
+    const event = { context: {} } as H3Event;
+
+    const result = await (
+      postViewHandler as unknown as (event: H3Event) => Promise<unknown>
+    )(event);
+
+    expect(mocks.validatePermissions).toHaveBeenCalledWith(event, "admin");
+    expect(mocks.createView).toHaveBeenCalledWith({
+      primaryDataset: "test_dataset",
+      secondaryDataset: undefined,
+      viewConfig: viewRow.viewConfig,
+      viewType: "gallery",
+    });
+    expect(setResponseStatus).toHaveBeenCalledWith(event, 201);
+    expect(result).toEqual(viewRow);
+  });
+
+  it("gets one view by ID", async () => {
+    mocks.fetchViewConfigRow.mockResolvedValue(viewRow);
+    const event = eventWithViewId("42");
+
+    const result = await (
+      getViewHandler as unknown as (event: H3Event) => Promise<unknown>
+    )(event);
+
+    expect(mocks.validateUserSession).toHaveBeenCalledWith(event);
+    expect(mocks.fetchViewConfigRow).toHaveBeenCalledWith(42);
+    expect(result).toEqual(viewRow);
+  });
+
+  it("updates one view by ID", async () => {
+    vi.mocked(readBody).mockResolvedValue({
+      viewConfig: { ROUTE_LEVEL_PERMISSION: "anyone" },
+    });
+    mocks.updateView.mockResolvedValue(viewRow);
+    const event = eventWithViewId("42");
+
+    await (patchViewHandler as unknown as (event: H3Event) => Promise<unknown>)(
+      event,
+    );
+
+    expect(mocks.validatePermissions).toHaveBeenCalledWith(event, "admin");
+    expect(mocks.updateView).toHaveBeenCalledWith(42, {
+      secondaryDataset: undefined,
+      viewConfig: { ROUTE_LEVEL_PERMISSION: "anyone" },
+    });
+  });
+
+  it("deletes one view by ID and returns 204", async () => {
+    const event = eventWithViewId("42");
+
+    await (
+      deleteViewHandler as unknown as (event: H3Event) => Promise<unknown>
+    )(event);
+
+    expect(mocks.validatePermissions).toHaveBeenCalledWith(event, "admin");
+    expect(mocks.deleteView).toHaveBeenCalledWith(42);
+    expect(setResponseStatus).toHaveBeenCalledWith(event, 204);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -203,6 +203,23 @@ export type PublicViewRow = Pick<
   "primaryDataset" | "viewId" | "viewType"
 >;
 
+export type CreateViewBody = {
+  primaryDataset: string;
+  secondaryDataset?: string | null;
+  viewConfig?: ViewConfig;
+  viewType: ViewType;
+};
+
+export type UpdateViewBody = {
+  secondaryDataset?: string | null;
+  viewConfig: ViewConfig;
+};
+
+export type WarehouseTablesResponse = {
+  geospatialTables: string[];
+  tables: string[];
+};
+
 export type ApiTestViewInput = {
   secondaryDataset?: string | null;
   sourceTable: string;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     exclude: ["node_modules/**", "tests/e2e/**"],
+    setupFiles: ["./tests/unit/helpers/serverGlobals.ts"],
   },
   plugins: [vue()],
   resolve: {


### PR DESCRIPTION
## Goal

> Part 2 of 3 for [#552: Refactor view configuration CRUD into a RESTful /api/views API](https://github.com/ConservationMetrics/gc-explorer/issues/552). 
> NOTE TO REVEIWER: Testing code adds ~400 LOC.

Expose view config as stable-ID REST resources while preserving validation, authorization, and public-view synchronization.

## Screenshots

Not applicable — API implementation only.

## What I changed and why

- Added authenticated `GET /api/views`.
- Added authenticated `GET /api/views/:view_id`.
- Added admin-only `POST /api/views`.
- Added admin-only `PATCH /api/views/:view_id`.
- Added admin-only `DELETE /api/views/:view_id`.
- Added open `GET /api/views/public`.
- Added authenticated `GET /api/warehouse/tables`.
- Added request parsing and validation for IDs and request bodies.
- Added stable-ID database CRUD operations.
- Return `409` for duplicate dataset/view-type combinations, including Drizzle-wrapped Postgres errors.
- Return `404` for missing views and `400` for invalid input.

## How I convinced myself this is right

It follows RESTful conventions. 

## What I'm not doing here

- Migrating the configuration UI to `/api/views`.
- Changing the remaining `/api/config/columns/:table` metadata endpoint.

## LLM use disclosure

GPT Sol 5.6 Helped