### PR TITLE
Migrate to pnpm 11 with committed allowBuilds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Install dependencies
         run: |
-          npm install -g pnpm@10.34.5
+          npm install -g pnpm@11.25.0
           pnpm install
       - name: Run linting and formatting
         run: |
@@ -49,10 +49,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Install dependencies and run unit tests
         run: |
-          npm install -g pnpm@10.34.5
+          npm install -g pnpm@11.25.0
           pnpm install
           pnpm run test:unit
 
@@ -68,10 +68,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Install dependencies
         run: |
-          npm install -g pnpm@10.34.5
+          npm install -g pnpm@11.25.0
           pnpm install
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-FROM node:20.15.0-slim AS builder
+FROM node:22-slim AS builder
 
 # Set the working directory
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm@10
+RUN npm install -g pnpm@11.25.0
 
 # Copy package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -27,13 +27,13 @@ RUN chmod +x /app/migrate-and-start.sh
 RUN pnpm run build
 
 # Production stage
-FROM node:20.15.0-slim AS production
+FROM node:22-slim AS production
 
 # Set the working directory
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm@10
+RUN npm install -g pnpm@11.25.0
 
 # Copy package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/package.json
+++ b/package.json
@@ -78,8 +78,9 @@
     "vue-eslint-parser": "^10.1.4",
     "vue-tsc": "^2.2.2"
   },
+  "packageManager": "pnpm@11.25.0",
   "engines": {
-    "node": "20.15.0"
+    "node": ">=22"
   },
   "author": "Conservation Metrics",
   "license": "MIT"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,8 @@ packages:
 allowBuilds:
   "@parcel/watcher": true
   esbuild: true
-  sharp: true
-  unrs-resolver: true
-  vue-demi: false
+  sharp: true # transitive dependency of turf
+  unrs-resolver: true # transitive dependency of @nuxt/eslint
+  vue-demi: false # transitive dependency of reka-ui
 
 minimumReleaseAge: 10080 # minutes == 7 days

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - .
 
 allowBuilds:
-  '@parcel/watcher': true
+  "@parcel/watcher": true
   esbuild: true
   sharp: true
   unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,11 @@
 packages:
   - .
 
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
+  vue-demi: false
+
 minimumReleaseAge: 10080 # minutes == 7 days


### PR DESCRIPTION

## Goal

Move GitHub Actions and Docker installs to pnpm 11 with a committed allowBuilds policy, so ignored dependency scripts do not fail CI. Closes #629 


## Screenshots

N/A


## What I changed and why

pnpm 11 treats unreviewed dependency build scripts as an error and requires Node 22. I pin the three GitHub Actions jobs that install dependencies on the runner to Node 22 and `pnpm@11.25.0`. I make the same Node and pnpm pins in both Dockerfile stages. I ran a pnpm 11 frozen install, then set `allowBuilds` in `pnpm-workspace.yaml` for the packages that install actually blocked. `@parcel/watcher`, `esbuild`, `sharp`, and `unrs-resolver` are allowed because they need native or platform binaries. `vue-demi` is denied because this app is Vue 3 and that script only switches Vue 2 versus Vue 3 entry points.

I also set `packageManager` to `pnpm@11.25.0` so local Corepack matches CI. The lockfile stayed valid under `--frozen-lockfile`.


## How I convinced myself this is right

Testing locally


## What I'm not doing here

Nothing extrenous


## LLM use disclosure

None