### PR TITLE
Stale column references block unrelated view configuration saves

### DIFF
--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -9,7 +9,10 @@ import {
 } from "@/types";
 import { VIEW_INFO_CONFIG_KEYS } from "@/composables/useCopyConfig";
 import { CONFIG_LIMITS } from "@/utils";
-import { validateViewConfigColumns } from "@/utils/viewConfigColumns";
+import {
+  FUNCTIONAL_COLUMN_KEYS,
+  validateViewConfigColumns,
+} from "@/utils/viewConfigColumns";
 import ConfigPermissions from "./ConfigPermissions.vue";
 import ConfigCollapsibleSection from "./ConfigCollapsibleSection.vue";
 import { Check, Trash2 } from "lucide-vue-next";
@@ -219,6 +222,25 @@ const columnValidation = computed(() =>
   ),
 );
 
+const staleInvalidColumnKeys = computed(
+  () =>
+    new Set<string>(
+      FUNCTIONAL_COLUMN_KEYS.filter((key) => {
+        const invalidValue = columnValidation.value.invalidSelections[key];
+        return (
+          invalidValue !== undefined &&
+          originalConfig.value[key]?.trim() === invalidValue
+        );
+      }),
+    ),
+);
+
+const hasNewInvalidColumnSelections = computed(() =>
+  Object.keys(columnValidation.value.invalidSelections).some(
+    (key) => !staleInvalidColumnKeys.value.has(key),
+  ),
+);
+
 const areColumnsLoading = computed(
   () =>
     props.primaryColumnsLoading ||
@@ -261,7 +283,7 @@ const isFormValid = computed(() => {
   return (
     isMapConfigValid &&
     isPermissionValid.value &&
-    columnValidation.value.isValid &&
+    !hasNewInvalidColumnSelections.value &&
     !areColumnsLoading.value
   );
 });
@@ -283,9 +305,15 @@ const handlePermissionValidation = (isValid: boolean) => {
 };
 
 const handleSubmit = () => {
+  const submittedConfig = Object.fromEntries(
+    Object.entries(localConfig.value).filter(
+      ([key]) => !staleInvalidColumnKeys.value.has(key),
+    ),
+  ) as ViewConfig;
+
   // Client-side validation before submission
-  if (localConfig.value.DATASET_TABLE) {
-    const datasetTableValue = String(localConfig.value.DATASET_TABLE);
+  if (submittedConfig.DATASET_TABLE) {
+    const datasetTableValue = String(submittedConfig.DATASET_TABLE);
     if (datasetTableValue.length > CONFIG_LIMITS.DATASET_TABLE) {
       alert(
         `DATASET_TABLE must be at most ${CONFIG_LIMITS.DATASET_TABLE} characters (current: ${datasetTableValue.length})`,
@@ -294,8 +322,8 @@ const handleSubmit = () => {
     }
   }
 
-  if (localConfig.value.VIEW_DESCRIPTION) {
-    const viewDescriptionValue = String(localConfig.value.VIEW_DESCRIPTION);
+  if (submittedConfig.VIEW_DESCRIPTION) {
+    const viewDescriptionValue = String(submittedConfig.VIEW_DESCRIPTION);
     if (viewDescriptionValue.length > CONFIG_LIMITS.VIEW_DESCRIPTION) {
       alert(
         `VIEW_DESCRIPTION must be at most ${CONFIG_LIMITS.VIEW_DESCRIPTION} characters (current: ${viewDescriptionValue.length})`,
@@ -306,7 +334,7 @@ const handleSubmit = () => {
 
   emit("submitConfig", {
     tableName: props.tableName,
-    config: localConfig.value,
+    config: submittedConfig,
     secondaryDataset: shouldUseSecondaryDataset.value
       ? localSecondaryDataset.value
       : null,

--- a/components/config/ConfigCard.vue
+++ b/components/config/ConfigCard.vue
@@ -4,6 +4,7 @@ import {
   supportsSecondaryDataset,
   type BasemapConfig,
   type ColumnEntry,
+  type FunctionalColumnKey,
   type ViewConfig,
   type ViewType,
 } from "@/types";
@@ -11,6 +12,7 @@ import { VIEW_INFO_CONFIG_KEYS } from "@/composables/useCopyConfig";
 import { CONFIG_LIMITS } from "@/utils";
 import {
   FUNCTIONAL_COLUMN_KEYS,
+  getFunctionalColumnSource,
   validateViewConfigColumns,
 } from "@/utils/viewConfigColumns";
 import ConfigPermissions from "./ConfigPermissions.vue";
@@ -222,12 +224,25 @@ const columnValidation = computed(() =>
   ),
 );
 
+/**
+ * Returns the loaded dataset columns used to validate a functional column key.
+ *
+ * @param {FunctionalColumnKey} key - Config field that stores a column name.
+ * @returns {ColumnEntry[]} Primary or secondary columns for that field.
+ */
+const availableColumnsForKey = (key: FunctionalColumnKey): ColumnEntry[] =>
+  getFunctionalColumnSource(key, props.viewType, hasSecondaryDataset.value) ===
+  "secondary"
+    ? props.secondaryColumns
+    : props.primaryColumns;
+
 const staleInvalidColumnKeys = computed(
   () =>
     new Set<string>(
       FUNCTIONAL_COLUMN_KEYS.filter((key) => {
         const invalidValue = columnValidation.value.invalidSelections[key];
         return (
+          availableColumnsForKey(key).length > 0 &&
           invalidValue !== undefined &&
           originalConfig.value[key]?.trim() === invalidValue
         );

--- a/tests/unit/components/ConfigCard.mapInit.test.ts
+++ b/tests/unit/components/ConfigCard.mapInit.test.ts
@@ -221,6 +221,26 @@ describe("ConfigCard map initialization", () => {
     expect(submission.config).not.toHaveProperty("ICON_COLUMN");
   });
 
+  it("keeps saved columns when no dataset columns are loaded", async () => {
+    const wrapper = mountConfigCard({
+      ...savedMapConfig,
+      COLOR_COLUMN: "color",
+      MEDIA_COLUMN: "photos",
+    });
+    const cardVm = wrapper.vm as unknown as { localConfig: ViewConfig };
+
+    cardVm.localConfig.MAPBOX_ZOOM = 12;
+    await nextTick();
+
+    await wrapper.get("form").trigger("submit");
+
+    const submission = wrapper.emitted("submitConfig")?.[0]?.[0] as {
+      config: ViewConfig;
+    };
+    expect(submission.config.COLOR_COLUMN).toBe("color");
+    expect(submission.config.MEDIA_COLUMN).toBe("photos");
+  });
+
   it("still blocks newly introduced unavailable columns", async () => {
     const wrapper = mountConfigCard(savedMapConfig, [
       {

--- a/tests/unit/components/ConfigCard.mapInit.test.ts
+++ b/tests/unit/components/ConfigCard.mapInit.test.ts
@@ -4,7 +4,7 @@ import { computed, nextTick, onMounted, reactive, ref, watch } from "vue";
 
 import ConfigCard from "@/components/config/ConfigCard.vue";
 import ConfigMap from "@/components/config/ConfigMap.vue";
-import type { ViewConfig } from "@/types";
+import type { ColumnEntry, ViewConfig } from "@/types";
 
 Object.assign(globalThis, {
   computed,
@@ -50,13 +50,17 @@ const savedMapConfig = {
   ROUTE_LEVEL_PERMISSION: "member",
 } as ViewConfig;
 
-const mountConfigCard = () =>
+const mountConfigCard = (
+  viewConfig: ViewConfig = savedMapConfig,
+  primaryColumns: ColumnEntry[] = [],
+) =>
   mount(ConfigCard, {
     props: {
       tableName: "test_map",
       viewType: "map",
-      viewConfig: savedMapConfig,
+      viewConfig,
       configToCopy: null,
+      primaryColumns,
     },
     global: {
       components: {
@@ -181,5 +185,57 @@ describe("ConfigCard map initialization", () => {
     await nextTick();
 
     expect(cardVm.isFormValid).toBe(false);
+  });
+
+  it("removes stale unavailable columns when saving another change", async () => {
+    const wrapper = mountConfigCard(
+      {
+        ...savedMapConfig,
+        COLOR_COLUMN: "color",
+        ICON_COLUMN: "icon",
+      },
+      [
+        {
+          original_column: "_submission_time",
+          sql_column: "_submission_time",
+        },
+      ],
+    );
+    const cardVm = wrapper.vm as unknown as { localConfig: ViewConfig };
+
+    cardVm.localConfig.TIMESTAMP_COLUMN = "_submission_time";
+    await nextTick();
+
+    const submitButton = wrapper.get<HTMLButtonElement>(
+      '[data-testid="config-submit-button"]',
+    );
+    expect(submitButton.element.disabled).toBe(false);
+
+    await wrapper.get("form").trigger("submit");
+
+    const submission = wrapper.emitted("submitConfig")?.[0]?.[0] as {
+      config: ViewConfig;
+    };
+    expect(submission.config.TIMESTAMP_COLUMN).toBe("_submission_time");
+    expect(submission.config).not.toHaveProperty("COLOR_COLUMN");
+    expect(submission.config).not.toHaveProperty("ICON_COLUMN");
+  });
+
+  it("still blocks newly introduced unavailable columns", async () => {
+    const wrapper = mountConfigCard(savedMapConfig, [
+      {
+        original_column: "_submission_time",
+        sql_column: "_submission_time",
+      },
+    ]);
+    const cardVm = wrapper.vm as unknown as { localConfig: ViewConfig };
+
+    cardVm.localConfig.COLOR_COLUMN = "not_a_column";
+    await nextTick();
+
+    expect(
+      wrapper.get<HTMLButtonElement>('[data-testid="config-submit-button"]')
+        .element.disabled,
+    ).toBe(true);
   });
 });

--- a/utils/viewConfigColumns.ts
+++ b/utils/viewConfigColumns.ts
@@ -38,7 +38,16 @@ export const getSelectableColumnOptions = (
     );
 };
 
-const getColumnSource = (
+/**
+ * Returns whether a functional column key is validated against primary or
+ * secondary dataset columns.
+ *
+ * @param {FunctionalColumnKey} key - Config field that stores a column name.
+ * @param {ViewType} viewType - Current view type.
+ * @param {boolean} hasSecondaryDataset - Whether the view uses a secondary dataset.
+ * @returns {"primary" | "secondary"} Which dataset's columns to use.
+ */
+export const getFunctionalColumnSource = (
   key: FunctionalColumnKey,
   viewType: ViewType,
   hasSecondaryDataset: boolean,
@@ -77,7 +86,11 @@ export const validateViewConfigColumns = (
     const value = config[key]?.trim();
     if (!value) return;
 
-    const source = getColumnSource(key, viewType, hasSecondaryDataset);
+    const source = getFunctionalColumnSource(
+      key,
+      viewType,
+      hasSecondaryDataset,
+    );
     const columns = source === "secondary" ? secondaryColumns : primaryColumns;
     if (
       !getSelectableColumnOptions(columns).some(


### PR DESCRIPTION
## Goal
Allow users to save valid configuration changes when an existing `view_config` contains stale references to warehouse columns that no longer exist, while preserving `COLOR_COLUMN` and `ICON_COLUMN` for views where those columns are still valid. Closes #652.



## Screenshots

Not included 

## What I changed and why

On save, we now distinguish stale invalid pointers (already in the saved config) from newly introduced invalid selections. Omit only the stale ones from the submitted payload. Keep blocking new invalid selections.
This lets users repair old configurations while preserving strict validation for new changes.

## How I convinced myself this is right

- Manually tested columns I know this exists
- Tested creating a new config 

## What I'm not doing here

- Relaxing server-side validation for invalid API payloads. That would be wrong. 
- Anything extrenous

## LLM use disclosure

Cursor agent helped