### PR TITLE
Export ignores active date filter and exports all data points

### DIFF
--- a/components/alerts/AlertsIntroPanel.vue
+++ b/components/alerts/AlertsIntroPanel.vue
@@ -160,6 +160,8 @@ const showDownloads = computed(
           <div class="flex justify-center [&>div]:!mt-0">
             <DownloadMapData
               :data-for-download="props.dataForAlertsIntroPanel"
+              :export-min-date="props.statsExportMinDate"
+              :export-max-date="props.statsExportMaxDate"
               variant="outline"
             />
           </div>

--- a/composables/useDateAndCategoryFilter.ts
+++ b/composables/useDateAndCategoryFilter.ts
@@ -79,9 +79,7 @@ export const useTimestampFilter = () => {
   const dateMax = ref("");
 
   const setDateRange = (payload: { start: Date | null; end: Date | null }) => {
-    dateMin.value = payload.start
-      ? payload.start.toISOString().slice(0, 10)
-      : "";
+    dateMin.value = payload.start ? payload.start.toISOString() : "";
     dateMax.value = payload.end ? payload.end.toISOString() : "";
   };
 

--- a/composables/useTableExportDownload.ts
+++ b/composables/useTableExportDownload.ts
@@ -47,7 +47,9 @@ export const buildTableExportQueryParams = (options: {
   }
   const isStatisticsExport = options.exportPath === "statistics-export";
   if (
-    (options.exportTimestampColumn || isStatisticsExport) &&
+    (options.exportTimestampColumn ||
+      isStatisticsExport ||
+      options.viewType === "alerts") &&
     (options.exportMinDate || options.exportMaxDate)
   ) {
     if (options.exportMinDate) params.minDate = options.exportMinDate;

--- a/server/api/[table]/export.get.ts
+++ b/server/api/[table]/export.get.ts
@@ -7,6 +7,7 @@ import {
   filterGeoData,
   filterToSelectedValues,
   filterByDateRange,
+  filterAlertsByDateRange,
 } from "@/server/dataProcessing/dataFilters";
 import { hasValidCoordinates } from "@/utils/geoUtils";
 import { validatePermissions } from "@/utils/accessControls";
@@ -187,7 +188,13 @@ export default defineEventHandler(async (event: H3Event) => {
     const timestampColumn = tableConfig.TIMESTAMP_COLUMN;
     const minDate = (query.minDate as string)?.trim();
     const maxDate = (query.maxDate as string)?.trim();
-    if (timestampColumn && (minDate || maxDate)) {
+    if (viewType === "alerts" && (minDate || maxDate)) {
+      dataToExport = filterAlertsByDateRange(
+        dataToExport,
+        minDate || undefined,
+        maxDate || undefined,
+      );
+    } else if (timestampColumn && (minDate || maxDate)) {
       dataToExport = filterByDateRange(
         dataToExport,
         timestampColumn,

--- a/server/dataProcessing/dataFilters.ts
+++ b/server/dataProcessing/dataFilters.ts
@@ -66,6 +66,31 @@ export const filterByDateRange = (
   });
 };
 
+/**
+ * Keeps alerts in the selected detection months.
+ *
+ * @param data - Warehouse rows with year_detec and month_detec text columns.
+ * @param minDate - Inclusive first month in YYYYMM format.
+ * @param maxDate - Inclusive last month in YYYYMM format.
+ * @returns Rows in the selected month range.
+ */
+export const filterAlertsByDateRange = (
+  data: DataEntry[],
+  minDate: string | undefined,
+  maxDate: string | undefined,
+): DataEntry[] => {
+  if (!minDate && !maxDate) return data;
+  return data.filter((item) => {
+    const year = item.year_detec;
+    const month = item.month_detec;
+    if (typeof year !== "string" || typeof month !== "string") return false;
+    if (!/^\d{4}$/.test(year) || !/^(0?[1-9]|1[0-2])$/.test(month))
+      return false;
+    const period = `${year}${month.padStart(2, "0")}`;
+    return (!minDate || period >= minDate) && (!maxDate || period <= maxDate);
+  });
+};
+
 /** Filters out data without columns storing valid coordinates. */
 export const filterGeoData = (
   data: DataEntry[] | null | undefined,

--- a/tests/e2e/15-export-date-filter-api.spec.ts
+++ b/tests/e2e/15-export-date-filter-api.spec.ts
@@ -1,0 +1,145 @@
+import type { APIResponse } from "@playwright/test";
+
+import { test, expect } from "@/tests/e2e/fixtures/auth-storage";
+import {
+  createApiTestView,
+  deleteApiTestView,
+} from "@/tests/e2e/helpers/apiTestData";
+import {
+  createTestDatabaseClient,
+  TEST_WAREHOUSE_DATABASE,
+} from "@/tests/e2e/helpers/testDatabase";
+import type { ApiTestView } from "@/types";
+
+/**
+ * Reads record IDs from an export response for the test dataset.
+ *
+ * @param response - HTTP export response.
+ * @param format - Requested file format.
+ * @returns IDs in the downloaded file.
+ */
+const exportIds = async (
+  response: APIResponse,
+  format: string,
+): Promise<string[]> => {
+  expect(response.status()).toBe(200);
+  if (format === "geojson") {
+    const data = await response.json();
+    return data.features.map(
+      (feature: { properties: { _id: string } }) => feature.properties._id,
+    );
+  }
+  const content = await response.text();
+  if (format === "kml") {
+    expect(response.headers()["content-type"]).toContain(
+      "application/vnd.google-earth.kml+xml",
+    );
+    const ids = [
+      ...content.matchAll(/<Data name="_id"><value>([^<]*)<\/value><\/Data>/g),
+    ].map((match) => match[1]);
+    expect(content.match(/<Placemark>/g) ?? []).toHaveLength(ids.length);
+    return ids;
+  }
+  const [header, ...rows] = content.trim().split("\n");
+  if (!header) return [];
+  expect(header.split(",")[0]).toBe("_id");
+  return rows.map((row) => row.split(",")[0]);
+};
+
+for (const viewType of ["map", "alerts"] as const) {
+  test.describe(`${viewType} export date filter (#645)`, () => {
+    let view: ApiTestView | null = null;
+    const records = [
+      { _id: "before", date: "2024-01-31T23:59:59.999Z", month: "1" },
+      { _id: "start", date: "2024-02-01T00:00:00.000Z", month: "02" },
+      { _id: "middle", date: "2024-02-15T12:00:00.000Z", month: "2" },
+      { _id: "end", date: "2024-02-29T23:59:59.999Z", month: "02" },
+      { _id: "after", date: "2024-03-01T00:00:00.000Z", month: "3" },
+      { _id: "missing", date: null, month: null },
+      { _id: "invalid", date: "not-a-date", month: "invalid" },
+    ];
+
+    test.beforeAll(async () => {
+      view = await createApiTestView({
+        sourceTable: viewType === "map" ? "seed_survey_data" : "fake_alerts",
+        viewConfig: {
+          ...(viewType === "map"
+            ? { TIMESTAMP_COLUMN: "_submission_time" }
+            : {}),
+          ROUTE_LEVEL_PERMISSION: "anyone",
+        },
+        viewType,
+      });
+      const sql = createTestDatabaseClient(TEST_WAREHOUSE_DATABASE);
+      try {
+        await sql`DELETE FROM ${sql(view.primaryDataset)}`;
+        await sql`INSERT INTO ${sql(view.primaryDataset)} ${sql(
+          records.map((record) => ({
+            _id: record._id,
+            ...(viewType === "map"
+              ? { _submission_time: record.date }
+              : { year_detec: "2024", month_detec: record.month }),
+            g__type: "Point",
+            g__coordinates: "[10,20]",
+          })),
+        )}`;
+      } finally {
+        await sql.end({ timeout: 5 });
+      }
+    });
+
+    test.afterAll(async () => {
+      if (view) await deleteApiTestView(view);
+    });
+
+    const cases = [
+      {
+        name: "includes both date bounds and excludes records outside the range",
+        dates:
+          viewType === "map"
+            ? { minDate: "2024-02-01", maxDate: "2024-02-29T23:59:59.999Z" }
+            : { minDate: "202402", maxDate: "202402" },
+        expectedIds: ["start", "middle", "end"],
+      },
+      {
+        name: "returns no records when no dates match",
+        dates: { minDate: viewType === "map" ? "2025-01-01" : "202501" },
+        expectedIds: [],
+      },
+      {
+        name: "supports an upper date bound alone",
+        dates: {
+          maxDate: viewType === "map" ? "2024-01-31T23:59:59.999Z" : "202401",
+        },
+        expectedIds: ["before"],
+      },
+    ];
+
+    for (const format of ["kml", "csv", "geojson"]) {
+      for (const { name, dates, expectedIds } of cases) {
+        test(`${format}: ${name}`, async ({ request }) => {
+          if (!view) throw new Error("Export API test view was not created");
+          const response = await request.get(
+            `/api/${view.primaryDataset}/export`,
+            {
+              params: { format, view_type: view.viewType, ...dates },
+            },
+          );
+          expect((await exportIds(response, format)).sort()).toEqual(
+            [...expectedIds].sort(),
+          );
+
+          const unfiltered = await request.get(
+            `/api/${view.primaryDataset}/export`,
+            {
+              params: { format, view_type: view.viewType },
+            },
+          );
+          expect((await exportIds(unfiltered, format)).sort()).toEqual(
+            records.map((record) => record._id).sort(),
+          );
+        });
+      }
+    }
+  });
+}

--- a/tests/unit/components/AlertsExport.test.ts
+++ b/tests/unit/components/AlertsExport.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { computed, defineComponent, onMounted, ref, watch } from "vue";
+import VueSlider from "vue-3-slider-component";
+import { useI18n, useRoute, useToast } from "#imports";
+import AlertsIntroPanel from "@/components/alerts/AlertsIntroPanel.vue";
+import DownloadMapData from "@/components/shared/DownloadMapData.vue";
+import AlertsSlider from "@/components/alerts/AlertsSlider.vue";
+import { useAlertsDateFilter } from "@/composables/useAlertsDateFilter";
+import type { AlertsData, AlertsStatistics } from "@/types";
+
+vi.mock("@/utils/browserDownload", () => ({ triggerBrowserDownload: vi.fn() }));
+
+const statistics: AlertsStatistics = {
+  territory: "Test Territory 645",
+  typeOfAlerts: [],
+  dataProviders: [],
+  alertDetectionRange: "01-2024 to 03-2024",
+  allDates: ["01-2024", "02-2024", "03-2024"],
+  earliestAlertsDate: "01-2024",
+  recentAlertsDate: "03-2024",
+  recentAlertsNumber: 1,
+  alertsTotal: 3,
+  alertsPerMonth: {},
+  hectaresTotal: null,
+  hectaresPerMonth: null,
+  twelveMonthsBefore: "03-2023",
+};
+
+for (const [buttonIndex, format] of ["csv", "geojson", "kml"].entries()) {
+  describe(`${format} alert locations export`, () => {
+    it("sends the sidebar slider's selected months to the export endpoint", async () => {
+      const fetchExport = vi.fn().mockResolvedValue(new Blob());
+      const originalRoute = useRoute();
+      onTestFinished(() => {
+        vi.unstubAllGlobals();
+        vi.mocked(useRoute).mockReturnValue(originalRoute);
+      });
+      Object.entries({
+        computed,
+        ref,
+        watch,
+        onMounted,
+        useI18n,
+        useToast,
+        $fetch: fetchExport,
+      }).forEach(([name, value]) => vi.stubGlobal(name, value));
+      vi.mocked(useRoute).mockReturnValue({
+        params: { tablename: "test_data" },
+        query: {},
+        path: "/alerts/test_data",
+      });
+      const wrapper = mount(
+        defineComponent({
+          components: { AlertsIntroPanel },
+          setup: () => {
+            const data = ref<AlertsData>({
+              mostRecentAlerts: { type: "FeatureCollection", features: [] },
+              previousAlerts: {
+                type: "FeatureCollection",
+                features: ["202401", "202402", "202403"].map((month) => ({
+                  type: "Feature",
+                  geometry: { type: "Point", coordinates: [10, 20] },
+                  properties: { YYYYMM: month },
+                })),
+              },
+            });
+            const { filteredData, resolvedDateRange, handleDateRangeChanged } =
+              useAlertsDateFilter(
+                ref(undefined),
+                data,
+                ref(statistics),
+                ref(data.value),
+                (key) => key,
+              );
+            return {
+              data: filteredData,
+              statistics,
+              resolvedDateRange,
+              handleDateRangeChanged,
+            };
+          },
+          template: `<AlertsIntroPanel :alerts-statistics="statistics" :date-options="statistics.allDates" :data-for-alerts-intro-panel="data" :show-slider="true" :stats-export-min-date="resolvedDateRange?.[0]" :stats-export-max-date="resolvedDateRange?.[1]" @date-range-changed="handleDateRangeChanged" />`,
+        }),
+        {
+          global: {
+            components: { AlertsSlider },
+            mocks: {
+              $t: (key: string) => key,
+              $n: (value: number) => value.toString(),
+            },
+            stubs: {
+              AdminConfigGear: true,
+              AlertsChart: true,
+              DownloadStatistics: true,
+            },
+          },
+        },
+      );
+      onTestFinished(() => wrapper.unmount());
+      await flushPromises();
+      const slider = wrapper.findComponent(VueSlider);
+      slider.vm.$emit("drag-start");
+      slider.vm.$emit("update:modelValue", ["02-2024", "02-2024"]);
+      await flushPromises();
+      expect(
+        (
+          wrapper
+            .findComponent(DownloadMapData)
+            .props("dataForDownload") as AlertsData
+        ).previousAlerts.features,
+      ).toHaveLength(1);
+      const buttons = wrapper
+        .get('[data-testid="alerts-download-data"]')
+        .findAll("button");
+      await buttons[buttonIndex].trigger("click");
+      await flushPromises();
+      expect(fetchExport).toHaveBeenLastCalledWith("/api/test_data/export", {
+        params: {
+          format,
+          view_type: "alerts",
+          minDate: "202402",
+          maxDate: "202402",
+        },
+        responseType: "blob",
+      });
+    });
+  });
+}

--- a/tests/unit/components/MapView.test.ts
+++ b/tests/unit/components/MapView.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, onTestFinished, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
+import VueSlider from "vue-3-slider-component";
 import {
   ref,
   reactive,
@@ -15,8 +16,14 @@ import {
 import * as mapboxMock from "@/tests/unit/helpers/mapboxMock";
 
 import MapView from "@/components/MapView.vue";
+import DownloadMapData from "@/components/shared/DownloadMapData.vue";
+import { useRoute, useI18n, useToast } from "#imports";
 
 import type { FeatureCollection } from "geojson";
+
+vi.mock("@/utils/browserDownload", () => ({
+  triggerBrowserDownload: vi.fn(),
+}));
 
 const makeFeatureCollection = (
   features: Array<{
@@ -353,6 +360,106 @@ describe("MapView component", () => {
     ).toBe("active");
     expect(sidebar.props("mapStatistics").totalFeatures).toBe(1);
   });
+
+  it.each(["csv", "geojson", "kml"])(
+    "exports the selected map dates as %s and restores the full range on reset (#645)",
+    async (format) => {
+      const fetchExport = vi.fn().mockResolvedValue(new Blob());
+      vi.stubGlobal("$fetch", fetchExport);
+      vi.stubGlobal("useI18n", useI18n);
+      vi.stubGlobal("useToast", useToast);
+      const originalRoute = useRoute();
+      onTestFinished(() => {
+        vi.unstubAllGlobals();
+        vi.mocked(useRoute).mockReturnValue(originalRoute);
+      });
+      vi.mocked(useRoute).mockReturnValue({
+        params: { tablename: "test_data" },
+        query: {},
+        path: "/map/test_data",
+      });
+      const wrapper = mount(MapView, {
+        props: {
+          ...baseProps,
+          table: "test_data",
+          timestampColumn: "observed_at",
+          mapData: makeFeatureCollection([
+            {
+              type: "Point",
+              coordinates: [0, 0],
+              properties: { observed_at: "2024-01-15" },
+            },
+            {
+              type: "Point",
+              coordinates: [1, 1],
+              properties: { observed_at: "2024-02-15" },
+            },
+            {
+              type: "Point",
+              coordinates: [2, 2],
+              properties: {
+                observed_at: new Date(
+                  new Date(2024, 1, 1).getTime() - 1,
+                ).toISOString(),
+              },
+            },
+          ]),
+        },
+        global: {
+          ...globalConfig,
+          stubs: {
+            ...globalConfig.stubs,
+            ViewSidebar: false,
+            TimestampFilter: false,
+            AdminConfigGear: true,
+          },
+        },
+      });
+      mapboxMock.fireLoad();
+      await flushPromises();
+
+      const slider = wrapper.findComponent(VueSlider);
+      slider.vm.$emit("drag-start");
+      slider.vm.$emit("update:modelValue", ["2024-02", "2024-02"]);
+      await flushPromises();
+
+      const download = wrapper.findComponent(DownloadMapData);
+      const exportButton =
+        download.findAll("button")[["csv", "geojson", "kml"].indexOf(format)];
+      expect(
+        (download.props("dataForDownload") as FeatureCollection).features,
+      ).toHaveLength(1);
+      await exportButton.trigger("click");
+      await flushPromises();
+      expect(fetchExport).toHaveBeenLastCalledWith("/api/test_data/export", {
+        params: {
+          format,
+          view_type: "map",
+          minDate: new Date(2024, 1, 1).toISOString(),
+          maxDate: new Date(2024, 2, 0, 23, 59, 59, 999).toISOString(),
+        },
+        responseType: "blob",
+      });
+
+      await wrapper.get('[data-testid="reset-date-button"]').trigger("click");
+      await flushPromises();
+      expect(
+        (download.props("dataForDownload") as FeatureCollection).features,
+      ).toHaveLength(3);
+      await exportButton.trigger("click");
+      await flushPromises();
+      expect(fetchExport).toHaveBeenLastCalledWith("/api/test_data/export", {
+        params: {
+          format,
+          view_type: "map",
+          minDate: new Date(2024, 0, 1).toISOString(),
+          maxDate: new Date(2024, 2, 0, 23, 59, 59, 999).toISOString(),
+        },
+        responseType: "blob",
+      });
+      wrapper.unmount();
+    },
+  );
 
   it("selects a feature and fetches full record on click", async () => {
     const wrapper = mount(MapView, {


### PR DESCRIPTION
  ## Goal

  Make dataset exports respect the selected date range. Closes #645 

  ## Screenshots
  
  Not a screenshot but I downloaded filtered by date (7 points) and exported KML and this was the output:

| Alert ID | Territory | Area (ha) | Grid | Basin ID | Detection Date | Confidence | Coordinates (approx. centroid lon, lat) |
|---|---|---|---|---|---|---|---|
| 2026016100161660431 | redacted | 0.66 | 6 | 6166043 | Jan 2026 | 1 | redacted |
| 20260111100161660491 | redacted | 1.48 | 11 | 6166049 | Jan 2026 | 1 | redacted |
| 20260112100161660411 | redacted | 1.22 | 12 | 6166041 | Jan 2026 | 1 | redacted |
| 20260119100161660482 | redacted | 3.58 | 19 | 6166048 | Jan 2026 | 1 | redacted |
| 20260119100161660481 | redacted | 0.71 | 19 | 6166048 | Jan 2026 | 1 | redacted |
| 20260111100161660492 | redacted | 1.58 | 11 | 6166049 | Jan 2026 | 1 | redacted |
| 2026016100161660432 | redacted | 0.93 | 6 | 6166043 | Jan 2026 | 1 | redacted |


## What I changed and why

- Alerts sidebar now includes selected months in the location download request, and the export endpoint filters rows by detection year and month before generating KML, CSV, or GeoJSON
- Fixed the shared map date filter to retain the full start timestamp, preventing UTC conversion followed by date truncation from including records before the selected start date

## How I convinced myself this is right

Manual verification really

## What I'm not doing here

Nothing extrenous 

 ## LLM use disclosure

Codex (Astra initially then Sol) helped